### PR TITLE
Fix for circular import error on websockets.py

### DIFF
--- a/alpaca/data/__init__.py
+++ b/alpaca/data/__init__.py
@@ -3,4 +3,3 @@ from .models import *
 from .timeframe import *
 from .requests import *
 from .historical import *
-from .live import *


### PR DESCRIPTION
Removing the live module from the websockets init fixes the circular import problem when using the raw websockets modules and allows more flexibility from the end user. The live module is a higher level implementation of websockets BaseStream and really shouldn't be included.

Removed:  from .live import *   from __init__.py