### PR TITLE
fixes issue #274 - can this get a review???????????????????????????

### DIFF
--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -668,8 +668,8 @@ class OrderRequest(BaseOrderRequest):
 
     @root_validator(pre=True)
     def order_type_must_be_market_for_lct(
-        cls, values: dict[str, Any]
-    ) -> dict[str, Any]:
+        cls, values: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
         Order type must always be market if currency is not USD.
         See https://alpaca.markets/docs/broker/integration/lct/#submit-stock-trade

--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -666,7 +666,7 @@ class OrderRequest(BaseOrderRequest):
     commission: Optional[float]
     currency: Optional[SupportedCurrencies] = None  # None = USD
 
-    @root_validator
+    @root_validator(pre=True)
     def order_type_must_be_market_for_lct(
         cls, values: dict[str, Any]
     ) -> dict[str, Any]:

--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -667,7 +667,9 @@ class OrderRequest(BaseOrderRequest):
     currency: Optional[SupportedCurrencies] = None  # None = USD
 
     @root_validator
-    def order_type_must_be_market_for_lct(cls, values: dict[str, Any]) -> OrderType:
+    def order_type_must_be_market_for_lct(
+        cls, values: dict[str, Any]
+    ) -> dict[str, Any]:
         """
         Order type must always be market if currency is not USD.
         See https://alpaca.markets/docs/broker/integration/lct/#submit-stock-trade

--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict, Any
 from uuid import UUID
 
 from pydantic import root_validator, validator
@@ -666,17 +666,22 @@ class OrderRequest(BaseOrderRequest):
     commission: Optional[float]
     currency: Optional[SupportedCurrencies] = None  # None = USD
 
-    @validator("type")
-    def order_type_must_be_market_for_lct(cls, value: OrderType) -> OrderType:
+    @root_validator
+    def order_type_must_be_market_for_lct(cls, values: dict[str, Any]) -> OrderType:
         """
         Order type must always be market if currency is not USD.
         See https://alpaca.markets/docs/broker/integration/lct/#submit-stock-trade
         """
-        if cls.currency and value != OrderType.MARKET:
+        if (
+            values.get("type") != OrderType.MARKET
+            and "currency" in values
+            and values.get("currency", SupportedCurrencies.USD)
+            != SupportedCurrencies.USD
+        ):
             raise ValueError(
                 "Order type must be OrderType.MARKET if the order is in a local currency."
             )
-        return value
+        return values
 
 
 class MarketOrderRequest(BaseMarketOrderRequest):


### PR DESCRIPTION
fixing an issue that prevented orders from being created because of how pydantic was being called

fixes #274 

```
❯ python
Python 3.10.11 (main, Apr  7 2023, 07:24:53) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from alpaca.broker.requests import OrderRequest
>>> from alpaca.common.enums import SupportedCurrencies
>>> OrderRequest(symbol="AAPL", side="buy", type="limit", time_in_force="day", qty=1, currency=SupportedCurrencies.USD)
{   'client_order_id': None,
    'commission': None,
    'currency': <SupportedCurrencies.USD: 'USD'>,
    'extended_hours': None,
    'notional': None,
    'order_class': None,
    'qty': 1.0,
    'side': <OrderSide.BUY: 'buy'>,
    'stop_loss': None,
    'symbol': 'AAPL',
    'take_profit': None,
    'time_in_force': <TimeInForce.DAY: 'day'>,
    'type': <OrderType.LIMIT: 'limit'>}
>>> OrderRequest(symbol="AAPL", side="buy", type="limit", time_in_force="day", qty=1, currency=SupportedCurrencies.EUR)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for OrderRequest
__root__
  Order type must be OrderType.MARKET if the order is in a local currency. (type=value_error)
>>> OrderRequest(symbol="AAPL", side="buy", type="market", time_in_force="day", qty=1, currency=SupportedCurrencies.EUR)
{   'client_order_id': None,
    'commission': None,
    'currency': <SupportedCurrencies.EUR: 'EUR'>,
    'extended_hours': None,
    'notional': None,
    'order_class': None,
    'qty': 1.0,
    'side': <OrderSide.BUY: 'buy'>,
    'stop_loss': None,
    'symbol': 'AAPL',
    'take_profit': None,
    'time_in_force': <TimeInForce.DAY: 'day'>,
    'type': <OrderType.MARKET: 'market'>}
>>>
```