### PR TITLE
fix: remove f-string for enum

### DIFF
--- a/alpaca/data/live/crypto.py
+++ b/alpaca/data/live/crypto.py
@@ -35,7 +35,7 @@ class CryptoDataStream(BaseStream):
             endpoint=(
                 url_override
                 if url_override is not None
-                else BaseURL.MARKET_DATA_STREAM.value + f"/v1beta3/crypto/{feed}"
+                else BaseURL.MARKET_DATA_STREAM.value + "/v1beta3/crypto/" + feed
             ),
             api_key=api_key,
             secret_key=secret_key,


### PR DESCRIPTION
fixes #383 

Context:
- there is 404 error when subscribe crypto data feed

Changes:
- avoid using f-string for enum

Ref:
- log indicates that enum value is used for f-string replacement for this issue. `CryptoFeed.US` should be `us` in the very last line of the below.
```
>>> wss_client.run()
DEBUG:asyncio:Using selector: EpollSelector
INFO:alpaca.common.websocket:started data stream
INFO:alpaca.common.websocket:starting data websocket connection
DEBUG:websockets.client:= connection is CONNECTING
DEBUG:websockets.client:> GET /v1beta3/crypto/CryptoFeed.US HTTP/1.1
```


You can test this by
```bash
$ docker run -it --entrypoint bash python:3.12-slim
$ apt-get update && apt-get install git -y
$ pip install git+https://github.com/hiohiohio/alpaca-py.git@fix-stream-url-not-found
$ python3

import logging
import sys
logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)

API_KEY=''
SECRET=''
from alpaca.data.live import CryptoDataStream
wss_client = CryptoDataStream(API_KEY, SECRET)

async def bars_data_handler(data):
    print(data)

wss_client.subscribe_bars(bars_data_handler, "BTC/USD")
wss_client.run()
```