### PR TITLE
fix: Fix handling empty market data

### DIFF
--- a/alpaca/data/historical/stock.py
+++ b/alpaca/data/historical/stock.py
@@ -99,9 +99,6 @@ class StockHistoricalDataClient(RESTClient):
         if self._use_raw_data:
             return raw_bars
 
-        if raw_bars is None:
-            return None
-
         return BarSet(raw_bars)
 
     def get_stock_quotes(
@@ -232,9 +229,6 @@ class StockHistoricalDataClient(RESTClient):
 
         if self._use_raw_data:
             return raw_latest_bars
-
-        if raw_latest_bars is None:
-            return {}
 
         return parse_obj_as_symbol_dict(Bar, raw_latest_bars)
 

--- a/alpaca/data/historical/stock.py
+++ b/alpaca/data/historical/stock.py
@@ -98,6 +98,9 @@ class StockHistoricalDataClient(RESTClient):
 
         if self._use_raw_data:
             return raw_bars
+    
+        if raw_bars is None:
+            return None
 
         return BarSet(raw_bars)
 
@@ -229,6 +232,9 @@ class StockHistoricalDataClient(RESTClient):
 
         if self._use_raw_data:
             return raw_latest_bars
+
+        if raw_latest_bars is None:
+            return {}
 
         return parse_obj_as_symbol_dict(Bar, raw_latest_bars)
 

--- a/alpaca/data/historical/stock.py
+++ b/alpaca/data/historical/stock.py
@@ -98,7 +98,7 @@ class StockHistoricalDataClient(RESTClient):
 
         if self._use_raw_data:
             return raw_bars
-    
+
         if raw_bars is None:
             return None
 

--- a/alpaca/data/historical/utils.py
+++ b/alpaca/data/historical/utils.py
@@ -23,6 +23,8 @@ def parse_obj_as_symbol_dict(model: Type, raw_data: RawData) -> Dict[str, Type]:
     Returns:
         Dict[str, Type]: The symbol keyed dictionary of parsed data
     """
+    if raw_data is None:
+        return {}
     return {k: model(symbol=k, raw_data=v) for k, v in raw_data.items()}
 
 

--- a/alpaca/data/historical/utils.py
+++ b/alpaca/data/historical/utils.py
@@ -25,7 +25,9 @@ def parse_obj_as_symbol_dict(model: Type, raw_data: RawData) -> Dict[str, Type]:
     """
     if raw_data is None:
         return {}
-    return {k: model(symbol=k, raw_data=v) for k, v in raw_data.items() if v is not None}
+    return {
+        k: model(symbol=k, raw_data=v) for k, v in raw_data.items() if v is not None
+    }
 
 
 def get_data_from_response(response: HTTPResult) -> RawData:

--- a/alpaca/data/historical/utils.py
+++ b/alpaca/data/historical/utils.py
@@ -25,7 +25,7 @@ def parse_obj_as_symbol_dict(model: Type, raw_data: RawData) -> Dict[str, Type]:
     """
     if raw_data is None:
         return {}
-    return {k: model(symbol=k, raw_data=v) for k, v in raw_data.items()}
+    return {k: model(symbol=k, raw_data=v) for k, v in raw_data.items() if v is not None}
 
 
 def get_data_from_response(response: HTTPResult) -> RawData:

--- a/alpaca/data/models/bars.py
+++ b/alpaca/data/models/bars.py
@@ -43,9 +43,12 @@ class Bar(BaseModel):
         Args:
             raw_data (RawData): Raw unparsed bar data from API, contains ohlc and other fields.
         """
-        mapped_bar = {
-            BAR_MAPPING[key]: val for key, val in raw_data.items() if key in BAR_MAPPING
-        }
+        mapped_bar = {}
+
+        if raw_data is not None:
+            mapped_bar = {
+                BAR_MAPPING[key]: val for key, val in raw_data.items() if key in BAR_MAPPING
+            }
 
         super().__init__(symbol=symbol, **mapped_bar)
 
@@ -71,7 +74,8 @@ class BarSet(BaseDataSet, TimeSeriesMixin):
 
         raw_bars = raw_data
 
-        for symbol, bars in raw_bars.items():
-            parsed_bars[symbol] = [Bar(symbol, bar) for bar in bars]
+        if raw_bars is not None:
+            for symbol, bars in raw_bars.items():
+                parsed_bars[symbol] = [Bar(symbol, bar) for bar in bars]
 
         super().__init__(data=parsed_bars)

--- a/alpaca/data/models/bars.py
+++ b/alpaca/data/models/bars.py
@@ -74,8 +74,7 @@ class BarSet(BaseDataSet, TimeSeriesMixin):
 
         raw_bars = raw_data
 
-        if raw_bars is not None:
-            for symbol, bars in raw_bars.items():
-                parsed_bars[symbol] = [Bar(symbol, bar) for bar in bars]
+        for symbol, bars in raw_bars.items():
+            parsed_bars[symbol] = [Bar(symbol, bar) for bar in bars]
 
         super().__init__(data=parsed_bars)

--- a/alpaca/data/models/bars.py
+++ b/alpaca/data/models/bars.py
@@ -47,7 +47,9 @@ class Bar(BaseModel):
 
         if raw_data is not None:
             mapped_bar = {
-                BAR_MAPPING[key]: val for key, val in raw_data.items() if key in BAR_MAPPING
+                BAR_MAPPING[key]: val
+                for key, val in raw_data.items()
+                if key in BAR_MAPPING
             }
 
         super().__init__(symbol=symbol, **mapped_bar)

--- a/alpaca/data/models/bars.py
+++ b/alpaca/data/models/bars.py
@@ -76,7 +76,8 @@ class BarSet(BaseDataSet, TimeSeriesMixin):
 
         raw_bars = raw_data
 
-        for symbol, bars in raw_bars.items():
-            parsed_bars[symbol] = [Bar(symbol, bar) for bar in bars]
+        if raw_bars is not None:
+            for symbol, bars in raw_bars.items():
+                parsed_bars[symbol] = [Bar(symbol, bar) for bar in bars]
 
         super().__init__(data=parsed_bars)

--- a/alpaca/data/models/bars.py
+++ b/alpaca/data/models/bars.py
@@ -78,6 +78,8 @@ class BarSet(BaseDataSet, TimeSeriesMixin):
 
         if raw_bars is not None:
             for symbol, bars in raw_bars.items():
-                parsed_bars[symbol] = [Bar(symbol, bar) for bar in bars]
+                parsed_bars[symbol] = [
+                    Bar(symbol, bar) for bar in bars if bar is not None
+                ]
 
         super().__init__(data=parsed_bars)

--- a/alpaca/data/models/base.py
+++ b/alpaca/data/models/base.py
@@ -21,10 +21,13 @@ class TimeSeriesMixin:
         # combine all lists of data into one list
         data_list = list(itertools.chain.from_iterable(self.dict().values()))
 
+        df = pd.DataFrame(data_list)
+
         # set multi-level index
         # level=0 - symbol
         # level=1 - timestamp
-        df = pd.DataFrame(data_list).set_index(["symbol", "timestamp"])
+        if set(["symbol", "timestamp"]).issubset(df.columns):
+            df = df.set_index(["symbol", "timestamp"])
 
         # drop null columns
         df.dropna(axis=1, how="all", inplace=True)

--- a/alpaca/data/models/base.py
+++ b/alpaca/data/models/base.py
@@ -37,7 +37,7 @@ class BaseDataSet(BaseModel):
     Base class to process data models for trades, bars and quotes.
     """
 
-    data: Dict[str, List[BaseModel]]
+    data: Dict[str, List[BaseModel]] = {}
     model_config = ConfigDict(protected_namespaces=tuple())
 
     def __getitem__(self, symbol: str) -> Any:

--- a/alpaca/data/models/quotes.py
+++ b/alpaca/data/models/quotes.py
@@ -73,6 +73,8 @@ class QuoteSet(BaseDataSet, TimeSeriesMixin):
 
         if raw_data is not None:
             for symbol, quotes in raw_data.items():
-                parsed_quotes[symbol] = [Quote(symbol, quote) for quote in quotes]
+                parsed_quotes[symbol] = [
+                    Quote(symbol, quote) for quote in quotes if quote is not None
+                ]
 
         super().__init__(data=parsed_quotes)

--- a/alpaca/data/models/quotes.py
+++ b/alpaca/data/models/quotes.py
@@ -71,7 +71,8 @@ class QuoteSet(BaseDataSet, TimeSeriesMixin):
         """
         parsed_quotes = {}
 
-        for symbol, quotes in raw_data.items():
-            parsed_quotes[symbol] = [Quote(symbol, quote) for quote in quotes]
+        if raw_data is not None:
+            for symbol, quotes in raw_data.items():
+                parsed_quotes[symbol] = [Quote(symbol, quote) for quote in quotes]
 
         super().__init__(data=parsed_quotes)

--- a/alpaca/data/models/snapshots.py
+++ b/alpaca/data/models/snapshots.py
@@ -45,9 +45,13 @@ class Snapshot(BaseModel):
 
         # Parse each data type
         if mapped_snapshot["latest_trade"] is not None:
-            mapped_snapshot["latest_trade"] = Trade(symbol, mapped_snapshot["latest_trade"])
+            mapped_snapshot["latest_trade"] = Trade(
+                symbol, mapped_snapshot["latest_trade"]
+            )
         if mapped_snapshot["latest_quote"] is not None:
-            mapped_snapshot["latest_quote"] = Quote(symbol, mapped_snapshot["latest_quote"])
+            mapped_snapshot["latest_quote"] = Quote(
+                symbol, mapped_snapshot["latest_quote"]
+            )
         if mapped_snapshot["minute_bar"] is not None:
             mapped_snapshot["minute_bar"] = Bar(symbol, mapped_snapshot["minute_bar"])
         if mapped_snapshot["daily_bar"] is not None:

--- a/alpaca/data/models/snapshots.py
+++ b/alpaca/data/models/snapshots.py
@@ -44,19 +44,19 @@ class Snapshot(BaseModel):
         }
 
         # Parse each data type
