### PR TITLE
fix: Fix update_trade_configuration_for_account()

### DIFF
--- a/alpaca/broker/client.py
+++ b/alpaca/broker/client.py
@@ -1,87 +1,83 @@
 import base64
-from typing import Callable, Iterator, List, Optional, Union, Dict
+from typing import Callable, Dict, Iterator, List, Optional, Union
 from uuid import UUID
 
 import sseclient
-
 from pydantic import TypeAdapter
 from requests import HTTPError, Response
 
-from .enums import ACHRelationshipStatus
 from alpaca.broker.models import (
-    ACHRelationship,
     Account,
+    ACHRelationship,
     Bank,
+    BatchJournalResponse,
     CIPInfo,
+    Journal,
+    Order,
     TradeAccount,
     TradeDocument,
     Transfer,
-    Order,
-    BatchJournalResponse,
-    Journal,
 )
-from .requests import (
-    CreateJournalRequest,
-    CreateBatchJournalRequest,
-    CreateReverseBatchJournalRequest,
-    GetJournalsRequest,
-    OrderRequest,
-    CancelOrderResponse,
-    UploadDocumentRequest,
-    CreateACHRelationshipRequest,
-    CreateACHTransferRequest,
-    CreateBankRequest,
-    CreateBankTransferRequest,
-    CreatePlaidRelationshipRequest,
-    GetAccountActivitiesRequest,
-    GetTradeDocumentsRequest,
-    GetTransfersRequest,
-    ListAccountsRequest,
-    CreateAccountRequest,
-    UpdateAccountRequest,
-    GetEventsRequest,
-)
-from alpaca.common.exceptions import APIError
 from alpaca.common.constants import (
     ACCOUNT_ACTIVITIES_DEFAULT_PAGE_SIZE,
     BROKER_DOCUMENT_UPLOAD_LIMIT,
 )
 from alpaca.common.enums import BaseURL, PaginationType
+from alpaca.common.exceptions import APIError
+from alpaca.common.utils import validate_symbol_or_asset_id, validate_uuid_id_param
+from alpaca.trading.enums import ActivityType
+from alpaca.trading.models import AccountConfiguration as TradeAccountConfiguration
 from alpaca.trading.models import (
-    PortfolioHistory,
-    Position,
     AllAccountsPositions,
-    ClosePositionResponse,
     Asset,
-    Watchlist,
+    BaseActivity,
     Calendar,
     Clock,
+    ClosePositionResponse,
     CorporateActionAnnouncement,
-    AccountConfiguration as TradeAccountConfiguration,
-)
-from alpaca.trading.models import (
-    BaseActivity,
     NonTradeActivity,
+    PortfolioHistory,
+    Position,
     TradeActivity,
+    Watchlist,
 )
 from alpaca.trading.requests import (
-    GetPortfolioHistoryRequest,
     ClosePositionRequest,
-    GetCalendarRequest,
-    UpdateWatchlistRequest,
     CreateWatchlistRequest,
-    ReplaceOrderRequest,
     GetAssetsRequest,
-    GetOrdersRequest,
-    GetOrderByIdRequest,
+    GetCalendarRequest,
     GetCorporateAnnouncementsRequest,
+    GetOrderByIdRequest,
+    GetOrdersRequest,
+    GetPortfolioHistoryRequest,
+    ReplaceOrderRequest,
+    UpdateWatchlistRequest,
 )
-from alpaca.trading.enums import (
-    ActivityType,
-)
+
 from ..common import RawData
 from ..common.rest import HTTPResult, RESTClient
-from alpaca.common.utils import validate_uuid_id_param, validate_symbol_or_asset_id
+from .enums import ACHRelationshipStatus
+from .requests import (
+    CancelOrderResponse,
+    CreateAccountRequest,
+    CreateACHRelationshipRequest,
+    CreateACHTransferRequest,
+    CreateBankRequest,
+    CreateBankTransferRequest,
+    CreateBatchJournalRequest,
+    CreateJournalRequest,
+    CreatePlaidRelationshipRequest,
+    CreateReverseBatchJournalRequest,
+    GetAccountActivitiesRequest,
+    GetEventsRequest,
+    GetJournalsRequest,
+    GetTradeDocumentsRequest,
+    GetTransfersRequest,
+    ListAccountsRequest,
+    OrderRequest,
+    UpdateAccountRequest,
+    UploadDocumentRequest,
+)
 
 
 class BrokerClient(RESTClient):
@@ -376,7 +372,7 @@ class BrokerClient(RESTClient):
 
         result = self.patch(
             f"/trading/accounts/{account_id}/account/configurations",
-            config.model_dump_json(),
+            config.model_dump(),
         )
 
         if self._use_raw_data:

--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -220,7 +220,9 @@ class RESTClient(ABC):
         """
         return self._request("GET", path, data, **kwargs)
 
-    def post(self, path: str, data: Optional[Union[dict, List[dict]]] = None) -> HTTPResult:
+    def post(
+        self, path: str, data: Optional[Union[dict, List[dict]]] = None
+    ) -> HTTPResult:
         """Performs a single POST request
 
         Args:

