### PR TITLE
fixing an issue where using f-strings uses the enum name instead of t…

### DIFF
--- a/alpaca/broker/client.py
+++ b/alpaca/broker/client.py
@@ -641,7 +641,10 @@ class BrokerClient(RESTClient):
         # self.get/post/etc all set follow redirects to false, however API will return a 301 redirect we need to follow,
         # so we just do a raw request
 
-        target_url = f"{self._base_url}/{self._api_version}/accounts/{account_id}/documents/{document_id}/download"
+        # force base_url to be a string value instead of enum name
+        base_url = self._base_url + ""
+
+        target_url = f"{base_url}/{self._api_version}/accounts/{account_id}/documents/{document_id}/download"
         num_tries = 0
 
         while num_tries <= self._retry:

--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -973,7 +973,6 @@ class GetJournalsRequest(NonEmptyRequest):
 
 
 class GetEventsRequest(NonEmptyRequest):
-
     id: Optional[str] = None
     since: Optional[Union[date, str]] = None
     until: Optional[Union[date, str]] = None

--- a/alpaca/common/websocket.py
+++ b/alpaca/common/websocket.py
@@ -163,7 +163,6 @@ class BaseStream:
         """
         result = msg
         if not self._raw_data:
-
             if "t" in msg:
                 msg["t"] = msg["t"].to_datetime()
 


### PR DESCRIPTION
…he enum value

exception hit in prod:
requests.exceptions.MissingSchema: Invalid URL 'BaseURL.BROKER_PRODUCTION/v1/accounts/XXXX-69da-44c2-bf62-37b29a9a2063/documents/XXXX-af19-45c1-8ad5-4313582caab0/download': No scheme supplied. Perhaps you meant https://BaseURL.BROKER_PRODUCTION/v1/accounts/XXXX-69da-44c2-bf62-37b29a9a2063/documents/XXXX-af19-45c1-8ad5-4313582caab0/download?

the behavior is like this:

```
(Pdb) self._base_url + "foo"
'https://broker-api.alpaca.marketsfoo/'
(Pdb) f"{self._base_url}"
'BaseURL.BROKER_PRODUCTION'
```