-        if mapped_snapshot["latest_trade"] is not None:
+        if mapped_snapshot.get("latest_trade", None) is not None:
             mapped_snapshot["latest_trade"] = Trade(
                 symbol, mapped_snapshot["latest_trade"]
             )
-        if mapped_snapshot["latest_quote"] is not None:
+        if mapped_snapshot.get("latest_quote", None) is not None:
             mapped_snapshot["latest_quote"] = Quote(
                 symbol, mapped_snapshot["latest_quote"]
             )
-        if mapped_snapshot["minute_bar"] is not None:
+        if mapped_snapshot.get("minute_bar", None) is not None:
             mapped_snapshot["minute_bar"] = Bar(symbol, mapped_snapshot["minute_bar"])
-        if mapped_snapshot["daily_bar"] is not None:
+        if mapped_snapshot.get("daily_bar", None) is not None:
             mapped_snapshot["daily_bar"] = Bar(symbol, mapped_snapshot["daily_bar"])
-        if mapped_snapshot["previous_daily_bar"] is not None:
+        if mapped_snapshot.get("previous_daily_bar", None) is not None:
             mapped_snapshot["previous_daily_bar"] = Bar(
                 symbol, mapped_snapshot["previous_daily_bar"]
             )

--- a/alpaca/data/models/snapshots.py
+++ b/alpaca/data/models/snapshots.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from pydantic import ConfigDict
 
