### PR TITLE
adding ss number verification enum

### DIFF
--- a/alpaca/broker/enums.py
+++ b/alpaca/broker/enums.py
@@ -131,6 +131,7 @@ class DocumentType(str, Enum):
     ACCOUNT_APPROVAL_LETTER = "account_approval_letter"
     LIMITED_TRADING_AUTHORIZATION = "limited_trading_authorization"
     W8BEN = "w8ben"
+    SOCIAL_SECURITY_NUMBER_VERIFICATION = "social_security_number_verification"
 
 
 class AccountEntities(str, Enum):


### PR DESCRIPTION
fixes an issue we got from running in production:

```
ValueError: 'social_security_number_verification' is not a valid DocumentType
```