### PR TITLE
documentation: fix README to have correct datetime type for CryptoBarsRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To get historical bar data for crypto, you will need to provide a ``CryptoBarsRe
 from alpaca.data.historical import CryptoHistoricalDataClient
 from alpaca.data.requests import CryptoBarsRequest
 from alpaca.data.timeframe import TimeFrame
+from datetime import datetime
 
 # no keys required for crypto data
 client = CryptoHistoricalDataClient()
@@ -87,7 +88,7 @@ client = CryptoHistoricalDataClient()
 request_params = CryptoBarsRequest(
                         symbol_or_symbols=["BTC/USD", "ETH/USD"],
                         timeframe=TimeFrame.Day,
-                        start="2022-07-01"
+                        start=datetime(2022, 7, 1)
                  )
 
 bars = client.get_crypto_bars(request_params)


### PR DESCRIPTION
The example for `CryptoBarsRequest` in `README.md` currently fails due to using a string instead of a `datetime` object. The [documentation](https://alpaca.markets/docs/python-sdk/market_data.html#retrieving-historical-bar-data) has a corrected example. This PR updates `README.md` to match the documentation.