@@ -14,19 +14,19 @@ class Snapshot(BaseModel):
 
     Attributes:
         symbol (str): The identifier for the snapshot security.
-        latest_trade(Trade): The latest transaction on the price and sales tape
-        latest_quote (Quote): Level 1 ask/bid pair quote data.
-        minute_bar (Bar): The latest minute OHLC bar data
-        daily_bar (Bar): The latest daily OHLC bar data
-        previous_daily_bar (Bar): The 2nd to latest (2 trading days ago) daily OHLC bar data
+        latest_trade (Optional[Trade]): The latest transaction on the price and sales tape
+        latest_quote (Optional[Quote]): Level 1 ask/bid pair quote data.
+        minute_bar (Optional[Bar]): The latest minute OHLC bar data
+        daily_bar (Optional[Bar]): The latest daily OHLC bar data
+        previous_daily_bar (Optional[Bar]): The 2nd to latest (2 trading days ago) daily OHLC bar data
     """
 
     symbol: str
-    latest_trade: Trade
-    latest_quote: Quote
-    minute_bar: Bar
-    daily_bar: Bar
-    previous_daily_bar: Bar
+    latest_trade: Optional[Trade] = None
+    latest_quote: Optional[Quote] = None
+    minute_bar: Optional[Bar] = None
+    daily_bar: Optional[Bar] = None
+    previous_daily_bar: Optional[Bar] = None
 
     model_config = ConfigDict(protected_namespaces=tuple())
 

--- a/alpaca/data/models/snapshots.py
+++ b/alpaca/data/models/snapshots.py
@@ -44,12 +44,17 @@ class Snapshot(BaseModel):
         }
 
         # Parse each data type
-        mapped_snapshot["latest_trade"] = Trade(symbol, mapped_snapshot["latest_trade"])
-        mapped_snapshot["latest_quote"] = Quote(symbol, mapped_snapshot["latest_quote"])
-        mapped_snapshot["minute_bar"] = Bar(symbol, mapped_snapshot["minute_bar"])
-        mapped_snapshot["daily_bar"] = Bar(symbol, mapped_snapshot["daily_bar"])
-        mapped_snapshot["previous_daily_bar"] = Bar(
-            symbol, mapped_snapshot["previous_daily_bar"]
-        )
+        if mapped_snapshot["latest_trade"] is not None:
+            mapped_snapshot["latest_trade"] = Trade(symbol, mapped_snapshot["latest_trade"])
+        if mapped_snapshot["latest_quote"] is not None:
+            mapped_snapshot["latest_quote"] = Quote(symbol, mapped_snapshot["latest_quote"])
+        if mapped_snapshot["minute_bar"] is not None:
+            mapped_snapshot["minute_bar"] = Bar(symbol, mapped_snapshot["minute_bar"])
+        if mapped_snapshot["daily_bar"] is not None:
+            mapped_snapshot["daily_bar"] = Bar(symbol, mapped_snapshot["daily_bar"])
+        if mapped_snapshot["previous_daily_bar"] is not None:
+            mapped_snapshot["previous_daily_bar"] = Bar(
+                symbol, mapped_snapshot["previous_daily_bar"]
+            )
 
         super().__init__(symbol=symbol, **mapped_snapshot)

--- a/alpaca/data/models/trades.py
+++ b/alpaca/data/models/trades.py
@@ -67,7 +67,8 @@ class TradeSet(BaseDataSet, TimeSeriesMixin):
         """
         parsed_trades = {}
 
