### PR TITLE
adding the account application enum type

### DIFF
--- a/alpaca/broker/enums.py
+++ b/alpaca/broker/enums.py
@@ -229,6 +229,8 @@ class TradeDocumentType(str, Enum):
 
     TAX_STATEMENT = "tax_statement"
 
+    ACCOUNT_APPLICATION = "account_application"
+
     # Legacy Values
     TAX_1099_B_DETAILS = "tax_1099_b_details"
     TAX_1099_B_FORM = "tax_1099_b_form"


### PR DESCRIPTION
pydantic_core._pydantic_core.ValidationError: 1 validation error for TradeDocument
type
  Input should be 'account_statement', 'trade_confirmation', 'trade_confirmation_json', 'tax_statement', 'tax_1099_b_details', 'tax_1099_b_form', 'tax_1099_div_details', 'tax_1099_div_form', 'tax_1099_int_details', 'tax_1099_int_form' or 'tax_w8' [type=enum, input_value='account_application', input_type=str]