### PR TITLE
Change string to datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ You can request bar data via the HistoricalDataClients. In this example, we quer
 from alpaca.data.historical import CryptoHistoricalDataClient
 from alpaca.data.requests import CryptoBarsRequest
 from alpaca.data.timeframe import TimeFrame
+from datetime import datetime
 
 # no keys required for crypto data
 client = CryptoHistoricalDataClient()
@@ -198,7 +199,7 @@ client = CryptoHistoricalDataClient()
 request_params = CryptoBarsRequest(
                         symbol_or_symbols=["BTC/USD", "ETH/USD"],
                         timeframe=TimeFrame.Day,
-                        start="2022-07-01"
+                        start=datetime.strptime("2022-07-01", '%Y-%m-%d')
                         )
 
 bars = client.get_crypto_bars(request_params)


### PR DESCRIPTION
If you pass in the string as presented in the description, an error will be thrown. Passing in a formatted datetime will not throw an error, so I have changed the string to reflect that.