### PR TITLE
fix: use int for max_options_trading_level of AccountConfiguration

### DIFF
--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -482,7 +482,7 @@ class TradingClient(RESTClient):
         if self._use_raw_data:
             return response
 
-        return AccountConfiguration(**json.loads(response))
+        return AccountConfiguration(**response)
 
     # ############################## WATCHLIST ################################# #
 

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -548,7 +548,7 @@ class AccountConfiguration(BaseModel):
         suspend_trade (bool): If true Account becomes unable to submit new orders
         trade_confirm_email (TradeConfirmationEmail): Controls whether Trade confirmation emails are sent.
         ptp_no_exception_entry (bool): If set to true then Alpaca will accept orders for PTP symbols with no exception. Default is false.
-        max_options_trading_level (Optional[str]): The desired maximum options trading level. 0=disabled, 1=Covered Call/Cash-Secured Put, 2=Long Call/Put.
+        max_options_trading_level (Optional[int]): The desired maximum options trading level. 0=disabled, 1=Covered Call/Cash-Secured Put, 2=Long Call/Put.
     """
 
     dtbp_check: DTBPCheck
@@ -559,7 +559,7 @@ class AccountConfiguration(BaseModel):
     suspend_trade: bool
     trade_confirm_email: TradeConfirmationEmail
     ptp_no_exception_entry: bool
-    max_options_trading_level: Optional[str] = None
+    max_options_trading_level: Optional[int] = None
 
 
 class CorporateActionAnnouncement(ModelWithID):

--- a/tests/trading/trading_client/test_account_routes.py
+++ b/tests/trading/trading_client/test_account_routes.py
@@ -67,7 +67,7 @@ def test_get_account_configurations(reqmock: Mocker, trading_client: TradingClie
           "pdt_check": "entry",
           "trade_confirm_email": "all",
           "ptp_no_exception_entry": false,
-          "max_options_trading_level": "1"
+          "max_options_trading_level": 1
         }
       """,
     )
@@ -75,7 +75,7 @@ def test_get_account_configurations(reqmock: Mocker, trading_client: TradingClie
     account_configurations = trading_client.get_account_configurations()
     assert reqmock.called_once
     assert isinstance(account_configurations, AccountConfiguration)
-    assert account_configurations.max_options_trading_level == "1"
+    assert account_configurations.max_options_trading_level == 1
 
 
 def test_set_account_configurations(reqmock: Mocker, trading_client: TradingClient):
@@ -89,11 +89,12 @@ def test_set_account_configurations(reqmock: Mocker, trading_client: TradingClie
             "pdt_check": "both",
             "trade_confirm_email": "all",
             "ptp_no_exception_entry": False,
+            "max_options_trading_level": 1,
         }
     )
     reqmock.patch(
         f"{BaseURL.TRADING_PAPER.value}/v2/account/configurations",
-        json=json.dumps(new_account_configurations.model_dump()),
+        json=new_account_configurations.model_dump(),
     )
 
     account_configurations = trading_client.set_account_configurations(


### PR DESCRIPTION
Context:
- max_options_trading_level should be int instead of str

Changes:
- fix max_options_trading_level to use int instead of str
- fix set_account_configurations;