### PR TITLE
fix: Fix TradeUpdate model for validation error

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -596,6 +596,7 @@ class TradeUpdate(BaseModel):
 
     ref. https://docs.alpaca.markets/docs/websocket-streaming#example
     """
+
     event: Union[TradeEvent, str]
     execution_id: Optional[UUID] = None
     order: Order

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -591,10 +591,15 @@ class CorporateActionAnnouncement(ModelWithID):
 
 
 class TradeUpdate(BaseModel):
+    """
+    Represents a trade update.
+
+    ref. https://docs.alpaca.markets/docs/websocket-streaming#example
+    """
     event: Union[TradeEvent, str]
-    execution_id: Optional[UUID]
+    execution_id: Optional[UUID] = None
     order: Order
     timestamp: datetime
-    position_qty: Optional[float]
-    price: Optional[float]
-    qty: Optional[float]
+    position_qty: Optional[float] = None
+    price: Optional[float] = None
+    qty: Optional[float] = None


### PR DESCRIPTION
fixes https://github.com/alpacahq/alpaca-py/issues/371

Context:
- we have validation errors for TradeUpdate reported in #371 

Changes:
- fix TradeUpdate model to set None as default

How to check:
- you can use the below code in google colab

```
# to reproduce an error
# ! pip install alpaca-py
# to confirm this PR's change
! pip install git+https://github.com/hiohiohio/alpaca-py.git@fix-trade-update-model

api_key=<YOUR API KEY>
secret_key=<YOUR SECRET>
paper = True

# required for asyncio in google colab
import nest_asyncio
nest_asyncio.apply()

from alpaca.trading.stream import TradingStream

cli = TradingStream(api_key, secret_key, paper=paper)

async def msg_handler(msg) -> None:
    print(msg)

cli.subscribe_trade_updates(msg_handler)
cli.run()
```
