### PR TITLE
fix: Support timezone aware datetime for get_orders()

### DIFF
--- a/alpaca/common/requests.py
+++ b/alpaca/common/requests.py
@@ -46,6 +46,10 @@ class NonEmptyRequest(BaseModel):
 
             # RFC 3339
             if isinstance(val, datetime):
+                # if the datetime is naive, assume it's UTC
+                # https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive
+                if val.tzinfo is None or val.tzinfo.utcoffset(val) is None:
+                    val = val.replace(tzinfo=datetime.timezone.utc)
                 return val.isoformat()
 
             return val

--- a/alpaca/common/requests.py
+++ b/alpaca/common/requests.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
 
@@ -49,7 +49,7 @@ class NonEmptyRequest(BaseModel):
                 # if the datetime is naive, assume it's UTC
                 # https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive
                 if val.tzinfo is None or val.tzinfo.utcoffset(val) is None:
-                    val = val.replace(tzinfo=datetime.timezone.utc)
+                    val = val.replace(tzinfo=timezone.utc)
                 return val.isoformat()
 
             return val

--- a/alpaca/common/requests.py
+++ b/alpaca/common/requests.py
@@ -46,7 +46,7 @@ class NonEmptyRequest(BaseModel):
 
             # RFC 3339
             if isinstance(val, datetime):
-                return val.isoformat("T") + "Z"
+                return val.isoformat()
 
             return val
 

