### PR TITLE
Fixes Counting Error in Multisymbol Paginated Data Request

### DIFF
--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -160,6 +160,7 @@ class RESTClient(ABC):
         symbol_or_symbols: Union[str, List[str]],
         endpoint_base: str = "stocks",
         api_version: str = "v2",
+        max_items_limit: Optional[int] = None,
         page_limit: int = DATA_V2_MAX_LIMIT,
         **kwargs,
     ) -> Generator[dict, None, None]:
@@ -171,14 +172,14 @@ class RESTClient(ABC):
             symbol_or_symbols (Union[str, List[str]]): The symbol or list of symbols that we want to query for
             endpoint_base (str, optional): The data API security type path. Defaults to 'stocks'.
             api_version (str, optional): Data API version. Defaults to "v2".
-            page_limit (int, optional): The maximum number of items returned in one request - different from limit. Defaults to DATA_V2_MAX_LIMIT.
+            max_items_limit (Optional[int]): The maximum number of items to query. Defaults to None.
+            page_limit (int, optional): The maximum number of items returned per page - different from limit. Defaults to DATA_V2_MAX_LIMIT.
 
         Yields:
             Generator[dict, None, None]: Market data from API
         """
         page_token = None
         total_items = 0
-        limit = kwargs.get("limit")
 
         data = kwargs
 
@@ -199,9 +200,9 @@ class RESTClient(ABC):
             actual_limit = None
 
             # adjusts the limit parameter value if it is over the page_limit
-            if limit:
+            if max_items_limit:
                 # actual_limit is the adjusted total number of items to query per request
-                actual_limit = min(int(limit) - total_items, page_limit)
+                actual_limit = min(int(max_items_limit) - total_items, page_limit)
                 if actual_limit < 1:
                     break
 

--- a/alpaca/data/historical.py
+++ b/alpaca/data/historical.py
@@ -69,7 +69,7 @@ class HistoricalDataClient(RESTClient):
             timeframe=timeframe_value,
             start=start,
             end=end,
-            limit=limit,
+            max_items_limit=limit,
             adjustment=adjustment,
             feed=feed,
         )
@@ -111,7 +111,7 @@ class HistoricalDataClient(RESTClient):
             symbol_or_symbols=symbol_or_symbols,
             start=start,
             end=end,
-            limit=limit,
+            max_items_limit=limit,
             feed=feed,
         )
 
@@ -151,7 +151,7 @@ class HistoricalDataClient(RESTClient):
             symbol_or_symbols=symbol_or_symbols,
             start=start,
             end=end,
-            limit=limit,
+            max_items_limit=limit,
             feed=feed,
         )
 
@@ -279,7 +279,7 @@ class HistoricalDataClient(RESTClient):
             timeframe=timeframe_value,
             start=start,
             end=end,
-            limit=limit,
+            max_items_limit=limit,
             exchanges=exchanges,
         )
 
@@ -322,7 +322,7 @@ class HistoricalDataClient(RESTClient):
             symbol_or_symbols=symbol_or_symbols,
             start=start,
             end=end,
-            limit=limit,
+            max_items_limit=limit,
             exchanges=exchanges,
         )
 
@@ -364,7 +364,7 @@ class HistoricalDataClient(RESTClient):
             symbol_or_symbols=symbol_or_symbols,
             start=start,
             end=end,
-            limit=limit,
+            max_items_limit=limit,
             exchanges=exchanges,
         )
 


### PR DESCRIPTION
Fixes the counting error caused by incrementing 1 to the total_items on each request, when `actual_limit` should be added. 

Also renames some variables for readability.
