### PR TITLE
feat: Support options market data api (historical bars/trades and exchange codes)

### DIFF
--- a/alpaca/data/models/bars.py
+++ b/alpaca/data/models/bars.py
@@ -1,12 +1,12 @@
 from datetime import datetime
-from typing import Optional, Dict, List
+from typing import Dict, List, Optional
 
 from pydantic import ConfigDict
 
-from alpaca.common.types import RawData
 from alpaca.common.models import ValidateBaseModel as BaseModel
-from alpaca.data.models.base import TimeSeriesMixin, BaseDataSet
+from alpaca.common.types import RawData
 from alpaca.data.mappings import BAR_MAPPING
+from alpaca.data.models.base import BaseDataSet, TimeSeriesMixin
 
 
 class Bar(BaseModel):
@@ -61,6 +61,8 @@ class BarSet(BaseDataSet, TimeSeriesMixin):
     Attributes:
         data (Dict[str, List[Bar]]): The collection of Bars keyed by symbol.
     """
+
+    data: Dict[str, List[Bar]] = {}
 
     def __init__(
         self,

--- a/alpaca/data/models/quotes.py
+++ b/alpaca/data/models/quotes.py
@@ -1,13 +1,13 @@
 from datetime import datetime
-from typing import Optional, Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from pydantic import ConfigDict
 
-from alpaca.common.types import RawData
 from alpaca.common.models import ValidateBaseModel as BaseModel
+from alpaca.common.types import RawData
 from alpaca.data.enums import Exchange
 from alpaca.data.mappings import QUOTE_MAPPING
-from alpaca.data.models.base import TimeSeriesMixin, BaseDataSet
+from alpaca.data.models.base import BaseDataSet, TimeSeriesMixin
 
 
 class Quote(BaseModel):
@@ -62,6 +62,8 @@ class QuoteSet(BaseDataSet, TimeSeriesMixin):
     Attributes:
         data (Dict[str, List[Quote]]): The collection of Quotes keyed by symbol.
     """
+
+    data: Dict[str, List[Quote]] = {}
 
     def __init__(self, raw_data: RawData) -> None:
         """Instantiates a QuoteSet.

--- a/alpaca/data/models/trades.py
+++ b/alpaca/data/models/trades.py
@@ -1,13 +1,13 @@
 from datetime import datetime
-from typing import Optional, Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from pydantic import ConfigDict
 
-from alpaca.common.types import RawData
 from alpaca.common.models import ValidateBaseModel as BaseModel
+from alpaca.common.types import RawData
 from alpaca.data.enums import Exchange
 from alpaca.data.mappings import TRADE_MAPPING
-from alpaca.data.models.base import TimeSeriesMixin, BaseDataSet
+from alpaca.data.models.base import BaseDataSet, TimeSeriesMixin
 
 
 class Trade(BaseModel):
@@ -58,6 +58,8 @@ class TradeSet(BaseDataSet, TimeSeriesMixin):
     Attributes:
         data (Dict[str, List[Trade]]]): The collection of Trades keyed by symbol.
     """
+
+    data: Dict[str, List[Trade]] = {}
 
     def __init__(self, raw_data: RawData) -> None:
         """Instantiates a TradeSet - a collection of Trades.

--- a/alpaca/data/requests.py
+++ b/alpaca/data/requests.py
@@ -91,6 +91,7 @@ class StockBarsRequest(BaseBarsRequest):
 
     Attributes:
         symbol_or_symbols (Union[str, List[str]]): The ticker identifier or list of ticker identifiers.
+        timeframe (TimeFrame): The period over which the bars should be aggregated. (i.e. 5 Min bars, 1 Day bars)
         start (Optional[datetime]): The beginning of the time interval for desired data. Timezone naive inputs assumed to be in UTC.
         end (Optional[datetime]): The end of the time interval for desired data. Defaults to now. Timezone naive inputs assumed to be in UTC.
         limit (Optional[int]): Upper limit of number of data points to return. Defaults to None.
@@ -111,6 +112,7 @@ class CryptoBarsRequest(BaseBarsRequest):
 
     Attributes:
         symbol_or_symbols (Union[str, List[str]]): The ticker identifier or list of ticker identifiers.
+        timeframe (TimeFrame): The period over which the bars should be aggregated. (i.e. 5 Min bars, 1 Day bars)
         start (Optional[datetime]): The beginning of the time interval for desired data. Timezone naive inputs assumed to be in UTC.
         end (Optional[datetime]): The end of the time interval for desired data. Defaults to now. Timezone naive inputs assumed to be in UTC.
         limit (Optional[int]): Upper limit of number of data points to return. Defaults to None.
@@ -118,6 +120,22 @@ class CryptoBarsRequest(BaseBarsRequest):
     """
 
     pass
