### PR TITLE
fix: Handle limit parameter

### DIFF
--- a/alpaca/data/historical/crypto.py
+++ b/alpaca/data/historical/crypto.py
@@ -367,7 +367,7 @@ class CryptoHistoricalDataClient(RESTClient):
 
             # if we've sent a request with a limit, increment count
             if actual_limit:
-                total_items += actual_limit
+                total_items = sum([len(items) for items in data_by_symbol])
 
             page_token = response.get("next_page_token", None)
 

--- a/alpaca/data/historical/crypto.py
+++ b/alpaca/data/historical/crypto.py
@@ -367,7 +367,7 @@ class CryptoHistoricalDataClient(RESTClient):
 
             # if we've sent a request with a limit, increment count
             if actual_limit:
-                total_items = sum([len(items) for items in data_by_symbol])
+                total_items = sum([len(items) for items in data_by_symbol.values()])
 
             page_token = response.get("next_page_token", None)
 

--- a/alpaca/data/historical/option.py
+++ b/alpaca/data/historical/option.py
@@ -268,7 +268,7 @@ class OptionHistoricalDataClient(RESTClient):
 
             # if we've sent a request with a limit, increment count
             if actual_limit:
-                total_items += actual_limit
+                total_items = sum([len(items) for items in data_by_symbol])
 
             page_token = response.get("next_page_token", None)
 

--- a/alpaca/data/historical/option.py
+++ b/alpaca/data/historical/option.py
@@ -268,7 +268,7 @@ class OptionHistoricalDataClient(RESTClient):
 
             # if we've sent a request with a limit, increment count
             if actual_limit:
-                total_items = sum([len(items) for items in data_by_symbol])
+                total_items = sum([len(items) for items in data_by_symbol.values()])
 
             page_token = response.get("next_page_token", None)
 

--- a/alpaca/data/historical/stock.py
+++ b/alpaca/data/historical/stock.py
@@ -347,7 +347,7 @@ class StockHistoricalDataClient(RESTClient):
 
             # if we've sent a request with a limit, increment count
             if actual_limit:
-                total_items += actual_limit
+                total_items = sum([len(items) for items in data_by_symbol])
 
             page_token = response.get("next_page_token", None)
 

--- a/alpaca/data/historical/stock.py
+++ b/alpaca/data/historical/stock.py
@@ -347,7 +347,7 @@ class StockHistoricalDataClient(RESTClient):
 
             # if we've sent a request with a limit, increment count
             if actual_limit:
-                total_items = sum([len(items) for items in data_by_symbol])
+                total_items = sum([len(items) for items in data_by_symbol.values()])
 
             page_token = response.get("next_page_token", None)
 


### PR DESCRIPTION
Context:
- There is an issue of handling limit parameter due to recent change of marketdata api behaviour
- The API may return less than limit, even if there are more available data points in the requested interval

Changes:
- count total_items using actual number of response items