### PR TITLE
feat: Adjust account configuration

### DIFF
--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -323,5 +323,3 @@ class TradeConfirmationEmail(str, Enum):
 
     ALL = "all"
     NONE = "none"
-    # please do not use this value, to support legacy code
-    ENABLED = "enabled"  # should not be used

--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -317,9 +317,11 @@ class TradeConfirmationEmail(str, Enum):
     """
     Used for controlling when an Account will receive a trade confirmation email.
 
-    please see https://alpaca.markets/docs/api-references/broker-api/trading/trading-configurations/#attributes
+    please see https://docs.alpaca.markets/reference/getaccountconfig
     for more info.
     """
 
     ALL = "all"
     NONE = "none"
+    # please do not use this value, to support legacy code
+    ENABLED = "enabled"  # should not be used

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -538,6 +538,7 @@ class AccountConfiguration(BaseModel):
         suspend_trade (bool): If true Account becomes unable to submit new orders
         trade_confirm_email (TradeConfirmationEmail): Controls whether Trade confirmation emails are sent.
         ptp_no_exception_entry (bool): If set to true then Alpaca will accept orders for PTP symbols with no exception. Default is false.
+        max_option_trading_level (Optional[str]): The desired maximum option trading level. 0=disabled, 1=Covered Call/Cash-Secured Put, 2=Long Call/Put.
     """
 
     dtbp_check: DTBPCheck
@@ -548,6 +549,7 @@ class AccountConfiguration(BaseModel):
     suspend_trade: bool
     trade_confirm_email: TradeConfirmationEmail
     ptp_no_exception_entry: bool
+    max_option_trading_level: Optional[str] = None
 
 
 class CorporateActionAnnouncement(ModelWithID):

--- a/tests/trading/trading_client/test_account_routes.py
+++ b/tests/trading/trading_client/test_account_routes.py
@@ -60,7 +60,8 @@ def test_get_account_configurations(reqmock: Mocker, trading_client: TradingClie
           "max_margin_multiplier": "4",
           "pdt_check": "entry",
           "trade_confirm_email": "all",
-          "ptp_no_exception_entry": false
+          "ptp_no_exception_entry": false,
+          "max_option_trading_level": "1"
         }
       """,
     )
@@ -68,6 +69,7 @@ def test_get_account_configurations(reqmock: Mocker, trading_client: TradingClie
     account_configurations = trading_client.get_account_configurations()
     assert reqmock.called_once
     assert isinstance(account_configurations, AccountConfiguration)
+    assert account_configurations.max_option_trading_level == "1"
 
 
 def test_set_account_configurations(reqmock: Mocker, trading_client: TradingClient):


### PR DESCRIPTION
Context:
- max_option_trading_level field is added into response of account configuration

Chages:
- add max_option_trading_level field into account configuration model