-        for symbol, trades in raw_data.items():
-            parsed_trades[symbol] = [Trade(symbol, trade) for trade in trades]
+        if raw_data is not None:
+            for symbol, trades in raw_data.items():
+                parsed_trades[symbol] = [Trade(symbol, trade) for trade in trades]
 
         super().__init__(data=parsed_trades)

--- a/alpaca/data/models/trades.py
+++ b/alpaca/data/models/trades.py
@@ -69,6 +69,8 @@ class TradeSet(BaseDataSet, TimeSeriesMixin):
 
         if raw_data is not None:
             for symbol, trades in raw_data.items():
-                parsed_trades[symbol] = [Trade(symbol, trade) for trade in trades]
+                parsed_trades[symbol] = [
+                    Trade(symbol, trade) for trade in trades if trade is not None
+                ]
 
         super().__init__(data=parsed_trades)

--- a/tests/data/test_historical_stock_data.py
+++ b/tests/data/test_historical_stock_data.py
@@ -208,6 +208,69 @@ def test_multisymbol_get_bars(reqmock, stock_client: StockHistoricalDataClient):
     assert barset.df.index.nlevels == 2
 
 
+def test_get_bars_single_empty_response(reqmock, stock_client: StockHistoricalDataClient):
+    symbol = "AAPL"
+    timeframe = TimeFrame.Day
+    start = datetime(2022, 2, 1)
+    limit = 2
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
+    reqmock.get(
+        f"https://data.alpaca.markets/v2/stocks/{symbol}/bars?start={_start_in_url}&timeframe={timeframe}&limit={limit}",
+        text="""
+    {
+        "bars": null,
+        "next_page_token": null,
+        "symbol": "AAPL"
+    }
+        """,
+    )
+    request = StockBarsRequest(
+        symbol_or_symbols=symbol, timeframe=timeframe, start=start, limit=limit
+    )
+    barset = stock_client.get_stock_bars(request_params=request)
+
+    assert isinstance(barset, BarSet)
+
+    assert barset.dict() == {"AAPL": []}
+
+    assert len(barset.df) == 0
+
+    assert reqmock.called_once
+
+
+def test_get_bars_multi_empty_response(reqmock, stock_client: StockHistoricalDataClient):
+    symbol = "AAPL"
+    timeframe = TimeFrame.Day
+    start = datetime(2022, 2, 1)
+    limit = 2
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
+    reqmock.get(
+        f"https://data.alpaca.markets/v2/stocks/bars?symbols={symbol}&start={_start_in_url}&timeframe={timeframe}&limit={limit}",
+        text="""
+    {
+        "bars": {},
+        "next_page_token": null
+    }
+        """,
+    )
+    request = StockBarsRequest(
+        symbol_or_symbols=[symbol], timeframe=timeframe, start=start, limit=limit
+    )
+    barset = stock_client.get_stock_bars(request_params=request)
+
+    assert isinstance(barset, BarSet)
+
+    assert barset.dict() == {}
+
+    assert len(barset.df) == 0
+
+    assert reqmock.called_once
+
+
 def test_get_quotes(reqmock, stock_client: StockHistoricalDataClient):
     # Test single symbol request
 
