### PR TITLE
Fix: Adding extra optional params to Asset model to accommodate cryptocurrencies

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -57,6 +57,9 @@ class Asset(BaseModel):
     shortable: bool
     easy_to_borrow: bool
     fractionable: bool
+    min_order_size: Optional[float] = None
+    min_trade_increment: Optional[float] = None
+    price_increment: Optional[float] = None
 
 
 class Position(BaseModel):


### PR DESCRIPTION
Fixes [this issue](https://github.com/alpacahq/alpaca-py/issues/161).

The trading client's `get_all_assets` method does not return minimum_order_size for cryptocurrencies because there were some parameters not implemented. Adding these into the `Asset` model solves the problem.

Example of new asset response:
```
id=UUID('c9b6f16b-e88d-439f-bb0b-acecccab3d10') asset_class=<AssetClass.CRYPTO: 'crypto'> exchange=<AssetExchange.FTXU: 'FTXU'> symbol='BCH/BTC' name='Bitcoin Cash / Bitcoin ' status=<AssetStatus.ACTIVE: 'active'> tradable=True marginable=False shortable=False easy_to_borrow=False fractionable=True min_order_size=0.001 min_trade_increment=0.001 price_increment=1e-06

```