### PR TITLE
Marking content as optional as the api may return docuements without it

### DIFF
--- a/alpaca/broker/models/documents.py
+++ b/alpaca/broker/models/documents.py
@@ -32,7 +32,7 @@ class AccountDocument(BaseModel):
     id: Optional[UUID]
     document_type: Optional[DocumentType]
     document_sub_type: Optional[str] = None
-    content: str
+    content: Optional[str]
     mime_type: Optional[str] = None
 
     def __init__(self, **data: Any) -> None:


### PR DESCRIPTION
After trying https://github.com/alpacahq/alpaca-py/pull/304 we ran into an additional issue where the documents don't actually return content so pydantic is erroring on that:

```
*** pydantic.error_wrappers.ValidationError: 3 validation errors for ParsingModel[List[alpaca.broker.models.documents.AccountDocument]]
__root__ -> 1 -> content
  field required (type=value_error.missing)
__root__ -> 2 -> content
  field required (type=value_error.missing)
__root__ -> 3 -> content
  field required (type=value_error.missing)
```

API response:
```
[{'content': '<truncating for security/privacy>',
  'created_at': '2023-07-06T15:24:10.880969Z',
  'document_sub_type': 'passport',
  'document_type': <DocumentType.IDENTITY_VERIFICATION: 'identity_verification'>,
  'id': '161b9f84-b86d-4233-a49b-1067aacf87a0'},
 {'created_at': '2023-07-06T15:25:30.350028Z',
  'document_type': <DocumentType.DATE_OF_BIRTH_VERIFICATION: 'date_of_birth_verification'>,
  'id': '1d0525b2-b22e-449c-8f55-e1bf620bc914'},
 {'created_at': '2023-07-06T15:25:30.352051Z',
  'document_type': <DocumentType.ADDRESS_VERIFICATION: 'address_verification'>,
  'id': '5a052cc0-9f04-4564-87f8-7387d362b2dc'},
 {'created_at': '2023-07-06T15:25:30.353331Z',
  'document_type': <DocumentType.SOCIAL_SECURITY_NUMBER_VERIFICATION: 'social_security_number_verification'>,
  'id': '0f8007b6-1b26-4b38-b69f-1984b42cd114'}]

```