@@ -335,6 +398,69 @@ def test_multisymbol_quotes(reqmock, stock_client: StockHistoricalDataClient):
     assert quoteset["AAPL"][0].bid_exchange == "Q"
 
     assert quoteset.df.index.nlevels == 2
+
+    assert reqmock.called_once
+
+
+def test_get_quotes_single_empty_response(reqmock, stock_client: StockHistoricalDataClient):
+    symbol = "AAPL"
+    start = datetime(2022, 3, 9)
+    limit = 2
+
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
+
+    reqmock.get(
+        f"https://data.alpaca.markets/v2/stocks/{symbol}/quotes?start={_start_in_url}&limit={limit}",
+        text="""
+    {
+        "next_page_token": null,
+        "quotes": null,
+        "symbol": "AAPL"
+    }
+        """,
+    )
+    request = StockQuotesRequest(symbol_or_symbols=symbol, start=start, limit=limit)
+
+    quoteset = stock_client.get_stock_quotes(request_params=request)
+
+    assert isinstance(quoteset, QuoteSet)
+
+    assert quoteset.dict() == {"AAPL": []}
+
+    assert len(quoteset.df) == 0
+
+    assert reqmock.called_once
+
+
+def test_get_quotes_multi_empty_response(reqmock, stock_client: StockHistoricalDataClient):
+    symbol = "AAPL"
+    start = datetime(2022, 3, 9)
+    limit = 2
+
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
+
+    reqmock.get(
+        f"https://data.alpaca.markets/v2/stocks/quotes?symbols={symbol}&start={_start_in_url}&limit={limit}",
+        text="""
+    {
+        "next_page_token": null,
+        "quotes": {}
+    }
+        """,
+    )
+    request = StockQuotesRequest(symbol_or_symbols=[symbol], start=start, limit=limit)
+
+    quoteset = stock_client.get_stock_quotes(request_params=request)
+
+    assert isinstance(quoteset, QuoteSet)
+
+    assert quoteset.dict() == {}
+
+    assert len(quoteset.df) == 0
 
     assert reqmock.called_once
 