--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -220,12 +220,12 @@ class RESTClient(ABC):
         """
         return self._request("GET", path, data, **kwargs)
 
-    def post(self, path: str, data: Union[dict, List[dict], str] = None) -> HTTPResult:
+    def post(self, path: str, data: Optional[Union[dict, List[dict]]] = None) -> HTTPResult:
         """Performs a single POST request
 
         Args:
             path (str): The API endpoint path
-            data (Union[dict, str], optional): The json payload if str, or a dict of values to be converted.
+            data (Optional[Union[dict, List[dict]]): The json payload as a dict of values to be converted.
              Defaults to None.
 
         Returns:
@@ -233,12 +233,12 @@ class RESTClient(ABC):
         """
         return self._request("POST", path, data)
 
-    def put(self, path: str, data: Union[dict, str] = None) -> dict:
+    def put(self, path: str, data: Optional[dict] = None) -> dict:
         """Performs a single PUT request
 
         Args:
             path (str): The API endpoint path
-            data (Union[dict, str], optional): The json payload if str, or a dict of values to be converted.
+            data (Optional[dict]): The json payload as a dict of values to be converted.
              Defaults to None.
 
         Returns:
@@ -246,12 +246,12 @@ class RESTClient(ABC):
         """
         return self._request("PUT", path, data)
 
-    def patch(self, path: str, data: Union[dict, str] = None) -> dict:
+    def patch(self, path: str, data: Optional[dict] = None) -> dict:
         """Performs a single PATCH request
 
         Args:
             path (str): The API endpoint path
-            data (Union[dict, str], optional): The json payload if str, or a dict of values to be converted.
+            data (Optional[dict]): The json payload as a dict of values to be converted.
              Defaults to None.
 
         Returns:

--- a/tests/broker/broker_client/test_accounts_routes.py
+++ b/tests/broker/broker_client/test_accounts_routes.py
@@ -824,8 +824,7 @@ def test_update_trade_configuration_for_account(reqmock, client: BrokerClient):
     account_id = "5fc0795e-1f16-40cc-aa90-ede67c39d7a9"
     config = factory.create_dummy_trade_account_configuration()
 
-    def match_request_text(request):
-        print(request.json())
+    def match_request_json(request):
         return request.json() == {
             "dtbp_check": "both",
             "fractional_trading": False,
@@ -840,7 +839,7 @@ def test_update_trade_configuration_for_account(reqmock, client: BrokerClient):
 
     reqmock.patch(
         f"{BaseURL.BROKER_SANDBOX.value}/v1/trading/accounts/{account_id}/account/configurations",
-        additional_matcher=match_request_text,
+        additional_matcher=match_request_json,
         text="""
         {
           "dtbp_check": "both",

--- a/tests/broker/broker_client/test_accounts_routes.py
+++ b/tests/broker/broker_client/test_accounts_routes.py
@@ -6,29 +6,22 @@ from uuid import UUID
 
 import pytest
 
-from alpaca.trading.models import AccountConfiguration as TradeAccountConfiguration
-from alpaca.trading.enums import DTBPCheck, PDTCheck
 from alpaca.broker.client import BrokerClient
-from alpaca.broker.enums import (
-    AccountEntities,
-)
-from alpaca.broker.models import (
-    Account,
-    Contact,
-    Identity,
-    TradeAccount,
-)
+from alpaca.broker.enums import AccountEntities
+from alpaca.broker.models import Account, Contact, Identity, TradeAccount
 from alpaca.broker.requests import (
+    CreateAccountRequest,
+    ListAccountsRequest,
     UpdatableContact,
     UpdatableDisclosures,
     UpdatableIdentity,
     UpdatableTrustedContact,
-    ListAccountsRequest,
-    CreateAccountRequest,
     UpdateAccountRequest,
 )
-from alpaca.common.exceptions import APIError
 from alpaca.common.enums import BaseURL, SupportedCurrencies
+from alpaca.common.exceptions import APIError
+from alpaca.trading.enums import DTBPCheck, PDTCheck
+from alpaca.trading.models import AccountConfiguration as TradeAccountConfiguration
 from tests.broker.factories import accounts as factory
 
 
@@ -831,8 +824,23 @@ def test_update_trade_configuration_for_account(reqmock, client: BrokerClient):
     account_id = "5fc0795e-1f16-40cc-aa90-ede67c39d7a9"
     config = factory.create_dummy_trade_account_configuration()
 
+    def match_request_text(request):
+        print(request.json())
+        return request.json() == {
+            "dtbp_check": "both",
+            "fractional_trading": False,
+            "max_margin_multiplier": "4",
+            "no_shorting": False,
+            "pdt_check": "entry",
+            "suspend_trade": False,
+            "trade_confirm_email": "all",
+            "ptp_no_exception_entry": False,
+            "max_options_trading_level": None,
+        }
+
     reqmock.patch(
         f"{BaseURL.BROKER_SANDBOX.value}/v1/trading/accounts/{account_id}/account/configurations",
+        additional_matcher=match_request_text,
         text="""
         {
           "dtbp_check": "both",


### PR DESCRIPTION
Context:
- we have got `request body format is invalid` error when updating trade configuration for an account
- We should pass dict to json parameter instead of json_str

Changes:
- use model_dump() instead of model_dump_json() to pass dict instead of json string