### PR TITLE
Adds Asset Model

### DIFF
--- a/alpaca/common/enums.py
+++ b/alpaca/common/enums.py
@@ -149,3 +149,34 @@ class OrderStatus(str, Enum):
     REJECTED = "rejected"
     SUSPENDED = "suspended"
     CALCULATED = "calculated"
+
+
+class AssetClass(str, Enum):
+    """
+    Represents what class of asset this is.
+    """
+
+    US_EQUITY = "us_equity"
+    CRYPTO = "crypto"
+
+
+class AssetStatus(str, Enum):
+    """
+    Represents the various states for an Asset's lifecycle
+    """
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+
+class AssetExchange(str, Enum):
+    """
+    Represents the current exchanges Alpaca supports.
+    """
+
+    AMEX = "AMEX"
+    ARCA = "ARCA"
+    BATS = "BATS"
+    NYSE = "NYSE"
+    NASDAQ = "NASDAQ"
+    NYSEARCA = "NYSEARCA"

--- a/alpaca/common/models/__init__.py
+++ b/alpaca/common/models/__init__.py
@@ -2,3 +2,4 @@ from .models import *
 from .accounts import *
 from .clock import Clock
 from .calendar import Calendar
+from .trading import *

--- a/alpaca/common/models/trading.py
+++ b/alpaca/common/models/trading.py
@@ -1,0 +1,28 @@
+from uuid import UUID
+from ..enums import AssetClass, AssetStatus, AssetExchange
+from .models import ValidateBaseModel as BaseModel
+from pydantic import Field
+from typing import Optional
+
+
+class Asset(BaseModel):
+    """
+    Represents a security. Some Assets are not tradable with Alpaca. These Assets are
+    marked with the flag `tradable=false`.
+
+    For more info, visit https://alpaca.markets/docs/api-references/trading-api/assets/
+    """
+
+    id: UUID
+    asset_class: AssetClass = Field(
+        alias="class"
+    )  # using a pydantic alias to allow parsing data with the `class` keyword field
+    exchange: AssetExchange
+    symbol: str
+    name: Optional[str] = None
+    status: AssetStatus
+    tradable: bool
+    marginable: bool
+    shortable: bool
+    easy_to_borrow: bool
+    fractionable: bool

--- a/alpaca/data/enums.py
+++ b/alpaca/data/enums.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class Exchange(Enum):
+class Exchange(str, Enum):
     """The exchanges that provide data feeds to Alpaca
 
     Attributes:
@@ -64,11 +64,8 @@ class Exchange(Enum):
     H: str = "H"
     K: str = "K"
 
-    def __str__(self):
-        return self.value
 
-
-class DataFeed(Enum):
+class DataFeed(str, Enum):
     """Equity market data feeds. OTC and SIP are available with premium data subscriptions.
 
     Attributes:
@@ -81,11 +78,8 @@ class DataFeed(Enum):
     SIP: str = "sip"
     OTC: str = "otc"
 
-    def __str__(self):
-        return self.value
 
-
-class Adjustment(Enum):
+class Adjustment(str, Enum):
     """Data normalization based on types of corporate actions.
 
     Attributes:
@@ -99,6 +93,3 @@ class Adjustment(Enum):
     SPLIT: str = "split"
     DIVIDEND: str = "dividend"
     ALL: str = "all"
-
-    def __str__(self):
-        return self.value

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -1,0 +1,1 @@
+from .trading import *

--- a/tests/common/factories/trading.py
+++ b/tests/common/factories/trading.py
@@ -1,0 +1,25 @@
+from alpaca.common.models import Asset
+
+
+def create_dummy_asset() -> Asset:
+    """
+    Creates an Asset object for testing
+
+    Returns:
+        Asset: An example asset
+    """
+
+    asset_data = {
+        "id": "904837e3-3b76-47ec-b432-046db621571b",
+        "class": "us_equity",
+        "exchange": "NASDAQ",
+        "symbol": "AAPL",
+        "status": "active",
+        "tradable": True,
+        "marginable": True,
+        "shortable": True,
+        "easy_to_borrow": True,
+        "fractionable": True,
+    }
+
+    return Asset(**asset_data)

--- a/tests/common/test_common_models.py
+++ b/tests/common/test_common_models.py
@@ -1,5 +1,7 @@
+from alpaca.common.enums import AssetClass, AssetStatus
 from alpaca.common.models import Clock, Calendar
 from datetime import datetime, date
+from factories import create_dummy_asset
 
 
 def test_clock_timestamps():
@@ -25,3 +27,14 @@ def test_calendar_timestamps():
     assert type(calendar.close) is datetime
 
     assert calendar.open.minute == 30
+
+
+def test_asset_parsed_successfully():
+    """
+    Tests whether an asset object is created successfully from API data
+    """
+    asset = create_dummy_asset()
+
+    assert asset.asset_class is AssetClass.US_EQUITY
+    assert asset.status is AssetStatus.ACTIVE
+    assert asset.tradable is True

--- a/tests/common/test_common_models.py
+++ b/tests/common/test_common_models.py
@@ -27,14 +27,3 @@ def test_calendar_timestamps():
     assert type(calendar.close) is datetime
 
     assert calendar.open.minute == 30
-
-
-def test_asset_parsed_successfully():
-    """
-    Tests whether an asset object is created successfully from API data
-    """
-    asset = create_dummy_asset()
-
-    assert asset.asset_class is AssetClass.US_EQUITY
-    assert asset.status is AssetStatus.ACTIVE
-    assert asset.tradable is True


### PR DESCRIPTION
* Adds `Asset` Model
* Adds `AssetClass`, `AssetStatus` and `AssetExchange` Enums. `AssetExchange` was created because the existing`Exchange` enum lists specific exchange datafeeds whereas the exchange field in `Asset` more generally lists which exchange the asset is related to. There's also a lot of overlap in terms of which exchanges they're referring to, I thought it would be cleaner to create a new `AssetExchange` enum to avoid any headache of duplicate exchanges within the same enum.

* Also added a small change to move the Data API enums to inherit from `str`.
