### PR TITLE
adding cip result document type

### DIFF
--- a/alpaca/broker/enums.py
+++ b/alpaca/broker/enums.py
@@ -133,6 +133,7 @@ class DocumentType(str, Enum):
     W8BEN = "w8ben"
     SOCIAL_SECURITY_NUMBER_VERIFICATION = "social_security_number_verification"
     NULL = ""
+    CIP_RESULT = "cip_result"
 
 
 class AccountEntities(str, Enum):


### PR DESCRIPTION
```
1 validation error for AccountDocument
document_type
 Input should be 'identity_verification', 'address_verification', 'date_of_birth_verification', 'tax_id_verification', 'account_approval_letter', 'limited_trading_authorization', 'w8ben', 'social_security_number_verification' or '' [type=enum, input_value='cip_result', input_type=str]
```