### PR TITLE
Add URL overriding to clients

### DIFF
--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -22,10 +22,10 @@ class RESTClient(ABC):
 
     def __init__(
         self,
+        base_url: Union[BaseURL, str],
         api_key: str = None,
         secret_key: str = None,
         api_version: str = "v2",
-        base_url: Optional[BaseURL] = None,
         sandbox: bool = False,
         raw_data: bool = False,
     ) -> None:
@@ -33,17 +33,18 @@ class RESTClient(ABC):
         Alpaca API endpoints.
 
         Args:
+            base_url (Optional[Union[BaseURL, str]]): The base url to target requests to.
+              Should be an instance of BaseURL, but allows for raw str if you need to override
             api_key (str, optional): description. Defaults to None.
             secret_key (str, optional): description. Defaults to None.
             api_version (str, optional): description. Defaults to 'v2'.
-            base_url (Optional[BaseURL], optional): description. Defaults to None.
             sandbox (bool, optional): description. Defaults to False.
             raw_data (bool, optional): description. Defaults to False.
         """
 
         self._api_key, self._secret_key = get_credentials(api_key, secret_key)
         self._api_version: str = get_api_version(api_version)
-        self._base_url: BaseURL = base_url
+        self._base_url: Union[BaseURL, str] = base_url
         self._sandbox: bool = sandbox
         self._use_raw_data: bool = raw_data
         self._session: Session = Session()

--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -33,8 +33,8 @@ class RESTClient(ABC):
         Alpaca API endpoints.
 
         Args:
-            base_url (Optional[Union[BaseURL, str]]): The base url to target requests to.
-              Should be an instance of BaseURL, but allows for raw str if you need to override
+            base_url (Union[BaseURL, str]): The base url to target requests to. Should be an instance of BaseURL, but
+              allows for raw str if you need to override
             api_key (str, optional): description. Defaults to None.
             secret_key (str, optional): description. Defaults to None.
             api_version (str, optional): description. Defaults to 'v2'.

--- a/alpaca/data/historical.py
+++ b/alpaca/data/historical.py
@@ -18,18 +18,22 @@ class HistoricalDataClient(RESTClient):
         api_key: Optional[str] = None,
         secret_key: Optional[str] = None,
         raw_data: bool = False,
+        url_override: Union[BaseURL, str] = None,
     ) -> None:
         """Instantiates a Historical Data Client.
         Args:
         api_key (Optional[str], optional): Alpaca API key. Defaults to None.
         secret_key (Optional[str], optional): Alpaca API secret key. Defaults to None.
-        raw_data (bool, optional): If true, API responses will not be wrapped and raw responses will returned from methods. Defaults to False.
+        raw_data (bool, optional): If true, API responses will not be wrapped and raw responses will be returned from
+          methods. Defaults to False.
+        url_override (Union[BaseURL, str], optional): If specified allows you to override the base url the client points
+          to for proxy/testing.
         """
         super().__init__(
             api_key=api_key,
             secret_key=secret_key,
             api_version="v2",
-            base_url=BaseURL.DATA,
+            base_url=url_override if url_override is not None else BaseURL.DATA,
             sandbox=False,
             raw_data=raw_data,
         )
@@ -521,7 +525,6 @@ class HistoricalDataClient(RESTClient):
             Union[BarSet, RawData]: The bar data either in raw or wrapped form
         """
         if isinstance(symbol_or_symbols, str):
-
             # BarSet expects a symbol keyed dictionary of bar data from API
             _raw_data_dict = {symbol_or_symbols: raw_data}
 

--- a/alpaca/data/historical.py
+++ b/alpaca/data/historical.py
@@ -18,7 +18,7 @@ class HistoricalDataClient(RESTClient):
         api_key: Optional[str] = None,
         secret_key: Optional[str] = None,
         raw_data: bool = False,
-        url_override: Union[BaseURL, str] = None,
+        url_override: Optional[str] = None,
     ) -> None:
         """
         Instantiates a Historical Data Client.
@@ -28,7 +28,7 @@ class HistoricalDataClient(RESTClient):
             secret_key (Optional[str], optional): Alpaca API secret key. Defaults to None.
             raw_data (bool, optional): If true, API responses will not be wrapped and raw responses will be returned from
               methods. Defaults to False.
-            url_override (Union[BaseURL, str], optional): If specified allows you to override the base url the client points
+            url_override (Optional[str], optional): If specified allows you to override the base url the client points
               to for proxy/testing.
         """
         super().__init__(

--- a/alpaca/data/historical.py
+++ b/alpaca/data/historical.py
@@ -20,14 +20,16 @@ class HistoricalDataClient(RESTClient):
         raw_data: bool = False,
         url_override: Union[BaseURL, str] = None,
     ) -> None:
-        """Instantiates a Historical Data Client.
+        """
+        Instantiates a Historical Data Client.
+
         Args:
-        api_key (Optional[str], optional): Alpaca API key. Defaults to None.
-        secret_key (Optional[str], optional): Alpaca API secret key. Defaults to None.
-        raw_data (bool, optional): If true, API responses will not be wrapped and raw responses will be returned from
-          methods. Defaults to False.
-        url_override (Union[BaseURL, str], optional): If specified allows you to override the base url the client points
-          to for proxy/testing.
+            api_key (Optional[str], optional): Alpaca API key. Defaults to None.
+            secret_key (Optional[str], optional): Alpaca API secret key. Defaults to None.
+            raw_data (bool, optional): If true, API responses will not be wrapped and raw responses will be returned from
+              methods. Defaults to False.
+            url_override (Union[BaseURL, str], optional): If specified allows you to override the base url the client points
+              to for proxy/testing.
         """
         super().__init__(
             api_key=api_key,

--- a/alpaca/data/live.py
+++ b/alpaca/data/live.py
@@ -12,7 +12,7 @@ class MarketDataStream(BaseStream):
         raw_data: bool = False,
         feed: DataFeed = DataFeed.IEX,
         websocket_params: Optional[Dict] = None,
-        url_override: Optional[Union[BaseURL, str]] = None,
+        url_override: Optional[str] = None,
     ) -> None:
         """WebSocket client for accessing live equity data.
 
@@ -22,7 +22,7 @@ class MarketDataStream(BaseStream):
             raw_data (bool, optional): Whether to return wrapped data or raw API data. Defaults to False.
             feed (DataFeed, optional): Which market data feed to use; IEX or SIP. Defaults to IEX.
             websocket_params (Optional[Dict], optional): Any parameters for configuring websocket connection. Defaults to None.
-            url_override (Optional[Union[BaseURL, str]]): If specified allows you to override the base url the client
+            url_override (Optional[str]): If specified allows you to override the base url the client
               points to for proxy/testing.
 
         Raises:

--- a/alpaca/data/live.py
+++ b/alpaca/data/live.py
@@ -1,5 +1,5 @@
 from alpaca.common.websocket import BaseStream
-from typing import Optional, Dict
+from typing import Optional, Dict, Union
 from alpaca.common.enums import BaseURL
 from .enums import DataFeed
 
@@ -12,6 +12,7 @@ class MarketDataStream(BaseStream):
         raw_data: bool = False,
         feed: DataFeed = DataFeed.IEX,
         websocket_params: Optional[Dict] = None,
+        url_override: Optional[Union[BaseURL, str]] = None,
     ) -> None:
         """WebSocket client for accessing live equity data.
 
@@ -21,6 +22,8 @@ class MarketDataStream(BaseStream):
             raw_data (bool, optional): Whether to return wrapped data or raw API data. Defaults to False.
             feed (DataFeed, optional): Which market data feed to use; IEX or SIP. Defaults to IEX.
             websocket_params (Optional[Dict], optional): Any parameters for configuring websocket connection. Defaults to None.
+            url_override (Optional[Union[BaseURL, str]]): If specified allows you to override the base url the client
+              points to for proxy/testing.
 
         Raises:
             ValueError: Only IEX or SIP market data feeds are supported
@@ -29,7 +32,11 @@ class MarketDataStream(BaseStream):
             raise ValueError("OTC not supported for live data feeds")
 
         super().__init__(
-            endpoint=BaseURL.MARKET_DATA_LIVE.value + "/v2/" + feed.value,
+            endpoint=(
+                url_override
+                if url_override is not None
+                else BaseURL.MARKET_DATA_LIVE.value + "/v2/" + feed.value
+            ),
             api_key=api_key,
             secret_key=secret_key,
             raw_data=raw_data,


### PR DESCRIPTION
This allows for overriding with str values if someone needs to use a proxy/local mock servers (I'd like to add this later for integration tests but is also useful in general for users)