--- a/tests/broker/broker_client/test_account_activities_routes.py
+++ b/tests/broker/broker_client/test_account_activities_routes.py
@@ -253,7 +253,7 @@ def test_get_activities_for_account_max_items_and_single_request_date(
     assert len(result) == max_limit
 
     request = reqmock.request_history[0]
-    assert "date" in request.qs and request.qs["date"] == [f"{date_str}t00:00:00z"]
+    assert "date" in request.qs and request.qs["date"] == [f"{date_str}t00:00:00+00:00"]
     assert "page_size" in request.qs and request.qs["page_size"] == ["2"]
 
 

--- a/tests/data/test_historical_crypto_data.py
+++ b/tests/data/test_historical_crypto_data.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+import urllib.parse
+from datetime import datetime, timezone
 from typing import Dict
 
 from alpaca.data import Quote, Trade, Bar
@@ -27,8 +28,10 @@ def test_get_crypto_bars(reqmock, crypto_client: CryptoHistoricalDataClient):
     timeframe = TimeFrame.Day
     _symbols_in_url = "%2C".join(s for s in symbols)
 
-    _start_in_url = start.isoformat("T") + "Z"
-    _end_in_url = end.isoformat("T") + "Z"
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
+    _end_in_url = urllib.parse.quote_plus(end.replace(tzinfo=timezone.utc).isoformat())
     reqmock.get(
         f"https://data.alpaca.markets/v1beta3/crypto/us/bars?timeframe={timeframe}&start={_start_in_url}&end={_end_in_url}&symbols={_symbols_in_url}",
         text="""
@@ -83,7 +86,9 @@ def test_get_trades(reqmock, crypto_client: CryptoHistoricalDataClient):
     start = datetime(2022, 3, 9)
     _symbols_in_url = "%2C".join(s for s in symbols)
 
-    _start_in_url = start.isoformat("T") + "Z"
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
 
     reqmock.get(
         f"https://data.alpaca.markets/v1beta3/crypto/us/trades?start={_start_in_url}&symbols={_symbols_in_url}",

--- a/tests/data/test_historical_stock_data.py
+++ b/tests/data/test_historical_stock_data.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+import urllib.parse
+from datetime import datetime, timezone
 from typing import Dict
 from alpaca.common.enums import Sort
 
@@ -25,7 +26,9 @@ def test_get_bars(reqmock, stock_client: StockHistoricalDataClient):
     timeframe = TimeFrame.Day
     start = datetime(2022, 2, 1)
     limit = 2
-    _start_in_url = start.isoformat("T") + "Z"
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
     reqmock.get(
         f"https://data.alpaca.markets/v2/stocks/{symbol}/bars?start={_start_in_url}&timeframe={timeframe}&limit={limit}",
         text="""
@@ -78,8 +81,10 @@ def test_get_bars_desc(reqmock, stock_client: StockHistoricalDataClient):
     start = datetime(2023, 9, 1)
     end = datetime(2023, 9, 27, 12)
     limit = 3
-    _start_in_url = start.isoformat("T") + "Z"
-    _end_in_url = end.isoformat("T") + "Z"
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
+    _end_in_url = urllib.parse.quote_plus(end.replace(tzinfo=timezone.utc).isoformat())
     reqmock.get(
         f"https://data.alpaca.markets/v2/stocks/{symbol}/bars?start={_start_in_url}&end={_end_in_url}&timeframe={timeframe}&limit={limit}&sort=desc",
         text="""
@@ -148,8 +153,10 @@ def test_multisymbol_get_bars(reqmock, stock_client: StockHistoricalDataClient):
     timeframe = TimeFrame.Day
     _symbols_in_url = "%2C".join(s for s in symbols)
 
-    _start_in_url = start.isoformat("T") + "Z"
-    _end_in_url = end.isoformat("T") + "Z"
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
+    _end_in_url = urllib.parse.quote_plus(end.replace(tzinfo=timezone.utc).isoformat())
 
     reqmock.get(
         f"https://data.alpaca.markets/v2/stocks/bars?timeframe={timeframe}&start={_start_in_url}&end={_end_in_url}&symbols={_symbols_in_url}",
@@ -208,7 +215,9 @@ def test_get_quotes(reqmock, stock_client: StockHistoricalDataClient):
     start = datetime(2022, 3, 9)
     limit = 2
 
-    _start_in_url = start.isoformat("T") + "Z"
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
 
     reqmock.get(
         f"https://data.alpaca.markets/v2/stocks/{symbol}/quotes?start={_start_in_url}&limit={limit}",
@@ -269,7 +278,9 @@ def test_multisymbol_quotes(reqmock, stock_client: StockHistoricalDataClient):
     start = datetime(2022, 3, 9)
     _symbols_in_url = "%2C".join(s for s in symbols)
 
-    _start_in_url = start.isoformat("T") + "Z"
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
 
     reqmock.get(
         f"https://data.alpaca.markets/v2/stocks/quotes?start={_start_in_url}&symbols={_symbols_in_url}",
@@ -334,7 +345,9 @@ def test_get_trades(reqmock, stock_client: StockHistoricalDataClient):
     start = datetime(2022, 3, 9)
     limit = 2
 
-    _start_in_url = start.isoformat("T") + "Z"
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
 
     reqmock.get(
         f"https://data.alpaca.markets/v2/stocks/{symbol}/trades?start={_start_in_url}&limit={limit}",
@@ -396,7 +409,9 @@ def test_multisymbol_get_trades(reqmock, stock_client: StockHistoricalDataClient
     start = datetime(2022, 3, 9)
     _symbols_in_url = "%2C".join(s for s in symbols)
 
-    _start_in_url = start.isoformat("T") + "Z"
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
 
     reqmock.get(
         f"https://data.alpaca.markets/v2/stocks/trades?start={_start_in_url}&symbols={_symbols_in_url}",


### PR DESCRIPTION
Fixes https://github.com/alpacahq/alpaca-py/issues/236

Context:
- tradeclient.get_orders errors when datetime has timezone
- we would like to support timezone aware datetime as well as naive datetime

Changes:
- support timezone aware datetime

you can use below code to check in google colab
```
# use alpaca-py v0.13.1 to reproduce this issue
# ! pip install alpaca-py==0.13.1
! pip install git+https://github.com/hiohiohio/alpaca-py.git@support-datetime-with-timezone


import datetime
from zoneinfo import ZoneInfo

from alpaca.trading.requests import GetOrdersRequest
from alpaca.trading.enums import QueryOrderStatus
from alpaca.trading.client import TradingClient

api_key=<YOUR API KEY>
secret_key=<YOUR SECRET KEY>
paper = True

# timezone aware datetime (UTC)
client = TradingClient(api_key, secret_key, paper=paper)
nowUTC = datetime.datetime.now(datetime.timezone.utc)
req = GetOrdersRequest(status=QueryOrderStatus.ALL, until=nowUTC)
print(client.get_orders(req)[:1]) # APIError <= is resolved

# naive datetime is treated as UTC (same as before)
now = datetime.datetime.now()
req2 = GetOrdersRequest(status=QueryOrderStatus.ALL, until=now)
print(client.get_orders(req2)[:1])

# timezone aware datetime (ET)
nowNY = datetime.datetime.now(ZoneInfo("US/Eastern"))
req3 = GetOrdersRequest(status=QueryOrderStatus.ALL, until=nowNY)
print(client.get_orders(req3)[:1])
```