### PR TITLE
feat: Use poetry-dynamic-versioning

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       # install poetry first for cache
       - name: setup poetry
-        run: pipx install poetry
+        run: pipx install poetry poetry-dynamic-versioning
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/alpaca/__init__.py
+++ b/alpaca/__init__.py
@@ -1,1 +1,2 @@
-__version__ = "0.13.4"
+# placeholder for poetry-dynamic-versioning
+__version__ = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "alpaca-py"
-version = "0.13.4"
+# placeholder for poetry-dynamic-versioning
+version = "0.0.0"
 description = "The Official Python SDK for Alpaca APIs"
 authors = [
     "Rahul Chowdhury <rahul.chowdhury@alpaca.markets>",
@@ -37,5 +38,10 @@ enum-tools = "^0.9.0"
 sphinx-toolbox = "^3.1.2"
 
 [build-system]
-requires = ["poetry-core>=1.4.2"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.4.2", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
+
+[tool.poetry-dynamic-versioning.substitution]
+folders = [
+  { path = "alpaca" }
+]


### PR DESCRIPTION
- use poetry-dynamic-versioning to specify release version of the alpaca-py package by git tag of `v0.0.0`