### PR TITLE
fix: https://github.com/alpacahq/alpaca-py/issues/172

### DIFF
--- a/alpaca/broker/client.py
+++ b/alpaca/broker/client.py
@@ -1669,7 +1669,7 @@ class BrokerClient(RESTClient):
 
     # ############################## CORPORATE ACTIONS ################################# #
 
-    def get_corporate_annoucements(
+    def get_corporate_announcements(
         self, filter: GetCorporateAnnouncementsRequest
     ) -> Union[List[CorporateActionAnnouncement], RawData]:
         """
@@ -1691,7 +1691,7 @@ class BrokerClient(RESTClient):
 
         return parse_obj_as(List[CorporateActionAnnouncement], response)
 
-    def get_corporate_announcment_by_id(
+    def get_corporate_announcement_by_id(
         self, corporate_announcment_id: Union[UUID, str]
     ) -> Union[CorporateActionAnnouncement, RawData]:
         """

--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -579,7 +579,7 @@ class TradingClient(RESTClient):
 
     # ############################## CORPORATE ACTIONS ################################# #
 
-    def get_corporate_annoucements(
+    def get_corporate_announcements(
         self, filter: GetCorporateAnnouncementsRequest
     ) -> Union[List[CorporateActionAnnouncement], RawData]:
         """
@@ -601,7 +601,7 @@ class TradingClient(RESTClient):
 
         return parse_obj_as(List[CorporateActionAnnouncement], response)
 
-    def get_corporate_announcment_by_id(
+    def get_corporate_announcement_by_id(
         self, corporate_announcment_id: Union[UUID, str]
     ) -> Union[CorporateActionAnnouncement, RawData]:
         """

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -503,7 +503,7 @@ class CorporateActionAnnouncement(BaseModel):
     target_symbol: str
     target_original_cusip: str
     declaration_date: Optional[date]
-    ex_date: date
+    ex_date: Optional[date]
     record_date: date
     payable_date: date
     cash: float

--- a/docs/api_reference/broker/corporate-actions.rst
+++ b/docs/api_reference/broker/corporate-actions.rst
@@ -8,11 +8,11 @@ corporate events.
 Get Corporate Actions
 ---------------------
 
-.. automethod:: alpaca.broker.client.BrokerClient.get_corporate_annoucements
+.. automethod:: alpaca.broker.client.BrokerClient.get_corporate_announcements
 
 
 
 Get  Corporate Action By ID
 ---------------------------
 
-.. automethod:: alpaca.broker.client.BrokerClient.get_corporate_announcment_by_id
+.. automethod:: alpaca.broker.client.BrokerClient.get_corporate_announcement_by_id

--- a/docs/api_reference/trading/corporate-actions.rst
+++ b/docs/api_reference/trading/corporate-actions.rst
@@ -8,11 +8,11 @@ corporate events.
 Get Corporate Actions
 ---------------------
 
-.. automethod:: alpaca.trading.client.TradingClient.get_corporate_annoucements
+.. automethod:: alpaca.trading.client.TradingClient.get_corporate_announcements
 
 
 
 Get  Corporate Action By ID
 ---------------------------
 
-.. automethod:: alpaca.trading.client.TradingClient.get_corporate_announcment_by_id
+.. automethod:: alpaca.trading.client.TradingClient.get_corporate_announcement_by_id

--- a/tests/trading/trading_client/test_corporate_announcements.py
+++ b/tests/trading/trading_client/test_corporate_announcements.py
@@ -57,7 +57,7 @@ def test_get_announcements(reqmock, trading_client: TradingClient):
         ca_types=[CorporateActionType.DIVIDEND], since="2021-01-01", until="2021-02-01"
     )
 
-    response = trading_client.get_corporate_annoucements(ca_filter)
+    response = trading_client.get_corporate_announcements(ca_filter)
 
     assert reqmock.called_once
     assert isinstance(response, List)


### PR DESCRIPTION
This PR fixes https://github.com/alpacahq/alpaca-py/issues/172 
The parameter ex_date must be optional in the CorporateActionAnnouncement base model since it's not present in all responses from the API. Also fixed some typos.