### PR TITLE
Add support for basic authorization for `StockHistoricalDataClient` and `RESTClient`

### DIFF
--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -47,6 +47,7 @@ class RESTClient(ABC):
             api_key (Optional[str]): The api key string for authentication.
             secret_key (Optional[str]): The corresponding secret key string for the api key.
             oauth_token (Optional[str]): The oauth token if authenticating via OAuth.
+            use_basic_auth (bool): Whether API requests should use basic authorization headers.
             api_version (Optional[str]): The API version for the endpoints.
             sandbox (bool): False if the live API should be used.
             raw_data (bool): Whether API responses should be wrapped in data models or returned raw.

--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -1,4 +1,5 @@
 import time
+import base64
 from abc import ABC
 from typing import Any, List, Optional, Type, Union, Tuple, Iterator
 
@@ -29,6 +30,7 @@ class RESTClient(ABC):
         api_key: Optional[str] = None,
         secret_key: Optional[str] = None,
         oauth_token: Optional[str] = None,
+        use_basic_auth: bool = False,
         api_version: str = "v2",
         sandbox: bool = False,
         raw_data: bool = False,
@@ -59,6 +61,7 @@ class RESTClient(ABC):
         self._api_version: str = api_version
         self._base_url: Union[BaseURL, str] = base_url
         self._sandbox: bool = sandbox
+        self._use_basic_auth: bool = use_basic_auth
         self._use_raw_data: bool = raw_data
         self._session: Session = Session()
 
@@ -156,6 +159,12 @@ class RESTClient(ABC):
 
         if self._oauth_token:
             headers["Authorization"] = "Bearer " + self._oauth_token
+        elif self._use_basic_auth:
+            api_key_secret = "{key}:{secret}".format(
+                key=self._api_key, secret=self._secret_key
+            ).encode("utf-8")
+            encoded_api_key_secret = base64.b64encode(api_key_secret).decode("utf-8")
+            headers["Authorization"] = "Basic " + encoded_api_key_secret
         else:
             headers["APCA-API-KEY-ID"] = self._api_key
             headers["APCA-API-SECRET-KEY"] = self._secret_key

--- a/alpaca/data/historical/stock.py
+++ b/alpaca/data/historical/stock.py
@@ -45,6 +45,7 @@ class StockHistoricalDataClient(RESTClient):
         api_key: Optional[str] = None,
         secret_key: Optional[str] = None,
         oauth_token: Optional[str] = None,
+        use_basic_auth: bool = False,
         raw_data: bool = False,
         url_override: Optional[str] = None,
     ) -> None:
@@ -64,6 +65,7 @@ class StockHistoricalDataClient(RESTClient):
             api_key=api_key,
             secret_key=secret_key,
             oauth_token=oauth_token,
+            use_basic_auth=use_basic_auth,
             api_version="v2",
             base_url=url_override if url_override is not None else BaseURL.DATA,
             sandbox=False,

--- a/alpaca/data/historical/stock.py
+++ b/alpaca/data/historical/stock.py
@@ -56,6 +56,7 @@ class StockHistoricalDataClient(RESTClient):
             api_key (Optional[str], optional): Alpaca API key. Defaults to None.
             secret_key (Optional[str], optional): Alpaca API secret key. Defaults to None.
             oauth_token (Optional[str]): The oauth token if authenticating via OAuth. Defaults to None.
+            use_basic_auth (bool, optional): If true, API requests will use basic authorization headers.
             raw_data (bool, optional): If true, API responses will not be wrapped and raw responses will be returned from
               methods. Defaults to False. This has not been implemented yet.
             url_override (Optional[str], optional): If specified allows you to override the base url the client points


### PR DESCRIPTION
### Is there an existing issue for this?

* [x]  I have searched the existing issues

### Is your feature request related to a problem? Please describe.

My company is using our Broker API key and secret to access the Market Data API as mentioned in the docs [here](https://alpaca.markets/docs/api-references/market-data-api/stock-pricing-data/).

However, this requires us to use basic authorisation headers, i.e. `Authorization: Basic <base64_encoded_key_and_secret>` with our API key and secret.

### Describe the solution you'd like.

Ideally, it would be great to just pass our Broker API key and secret to use the `APCA-API-KEY-ID` / `APCA-API-SECRET-KEY` headers, passing `api_key` and `secret_key` to the `StockHistoricalDataClient` as per usual.

### Describe an alternate solution.

Perhaps there is a way to override the `_get_auth_headers` method for the `RESTClient`?

https://github.com/alpacahq/alpaca-py/blob/master/alpaca/common/rest.py#L148-L149

### Anything else? (Additional Context)

I've copied the alpaca-py package in our VCS and made the exact same modification to the codebase, and upon initial use have not identified any issues thus far.

We've also been in contact with our Alpaca Technical Consultant who stated:

> I have flagged both of these internally but I would suggest resorting to alternatives as to not make this a blocker on your end.