+
+
+class OptionBarsRequest(BaseBarsRequest):
+    """
+    The request model for retrieving bar data for option contracts.
+
+    See BaseBarsRequest for more information on available parameters.
+
+    Attributes:
+        symbol_or_symbols (Union[str, List[str]]): The ticker identifier or list of ticker identifiers.
+        timeframe (TimeFrame): The period over which the bars should be aggregated. (i.e. 5 Min bars, 1 Day bars)
+        start (Optional[datetime]): The beginning of the time interval for desired data. Timezone naive inputs assumed to be in UTC.
+        end (Optional[datetime]): The end of the time interval for desired data. Defaults to now. Timezone naive inputs assumed to be in UTC.
+        limit (Optional[int]): Upper limit of number of data points to return. Defaults to None.
+        sort (Optional[Sort]): The chronological order of response based on the timestamp. Defaults to ASC.
+    """
 
 
 # ############################## Quotes ################################# #
@@ -170,6 +188,23 @@ class CryptoTradesRequest(BaseTimeseriesDataRequest):
 
     Attributes:
         symbol_or_symbols (Union[str, List[str]]): The ticker identifier or list of ticker identifiers.
+        start (Optional[datetime]): The beginning of the time interval for desired data. Timezone naive inputs assumed to be in UTC.
+        end (Optional[datetime]): The end of the time interval for desired data. Defaults to now. Timezone naive inputs assumed to be in UTC.
+        limit (Optional[int]): Upper limit of number of data points to return. Defaults to None.
+        sort (Optional[Sort]): The chronological order of response based on the timestamp. Defaults to ASC.
+    """
+
+    pass
+
+
+class OptionTradesRequest(BaseTimeseriesDataRequest):
+    """
+    This request class is used to submit a request for option trade data.
+
+    See BaseTimeseriesDataRequest for more information on available parameters.
+
+    Attributes:
+        symbol_or_symbols (Union[str, List[str]]): The option identifier or list of option identifiers.
         start (Optional[datetime]): The beginning of the time interval for desired data. Timezone naive inputs assumed to be in UTC.
         end (Optional[datetime]): The end of the time interval for desired data. Defaults to now. Timezone naive inputs assumed to be in UTC.
         limit (Optional[int]): Upper limit of number of data points to return. Defaults to None.

--- a/docs/api_reference/data/common.rst
+++ b/docs/api_reference/data/common.rst
@@ -1,0 +1,9 @@
+Common
+======
+
+This module represents a bunch of classes that have common/shared functionality across the stock/crypto/options
+
+.. toctree::
+   :maxdepth: 2
+
+   common/requests

--- a/docs/api_reference/data/common/requests.rst
+++ b/docs/api_reference/data/common/requests.rst
@@ -1,0 +1,15 @@
+========
+Requests
+========
+
+
+BaseTimeseriesDataRequest
+-------------------------
+
+.. autoclass:: alpaca.data.requests.BaseTimeseriesDataRequest
+
+
+BaseBarsRequest
+---------------
+
+.. autoclass:: alpaca.data.requests.BaseBarsRequest

--- a/docs/api_reference/data/crypto/requests.rst
+++ b/docs/api_reference/data/crypto/requests.rst
@@ -3,6 +3,12 @@ Requests
 ========
 
 
+BaseCryptoLatestDataRequest
+---------------------------
+
+.. autoclass:: alpaca.data.requests.BaseCryptoLatestDataRequest
+
+
 CryptoBarsRequest
 -----------------
 

--- a/docs/api_reference/data/option/historical.rst
+++ b/docs/api_reference/data/option/historical.rst
@@ -9,6 +9,24 @@ OptionHistoricalDataClient
    :members: __init__
 
 
+Get Option Bars
+---------------
+
+.. automethod:: alpaca.data.historical.option.OptionHistoricalDataClient.get_option_bars
+
+
+Get Option Trades
+-----------------
+
+.. automethod:: alpaca.data.historical.option.OptionHistoricalDataClient.get_option_trades
+
+
+Get Option Exchange Codes
+-------------------------
+
+.. automethod:: alpaca.data.historical.option.OptionHistoricalDataClient.get_option_exchange_codes
+
+
 Get Option Latest Quote
 -----------------------
 

--- a/docs/api_reference/data/option/requests.rst
+++ b/docs/api_reference/data/option/requests.rst
@@ -3,6 +3,24 @@ Requests
 ========
 
 
