### PR TITLE
Fix #291 by making target_symbol, target_original_cusip optional in CorporateActionAnnouncement

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -580,8 +580,8 @@ class CorporateActionAnnouncement(BaseModel):
     ca_sub_type: CorporateActionSubType
     initiating_symbol: str
     initiating_original_cusip: str
-    target_symbol: str
-    target_original_cusip: str
+    target_symbol: Optional[str]
+    target_original_cusip: Optional[str]
     declaration_date: Optional[date]
     ex_date: Optional[date]
     record_date: date


### PR DESCRIPTION
If corporate announcements in the timeframe specified in `trading_client.get_corporate_announcements` are missing either the `target_symbol` or `target_original_cusip` fields, the function will raise an error via Pydantic. 

To fix this I made these two fields optional in the `CorporateActionAnnouncement` class. This may not be what is wanted long-term since I assume corporate announcements are only useful if they contain at least the `target_symbol` field, but it is a necessary fix for now to make the api usable.