### PR TITLE
feat: support type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ documentation = "https://alpaca.markets/docs/python-sdk/"
 packages = [
     { include = "alpaca" }
 ]
+include = [ "alpaca/py.typed" ]
 
 [tool.poetry.dependencies]
 python = "^3.7.1"


### PR DESCRIPTION
Good day 👋

In order to use your type hinting, type checkers like mypy require you to be [pep 561](https://peps.python.org/pep-0561/) compliant.