### PR TITLE
fix: Change profit_loss_pct to List[Optional[float]] in PortfolioHistory model

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -288,7 +288,7 @@ class PortfolioHistory(BaseModel):
         timestamp (List[int]): Time of each data element, left-labeled (the beginning of time window).
         equity (List[float]): Equity value of the account in dollar amount as of the end of each time window.
         profit_loss (List[float]): Profit/loss in dollar from the base value.
-        profit_loss_pct (List[float]): Profit/loss in percentage from the base value.
+        profit_loss_pct (List[Optional[float]]): Profit/loss in percentage from the base value.
         base_value (float): Basis in dollar of the profit loss calculation.
         timeframe (str): Time window size of each data element.
     """
@@ -296,7 +296,7 @@ class PortfolioHistory(BaseModel):
     timestamp: List[int]
     equity: List[float]
     profit_loss: List[float]
-    profit_loss_pct: List[float]
+    profit_loss_pct: List[Optional[float]]
     base_value: float
     timeframe: str
 

--- a/tests/broker/broker_client/test_trading_routes.py
+++ b/tests/broker/broker_client/test_trading_routes.py
@@ -533,6 +533,30 @@ def test_get_portfolio_history(reqmock, client: BrokerClient):
     assert isinstance(portfolio_history, PortfolioHistory)
 
 
+def test_get_portfolio_history_with_null_pl_pct(reqmock, client: BrokerClient):
+    account_id = "2a87c088-ffb6-472b-a4a3-cd9305c8605c"
+
+    reqmock.get(
+        f"{BaseURL.BROKER_SANDBOX.value}/v1/trading/accounts/{account_id}/account/portfolio/history",
+        text="""
+        {
+          "timestamp": [1580826600000, 1580827500000, 1580828400000],
+          "equity": [27423.73, 27408.19, 27515.97],
+          "profit_loss": [11.8, -3.74, 104.04],
+          "profit_loss_pct": [null, null, null],
+          "base_value": 27411.93,
+          "timeframe": "15Min"
+        }
+        """,
+    )
+
+    portfolio_history = client.get_portfolio_history_for_account(account_id)
+
+    assert reqmock.called_once
+    assert reqmock.request_history[0].qs == {}
+    assert isinstance(portfolio_history, PortfolioHistory)
+
+
 def test_get_portfolio_history_with_filter(reqmock, client: BrokerClient):
     account_id = "2a87c088-ffb6-472b-a4a3-cd9305c8605c"
 


### PR DESCRIPTION
Context:
- profit_loss_pct could be null values of array in API response of [Get Account Portfolio History](https://docs.alpaca.markets/reference/get-v1-trading-accounts-account_id-account-portfolio-history-1)
- current model raises validation error when receiving null values
- this PR fix the model definition

Changes:
- change profit_loss_pct to List[Optional[float]] in PortfolioHistory model 