### PR TITLE
Update GetEventsRequest to match Broker API docs 

### DIFF
--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -936,7 +936,8 @@ class GetJournalsRequest(NonEmptyRequest):
 
 class GetEventsRequest(NonEmptyRequest):
 
-    since: date
-    until: date
-    since_id: int
-    until_id: int
+    id: Optional[str]
+    since: Optional[Union[date, str]]
+    until: Optional[Union[date, str]]
+    since_id: Optional[int]
+    until_id: Optional[int]


### PR DESCRIPTION
Attributes of requests to /v1/events/trades are optional (https://alpaca.markets/docs/api-references/broker-api/events/#request), but the Python client raises an error if some but not all attributes are provided.