### PR TITLE
Fixed issue with the `get_order_for_account_by_client_id` functions

### DIFF
--- a/alpaca/broker/client.py
+++ b/alpaca/broker/client.py
@@ -1589,7 +1589,9 @@ class BrokerClient(RESTClient):
         """
         account_id = validate_uuid_id_param(account_id, "account_id")
 
-        response = self.get(f"/trading/accounts/{account_id}/orders/{client_id}")
+        params = { "client_order_id": client_id }
+
+        response = self.get(f"/trading/accounts/{account_id}/orders:by_client_order_id", params)
 
         if self._use_raw_data:
             return response

--- a/alpaca/broker/client.py
+++ b/alpaca/broker/client.py
@@ -1589,9 +1589,11 @@ class BrokerClient(RESTClient):
         """
         account_id = validate_uuid_id_param(account_id, "account_id")
 
-        params = { "client_order_id": client_id }
+        params = {"client_order_id": client_id}
 
-        response = self.get(f"/trading/accounts/{account_id}/orders:by_client_order_id", params)
+        response = self.get(
+            f"/trading/accounts/{account_id}/orders:by_client_order_id", params
+        )
 
         if self._use_raw_data:
             return response

--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -153,7 +153,9 @@ class TradingClient(RESTClient):
         Returns:
             alpaca.trading.models.Order: The queried order.
         """
-        response = self.get(f"/orders/{client_id}")
+        params = { "client_order_id": client_id }
+
+        response = self.get(f"/orders:by_client_order_id", params)
 
         if self._use_raw_data:
             return response

--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -153,7 +153,7 @@ class TradingClient(RESTClient):
         Returns:
             alpaca.trading.models.Order: The queried order.
         """
-        params = { "client_order_id": client_id }
+        params = {"client_order_id": client_id}
 
         response = self.get(f"/orders:by_client_order_id", params)
 

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -179,7 +179,7 @@ def test_get_order_by_client_id(reqmock, trading_client: TradingClient):
     client_id = "eb9e2aaa-f71a-4f51-b5b4-52a6c565dad4"
 
     reqmock.get(
-        f"{BaseURL.TRADING_PAPER}/v2/orders/{client_id}",
+        f"{BaseURL.TRADING_PAPER}/v2/orders:by_client_order_id?client_order_id={client_id}",
         text="""
     {
         "id": "61e69015-8549-4bfd-b9c3-01e75843f47d",


### PR DESCRIPTION
Fixes issue #199 - the correct URL used for both trading and broker clients and unit test updated according to documentation.