### PR TITLE
fix: Add correct JournalStatus

### DIFF
--- a/alpaca/broker/enums.py
+++ b/alpaca/broker/enums.py
@@ -424,4 +424,5 @@ class JournalStatus(str, Enum):
     REJECTED = "rejected"
     CANCELED = "canceled"
     REFUSED = "refused"
+    CORRECT = "correct"
     DELETED = "deleted"


### PR DESCRIPTION
Context:
- we missed one JournalStatus `correct` in our enum
- this PR will fix the issue
- fixes https://github.com/alpacahq/alpaca-py/issues/447
- ref. https://docs.alpaca.markets/docs/funding-via-journals#journals-status

Changes:
- add correct into JournalStatus