+BaseOptionLatestDataRequest
+---------------------------
+
+.. autoclass:: alpaca.data.requests.BaseOptionLatestDataRequest
+
+
+OptionBarsRequest
+-----------------
+
+.. autoclass:: alpaca.data.requests.OptionBarsRequest
+
+
+OptionTradesRequest
+-------------------
+
+.. autoclass:: alpaca.data.requests.OptionTradesRequest
+
+
 OptionLatestQuoteRequest
 ------------------------
 

--- a/docs/api_reference/data/stock/requests.rst
+++ b/docs/api_reference/data/stock/requests.rst
@@ -3,6 +3,12 @@ Requests
 ========
 
 
+BaseStockLatestDataRequest
+--------------------------
+
+.. autoclass:: alpaca.data.requests.BaseStockLatestDataRequest
+
+
 StockBarsRequest
 ----------------
 

--- a/docs/api_reference/data_api.rst
+++ b/docs/api_reference/data_api.rst
@@ -5,6 +5,7 @@ Market Data Reference
 .. toctree::
    :maxdepth: 2
 
+   data/common
    data/stock
    data/crypto
    data/option

--- a/examples/options-trading-basic.ipynb
+++ b/examples/options-trading-basic.ipynb
@@ -81,6 +81,7 @@
     "from alpaca.data.live.option import *\n",
     "from alpaca.data.historical.option import *\n",
     "from alpaca.data.requests import *\n",
+    "from alpaca.data.timeframe import *\n",
     "from alpaca.trading.client import *\n",
     "from alpaca.trading.stream import *\n",
     "from alpaca.trading.requests import *\n",
@@ -291,7 +292,7 @@
     "open_interest = 0\n",
     "high_open_interest_contract = None\n",
     "for contract in res.option_contracts:\n",
-    "    if int(contract.open_interest) > open_interest:\n",
+    "    if (contract.open_interest is not None) and (int(contract.open_interest) > open_interest):\n",
     "        open_interest = int(contract.open_interest)\n",
     "        high_open_interest_contract = contract\n",
     "high_open_interest_contract"
@@ -441,6 +442,49 @@
    "source": [
     "# setup option historical data client\n",
     "option_historical_data_client = OptionHistoricalDataClient(api_key, secret_key, url_override=DATA_API_URL)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get options historical bars by symbol\n",
+    "req = OptionBarsRequest(\n",
+    "    symbol_or_symbols=high_open_interest_contract.symbol,\n",
+    "    timeframe=TimeFrame(amount=1, unit=TimeFrameUnit.Hour), # specify timeframe\n",
+    "    start=now - timedelta(days=5),                          # specify start datetime, default=the beginning of the current day.\n",
+    "    # end_date=None,                                        # specify end datetime, default=now\n",
+    "    limit=2,                                               # specify limit\n",
+    ")\n",
+    "option_historical_data_client.get_option_bars(req)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get options historical trades by symbol\n",
+    "req = OptionTradesRequest(\n",
+    "    symbol_or_symbols=high_open_interest_contract.symbol,\n",
+    "    start=now - timedelta(days=5),                          # specify start datetime, default=the beginning of the current day.\n",
+    "    # end=None,                                             # specify end datetime, default=now\n",
+    "    limit=2,                                                # specify limit\n",
+    ")\n",
+    "option_historical_data_client.get_option_trades(req)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get options exchange codes\n",
+    "option_historical_data_client.get_option_exchange_codes()"
    ]
   },
   {

--- a/examples/options-trading-basic.ipynb
+++ b/examples/options-trading-basic.ipynb
@@ -458,7 +458,7 @@
     "    # end_date=None,                                        # specify end datetime, default=now\n",
     "    limit=2,                                               # specify limit\n",
     ")\n",
-    "option_historical_data_client.get_option_bars(req)"
+    "option_historical_data_client.get_option_bars(req).df"
    ]
   },
   {
@@ -474,7 +474,7 @@
     "    # end=None,                                             # specify end datetime, default=now\n",
     "    limit=2,                                                # specify limit\n",
     ")\n",
-    "option_historical_data_client.get_option_trades(req)"
+    "option_historical_data_client.get_option_trades(req).df"
    ]
   },
   {


### PR DESCRIPTION
Context:
- support newly added options market data endpoints
    - [Historical bars](https://docs.alpaca.markets/reference/optionbars)
    - [Exchange codes](https://docs.alpaca.markets/reference/optionmetaexchanges)
    - [Historical trades](https://docs.alpaca.markets/reference/optiontrades)

Changes:
- added `get_option_bars()`
- added `get_option_exchange_codes()`
- added `get_option_trades()`
- updated docs for options market data