@@ -467,6 +593,71 @@ def test_multisymbol_get_trades(reqmock, stock_client: StockHistoricalDataClient
 
     assert tradeset.df.index[0][1].day == 9
     assert tradeset.df.index.nlevels == 2
+
+    assert reqmock.called_once
+
+
+def test_get_trades_single_empty_response(reqmock, stock_client: StockHistoricalDataClient):
+    symbol = "AAPL"
+    start = datetime(2022, 3, 9)
+    limit = 2
+
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
+
+    reqmock.get(
+        f"https://data.alpaca.markets/v2/stocks/{symbol}/trades?start={_start_in_url}&limit={limit}",
+        text="""
+    {
+        "next_page_token": null,
+        "trades": null,
+        "symbol": "AAPL"
+    }
+        """,
+    )
+
+    request = StockTradesRequest(symbol_or_symbols=symbol, start=start, limit=limit)
+
+    tradeset = stock_client.get_stock_trades(request_params=request)
+
+    assert isinstance(tradeset, TradeSet)
+
+    assert tradeset.dict() == {"AAPL": []}
+
+    assert len(tradeset.df) == 0
+
+    assert reqmock.called_once
+
+
+def test_get_trades_multi_empty_response(reqmock, stock_client: StockHistoricalDataClient):
+    symbol = "AAPL"
+    start = datetime(2022, 3, 9)
+    limit = 2
+
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
+
+    reqmock.get(
+        f"https://data.alpaca.markets/v2/stocks/trades?symbols={symbol}&start={_start_in_url}&limit={limit}",
+        text="""
+    {
+        "next_page_token": null,
+        "trades": {}
+    }
+        """,
+    )
+
+    request = StockTradesRequest(symbol_or_symbols=[symbol], start=start, limit=limit)
+
+    tradeset = stock_client.get_stock_trades(request_params=request)
+
+    assert isinstance(tradeset, TradeSet)
+
+    assert tradeset.dict() == {}
+
+    assert len(tradeset.df) == 0
 
     assert reqmock.called_once
 

--- a/tests/data/test_historical_stock_data.py
+++ b/tests/data/test_historical_stock_data.py
@@ -779,15 +779,19 @@ def test_get_latest_trade_multi_not_found(
         f"https://data.alpaca.markets/v2/stocks/{symbol}/trades/latest?&feed=IEX",
         text="""
     {
-        "message":"no trade found for AAPL"
+        "next_page_token": null
+        "trade": null,
+        "symbol": "AAPL"
     }
         """,
-        status_code=404,
     )
     request = StockLatestTradeRequest(symbol_or_symbols=symbol, feed=DataFeed.IEX)
 
-    with pytest.raises(APIError):
-        stock_client.get_stock_latest_trade(request_params=request)
+    trade = stock_client.get_stock_latest_trade(request_params=request)
+
+    assert isinstance(trade, Dict)
+
+    assert trade == {}
 
     assert reqmock.called_once
 
@@ -870,16 +874,20 @@ def test_get_latest_quote_single_empty_response(
         f"https://data.alpaca.markets/v2/stocks/{symbol}/quotes/latest",
         text="""
     {
-        "message":"no quote found for AAPL"
+        "next_page_token": null,
+        "quote": null,
+        "symbol": "AAPL"
     }
         """,
-        status_code=404,
     )
 
     request = StockLatestQuoteRequest(symbol_or_symbols=symbol)
 
-    with pytest.raises(APIError):
-        stock_client.get_stock_latest_quote(request)
+    quote = stock_client.get_stock_latest_quote(request)
+
+    assert isinstance(quote, Dict)
+
+    assert quote == {}
 
     assert reqmock.called_once
 
@@ -1004,16 +1012,32 @@ def test_get_snapshot_single_empty_response(
         f"https://data.alpaca.markets/v2/stocks/{symbol}/snapshot",
         text="""
     {
-        "message":"no snapshot found for OTOC"
+        "symbol": "AAPL",
+        "latestTrade": null,
+        "latestQuote": null,
+        "minuteBar": null,
+        "dailyBar": null,
+        "prevDailyBar": null
     }
         """,
-        status_code=404,
     )
 
     request = StockSnapshotRequest(symbol_or_symbols=symbol)
 
-    with pytest.raises(APIError):
-        stock_client.get_stock_snapshot(request)
+    snapshot = stock_client.get_stock_snapshot(request)
+
+    assert isinstance(snapshot, Dict)
+
+    assert "AAPL" in snapshot
+
+    assert snapshot["AAPL"].model_dump() == {
+            "daily_bar": None,
+            "latest_quote": None,
+            "latest_trade": None,
+            "minute_bar": None,
+            "previous_daily_bar": None,
+            "symbol": "AAPL",
+        }
 
     assert reqmock.called_once
 
@@ -1133,16 +1157,19 @@ def test_stock_latest_bar_single_empty_response(
         f"https://data.alpaca.markets/v2/stocks/{symbol}/bars/latest",
         text="""
         {
-            "message":"no bar found for OTOC"
+            "symbol": "SPY",
+            "bar": null
         }
     """,
-        status_code=404,
     )
 
     request = StockLatestBarRequest(symbol_or_symbols=symbol)
 
-    with pytest.raises(APIError):
-        stock_client.get_stock_latest_bar(request)
+    bar = stock_client.get_stock_latest_bar(request)
+
+    assert isinstance(bar, Dict)
+
+    assert bar == {}
 
     assert reqmock.called_once
 

--- a/tests/data/test_historical_stock_data.py
+++ b/tests/data/test_historical_stock_data.py
@@ -10,10 +10,15 @@ from alpaca.data import Bar, Quote, Snapshot, Trade
 from alpaca.data.enums import DataFeed, Exchange
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.models import BarSet, QuoteSet, TradeSet
-from alpaca.data.requests import (StockBarsRequest, StockLatestBarRequest,
-                                  StockLatestQuoteRequest,
-                                  StockLatestTradeRequest, StockQuotesRequest,
-                                  StockSnapshotRequest, StockTradesRequest)
+from alpaca.data.requests import (
+    StockBarsRequest,
+    StockLatestBarRequest,
+    StockLatestQuoteRequest,
+    StockLatestTradeRequest,
+    StockQuotesRequest,
+    StockSnapshotRequest,
+    StockTradesRequest,
+)
 from alpaca.data.timeframe import TimeFrame
 
 

--- a/tests/data/test_historical_stock_data.py
+++ b/tests/data/test_historical_stock_data.py
@@ -1031,13 +1031,13 @@ def test_get_snapshot_single_empty_response(
     assert "AAPL" in snapshot
 
     assert snapshot["AAPL"].model_dump() == {
-            "daily_bar": None,
-            "latest_quote": None,
-            "latest_trade": None,
-            "minute_bar": None,
-            "previous_daily_bar": None,
-            "symbol": "AAPL",
-        }
+        "daily_bar": None,
+        "latest_quote": None,
+        "latest_trade": None,
+        "minute_bar": None,
+        "previous_daily_bar": None,
+        "symbol": "AAPL",
+    }
 
     assert reqmock.called_once
 


### PR DESCRIPTION
fixes https://github.com/alpacahq/alpaca-py/issues/317

Context:
- we currently cannot handle empty response when querying trades/quotes/snapshot/etc...
- this PR fixes unintended errors when handling empty response.

Changes:
- returning empty object/dict instead of raising an error when API returns empty data