### PR TITLE
feat: Add transmitter info into BatchJournalRequestEntry

### DIFF
--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -892,6 +892,7 @@ class BatchJournalRequestEntry(NonEmptyRequest):
     Attributes:
         to_account (UUID): Account to fund in batch journal request.
         amount (Union[str, float]): The cash amount in USD to fund by.
+        description (Optional[str]): Journal description.
         transmitter_name (Optional[str]): For cash journals, travel rule related name info.
         transmitter_account_number (Optional[str]): For cash journals, travel rule account number info.
         transmitter_address (Optional[str]): For cash journals, travel rule related address info.
@@ -901,6 +902,7 @@ class BatchJournalRequestEntry(NonEmptyRequest):
 
     to_account: UUID
     amount: Union[str, float]
+    description: Optional[str] = None
     transmitter_name: Optional[str] = None
     transmitter_account_number: Optional[str] = None
     transmitter_address: Optional[str] = None

--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -892,10 +892,20 @@ class BatchJournalRequestEntry(NonEmptyRequest):
     Attributes:
         to_account (UUID): Account to fund in batch journal request.
         amount (float): The cash amount in USD to fund by.
+        transmitter_name (Optional[str]): For cash journals, travel rule related name info.
+        transmitter_account_number (Optional[str]): For cash journals, travel rule account number info.
+        transmitter_address (Optional[str]): For cash journals, travel rule related address info.
+        transmitter_financial_institution (Optional[str]): For cash journals, travel rule related institution info.
+        transmitter_timestamp (Optional[str]): For cash journals, travel rule related timestamp info.
     """
 
     to_account: UUID
-    amount: float
+    amount: Union[str, float]
+    transmitter_name: Optional[str] = None
+    transmitter_account_number: Optional[str] = None
+    transmitter_address: Optional[str] = None
+    transmitter_financial_institution: Optional[str] = None
+    transmitter_timestamp: Optional[str] = None
 
 
 class ReverseBatchJournalRequestEntry(NonEmptyRequest):

--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -891,7 +891,7 @@ class BatchJournalRequestEntry(NonEmptyRequest):
 
     Attributes:
         to_account (UUID): Account to fund in batch journal request.
-        amount (float): The cash amount in USD to fund by.
+        amount (Union[str, float]): The cash amount in USD to fund by.
         transmitter_name (Optional[str]): For cash journals, travel rule related name info.
         transmitter_account_number (Optional[str]): For cash journals, travel rule account number info.
         transmitter_address (Optional[str]): For cash journals, travel rule related address info.


### PR DESCRIPTION
Context:
- transmitter info is required in some cases to process journal requests

Changes:
- transmitter info is added into BatchJournalRequestEntry
- add description into BatchJournalRequestEntry