### PR TITLE
fix: Add validation to ReplaceOrderRequest

### DIFF
--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -1,26 +1,26 @@
 from datetime import date, datetime, timedelta
-from typing import Optional, Any, List, Union
+from typing import Any, List, Optional, Union
 
 import pandas as pd
 from pydantic import model_validator
-from alpaca.common.models import ModelWithID
 
-from alpaca.common.requests import NonEmptyRequest
 from alpaca.common.enums import Sort
+from alpaca.common.models import ModelWithID
+from alpaca.common.requests import NonEmptyRequest
 from alpaca.trading.enums import (
-    ContractType,
-    ExerciseStyle,
-    OrderType,
-    AssetStatus,
     AssetClass,
     AssetExchange,
-    TimeInForce,
-    OrderSide,
-    OrderClass,
-    CorporateActionType,
+    AssetStatus,
+    ContractType,
     CorporateActionDateType,
-    QueryOrderStatus,
+    CorporateActionType,
+    ExerciseStyle,
+    OrderClass,
+    OrderSide,
+    OrderType,
     PositionIntent,
+    QueryOrderStatus,
+    TimeInForce,
 )
 
 

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -209,6 +209,24 @@ class ReplaceOrderRequest(NonEmptyRequest):
     trail: Optional[float] = None
     client_order_id: Optional[str] = None
 
+    @model_validator(mode="before")
+    def root_validator(cls, values: dict) -> dict:
+        qty = values.get("qty", None)
+        limit_price = values.get("limit_price", None)
+        stop_price = values.get("stop_price", None)
+        trail = values.get("trail", None)
+
+        if (qty is not None) and (qty <= 0):
+            raise ValueError("qty must be greater than 0")
+        if (limit_price is not None) and (limit_price <= 0):
+            raise ValueError("limit_price must be greater than 0")
+        if (stop_price is not None) and (stop_price <= 0):
+            raise ValueError("stop_price must be greater than 0")
+        if (trail is not None) and (trail <= 0):
+            raise ValueError("trail must be greater than 0")
+
+        return values
+
 
 class CancelOrderResponse(ModelWithID):
     """

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -270,6 +270,33 @@ def test_replace_order(reqmock, trading_client: TradingClient):
 
     assert type(order) is Order
 
+def test_replace_order_validate_replace_request(reqmock, trading_client: TradingClient):
+    # qty
+    ReplaceOrderRequest(qty=1)
+    with pytest.raises(ValueError):
+        ReplaceOrderRequest(qty=0)
+        ReplaceOrderRequest(qty=0, limit_price=0.1)
+        ReplaceOrderRequest(qty=0, stop_price=0.1)
+        ReplaceOrderRequest(qty=0, trail=0.1)
+
+    # limit_price
+    ReplaceOrderRequest(limit_price=0.1)
+    ReplaceOrderRequest(qty=1, limit_price=0.1)
+    with pytest.raises(ValueError):
+        ReplaceOrderRequest(limit_price=0)
+
+    # stop_price
+    ReplaceOrderRequest(stop_price=0.1)
+    ReplaceOrderRequest(qty=1, stop_price=0.1)
+    with pytest.raises(ValueError):
+        ReplaceOrderRequest(stop_price=0)
+
+    # trail
+    ReplaceOrderRequest(trail=0.1)
+    ReplaceOrderRequest(qty=1, trail=0.1)
+    with pytest.raises(ValueError):
+        ReplaceOrderRequest(trail=0)
+
 
 def test_cancel_order_by_id(reqmock, trading_client: TradingClient):
     order_id = "61e69015-8549-4bfd-b9c3-01e75843f47d"

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -1,18 +1,18 @@
+import pytest
+
+from alpaca.common.enums import BaseURL
 from alpaca.common.exceptions import APIError
+from alpaca.trading.client import TradingClient
+from alpaca.trading.enums import OrderSide, OrderStatus, PositionIntent, TimeInForce
+from alpaca.trading.models import Order
 from alpaca.trading.requests import (
+    CancelOrderResponse,
     GetOrderByIdRequest,
     GetOrdersRequest,
-    ReplaceOrderRequest,
-    CancelOrderResponse,
-    MarketOrderRequest,
     LimitOrderRequest,
+    MarketOrderRequest,
+    ReplaceOrderRequest,
 )
-from alpaca.trading.models import Order
-from alpaca.trading.client import TradingClient
-from alpaca.trading.enums import OrderSide, OrderStatus, TimeInForce, PositionIntent
-from alpaca.common.enums import BaseURL
-
-import pytest
 
 
 def test_market_order(reqmock, trading_client):
@@ -269,6 +269,7 @@ def test_replace_order(reqmock, trading_client: TradingClient):
     order = trading_client.replace_order_by_id(order_id, replace_order_request)
 
     assert type(order) is Order
+
 
 def test_replace_order_validate_replace_request(reqmock, trading_client: TradingClient):
     # qty

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -271,7 +271,7 @@ def test_replace_order(reqmock, trading_client: TradingClient):
     assert type(order) is Order
 
 
-def test_replace_order_validate_replace_request(reqmock, trading_client: TradingClient):
+def test_replace_order_validate_replace_request() -> None:
     # qty
     ReplaceOrderRequest(qty=1)
     with pytest.raises(ValueError):


### PR DESCRIPTION
Context:
- ReplaceOrderRequest ignores qty/limit_price/stop_price/trail if value is zero
- this may cause confusion
- this PR will add validation to ReplaceOrderRequest to let users know that those values should be greater than zero

Change:
- add validation to ReplaceOrderRequest
- apply `poetry run isort --profile black <file>`