### PR TITLE
Update enums to include Crypto Exchange

### DIFF
--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -177,6 +177,7 @@ class AssetExchange(str, Enum):
     GNSS = "GNSS"
     ERSX = "ERSX"
     OTC = "OTC"
+    CRYPTO = "CRYPTO"
 
 
 class PositionSide(str, Enum):


### PR DESCRIPTION
Starting 4/25/23, the TradingClient's `get_all_assets` method returns crypto assets with exchange value set to `CRYPTO`
This is likely only happening for clients with Crypto enabled on their account, but breaking the `pydantic` validation.