### PR TITLE
Added new order status `held`

### DIFF
--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -139,6 +139,7 @@ class OrderStatus(str, Enum):
     REJECTED = "rejected"
     SUSPENDED = "suspended"
     CALCULATED = "calculated"
+    HELD = "held"
 
 
 class AssetClass(str, Enum):


### PR DESCRIPTION
This order status is not documented [here](https://alpaca.markets/docs/api-references/broker-api/trading/orders/#order-status) but the back-end sends it in some rare cases. I've added it into C# SDK months ago for unblocking clients' bracket order placement logic. This PR should solve issue #153 completely.