### PR TITLE
fix: Fix publish-pypi

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -19,8 +19,6 @@ jobs:
       # install poetry first for cache
       - name: setup poetry
         run: pipx install poetry
-      - name: setup poetry-dynamic-versioning
-        run: pipx install poetry-dynamic-versioning
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -37,3 +35,4 @@ jobs:
         uses: JRubics/poetry-publish@v1.16
         with:
           pypi_token: ${{ secrets.PYPI_API_TOKEN }}
+          plugins: "poetry-dynamic-versioning"

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -18,7 +18,9 @@ jobs:
       - uses: actions/checkout@v4
       # install poetry first for cache
       - name: setup poetry
-        run: pipx install poetry poetry-dynamic-versioning
+        run: pipx install poetry
+      - name: setup poetry-dynamic-versioning
+        run: pipx install poetry-dynamic-versioning
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ sphinx-toolbox = "^3.1.2"
 requires = ["poetry-core>=1.4.2", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 build-backend = "poetry_dynamic_versioning.backend"
 
+[tool.poetry-dynamic-versioning]
+enable=true
+
 [tool.poetry-dynamic-versioning.substitution]
 folders = [
   { path = "alpaca" }


### PR DESCRIPTION
Context:
- introduced poetry-dynamic-versioning in https://github.com/alpacahq/alpaca-py/pull/390
- however, it causes an error when installing the poetry-dynamic-versioning package as pipx does not support installing multiple packages

```
  pipx install poetry poetry-dynamic-versioning
  shell: /usr/bin/bash -e {0}
usage: pipx [-h] [--version]
            {install,uninject,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall,reinstall-all,list,run,runpip,ensurepath,environment,completions}
            ...
pipx: error: unrecognized arguments: poetry-dynamic-versioning
Error: Process completed with exit code 2.
```

Changes:
- separate installing poetry-dynamic-versioning for poetry-publish