### PR TITLE
Added message property to APIError

### DIFF
--- a/alpaca/common/exceptions.py
+++ b/alpaca/common/exceptions.py
@@ -20,7 +20,7 @@ class APIError(Exception):
     @property
     def message(self):
         error = json.loads(self._error)
-        return error['message']
+        return error["message"]
 
     @property
     def status_code(self):

--- a/alpaca/common/exceptions.py
+++ b/alpaca/common/exceptions.py
@@ -18,6 +18,11 @@ class APIError(Exception):
         return error["code"]
 
     @property
+    def message(self):
+        error = json.loads(self._error)
+        return error['message']
+
+    @property
     def status_code(self):
         http_error = self._http_error
         if http_error is not None and hasattr(http_error, "response"):


### PR DESCRIPTION
Given that the APIError object returns both a code and message, both should be readily accessible to the end user. The end user can already access this by accessing the protected variable _error, but that isn't best practice.

This would address #431 