### PR TITLE
fix: add date and IPAddress at to_request_fields

### DIFF
--- a/alpaca/common/requests.py
+++ b/alpaca/common/requests.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import date, datetime
+from ipaddress import _IPAddressBase
 from typing import Any
 from uuid import UUID
 
@@ -47,6 +48,12 @@ class NonEmptyRequest(BaseModel):
             # RFC 3339
             if isinstance(val, datetime):
                 return val.isoformat("T") + "Z"
+
+            if isinstance(val, date):
+                return val.strftime("%Y-%m-%d")
+
+            if isinstance(val, _IPAddressBase):
+                return str(val)
 
             return val
 

--- a/tests/broker/broker_client/test_documents_routes.py
+++ b/tests/broker/broker_client/test_documents_routes.py
@@ -1,10 +1,13 @@
+from datetime import datetime, date
+from ipaddress import IPv4Address
 import os.path
 import tempfile
 from typing import List
+from alpaca.broker.models.documents import W8BenDocument
 
 import pytest
 
-from alpaca.broker.requests import UploadDocumentRequest
+from alpaca.broker.requests import UploadDocumentRequest, UploadW8BenDocumentRequest
 from alpaca.broker.client import BrokerClient
 from alpaca.common.constants import BROKER_DOCUMENT_UPLOAD_LIMIT
 from alpaca.broker.enums import (
@@ -100,6 +103,54 @@ def test_upload_documents_to_account(reqmock, client: BrokerClient):
         == '[{"document_type": "account_approval_letter", "content": "fake base64", "mime_type": "application/pdf"}]'
     )
 
+def test_upload_documents_to_account(reqmock, client: BrokerClient):
+    account_id = "2a87c088-ffb6-472b-a4a3-cd9305c8605c"
+    document_date = date(2023, 1, 3)
+    date_of_birth = date(1999, 1,23)
+    timestamp = datetime.now()
+    ip_address=IPv4Address(address="189.147.173.150")
+
+    reqmock.post(
+        BaseURL.BROKER_SANDBOX + f"/v1/accounts/{account_id}/documents/upload",
+        json={},
+        status_code=202,
+    )
+
+    client.upload_documents_to_account(
+        account_id=account_id,
+        document_data=[
+            UploadW8BenDocumentRequest(
+                content_data=W8BenDocument(
+                    country_citizen="Mexico",
+                    date=document_date,
+                    date_of_birth=date_of_birth,
+                    full_name="Some Name",
+                    ip_address=ip_address,
+                    permanent_address_city_state="Springfield",
+                    permanent_address_country="US",
+                    permanent_address_street="742 de Evergreen Terrace",
+                    revision="10-2021",
+                    signer_full_name="Some Name",
+                    timestamp=timestamp,
+                    foreign_tax_id="CXXC990123ME2",
+                ),
+            )
+        ],
+    )
+
+    assert reqmock.called_once
+    response = reqmock.request_history[0].json()[0]
+    document_type = response['document_type']
+    document_sub_type = response['document_sub_type']
+    mime_type = response['mime_type']
+    content_data = response['content_data']
+
+    assert ( document_type == 'w8ben')
+    assert ( document_sub_type == 'Form W-8BEN')
+    assert ( mime_type == 'application/json')
+    assert ( content_data['date'] == str(document_date))
+    assert ( content_data['date_of_birth'] == str(date_of_birth))
+    assert ( content_data['timestamp'] == timestamp.isoformat("T") + "Z")
 
 def test_upload_documents_to_account_validates_limit(reqmock, client: BrokerClient):
     with pytest.raises(ValueError) as e:

--- a/tests/broker/broker_client/test_trading_routes.py
+++ b/tests/broker/broker_client/test_trading_routes.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import date
 from alpaca.broker.client import BrokerClient
 from alpaca.common.enums import BaseURL
 from alpaca.trading.requests import (
@@ -451,7 +451,7 @@ def test_get_portfolio_history_with_filter(reqmock, client: BrokerClient):
     history_filter = GetPortfolioHistoryRequest(
         period="1M",
         timeframe="15M",
-        date_end=datetime.date(2022, 1, 1),
+        date_end=date(2022, 1, 1),
         extended_hours=True,
     )
     portfolio_history = client.get_portfolio_history_for_account(


### PR DESCRIPTION
Closes alpacahq/alpaca-py#226

Fix `UploadW8BenDocumentRequest` by adding `date` and `_IPAddressBase` conversion to proper string on `NonEmptyRequest.to_request_fields` , `map_values` inner function