### PR TITLE
Fix: Add trading stream class import to init file

### DIFF
--- a/alpaca/trading/__init__.py
+++ b/alpaca/trading/__init__.py
@@ -2,3 +2,4 @@ from .client import *
 from .models import *
 from .enums import *
 from .requests import *
+from .stream import *


### PR DESCRIPTION
Fixes [this issue](https://github.com/alpacahq/alpaca-py/issues/147)