### PR TITLE
feat: Add sandbox data support

### DIFF
--- a/alpaca/common/enums.py
+++ b/alpaca/common/enums.py
@@ -9,6 +9,7 @@ class BaseURL(str, Enum):
     TRADING_PAPER = "https://paper-api.alpaca.markets"
     TRADING_LIVE = "https://api.alpaca.markets"
     DATA = "https://data.alpaca.markets"
+    DATA_SANDBOX = "https://data.sandbox.alpaca.markets"
     MARKET_DATA_STREAM = "wss://stream.data.alpaca.markets"
     OPTION_DATA_STREAM = "wss://stream.data.alpaca.markets"  # Deprecated: use MARKET_DATA_STREAM instead!
     TRADING_STREAM_PAPER = "wss://paper-api.alpaca.markets/stream"

--- a/alpaca/data/historical/crypto.py
+++ b/alpaca/data/historical/crypto.py
@@ -46,6 +46,8 @@ class CryptoHistoricalDataClient(RESTClient):
         oauth_token: Optional[str] = None,
         raw_data: bool = False,
         url_override: Optional[str] = None,
+        use_basic_auth: bool = False,
+        sandbox: bool = False,
     ) -> None:
         """
         Instantiates a Historical Data Client for Crypto Data.
@@ -58,15 +60,26 @@ class CryptoHistoricalDataClient(RESTClient):
               methods. Defaults to False. This has not been implemented yet.
             url_override (Optional[str], optional): If specified allows you to override the base url the client points
               to for proxy/testing.
+            use_basic_auth (bool, optional): If true, API requests will use basic authorization headers. Set to true if using
+              broker api sandbox credentials
+            sandbox (bool): True if using sandbox mode. Defaults to False.
         """
+
+        base_url = (
+            url_override
+            if url_override is not None
+            else BaseURL.DATA_SANDBOX if sandbox else BaseURL.DATA
+        )
+
         super().__init__(
             api_key=api_key,
             secret_key=secret_key,
             oauth_token=oauth_token,
             api_version="v1beta3",
-            base_url=url_override if url_override is not None else BaseURL.DATA,
-            sandbox=False,
+            base_url=base_url,
+            sandbox=sandbox,
             raw_data=raw_data,
+            use_basic_auth=use_basic_auth,
         )
 
     def get_crypto_bars(

--- a/alpaca/data/historical/option.py
+++ b/alpaca/data/historical/option.py
@@ -48,6 +48,7 @@ class OptionHistoricalDataClient(RESTClient):
         use_basic_auth: bool = False,
         raw_data: bool = False,
         url_override: Optional[str] = None,
+        sandbox: bool = False,
     ) -> None:
         """
         Instantiates a Historical Data Client.
@@ -56,20 +57,29 @@ class OptionHistoricalDataClient(RESTClient):
             api_key (Optional[str], optional): Alpaca API key. Defaults to None.
             secret_key (Optional[str], optional): Alpaca API secret key. Defaults to None.
             oauth_token (Optional[str]): The oauth token if authenticating via OAuth. Defaults to None.
-            use_basic_auth (bool, optional): If true, API requests will use basic authorization headers.
+            use_basic_auth (bool, optional): If true, API requests will use basic authorization headers. Set to true if using
+              broker api sandbox credentials
             raw_data (bool, optional): If true, API responses will not be wrapped and raw responses will be returned from
               methods. Defaults to False. This has not been implemented yet.
             url_override (Optional[str], optional): If specified allows you to override the base url the client points
               to for proxy/testing.
+            sandbox (bool): True if using sandbox mode. Defaults to False.
         """
+
+        base_url = (
+            url_override
+            if url_override is not None
+            else BaseURL.DATA_SANDBOX if sandbox else BaseURL.DATA
+        )
+
         super().__init__(
             api_key=api_key,
             secret_key=secret_key,
             oauth_token=oauth_token,
             use_basic_auth=use_basic_auth,
             api_version="v1beta1",
-            base_url=url_override if url_override is not None else BaseURL.DATA,
-            sandbox=False,
+            base_url=base_url,
+            sandbox=sandbox,
             raw_data=raw_data,
         )
 

--- a/alpaca/data/historical/stock.py
+++ b/alpaca/data/historical/stock.py
@@ -48,6 +48,7 @@ class StockHistoricalDataClient(RESTClient):
         use_basic_auth: bool = False,
         raw_data: bool = False,
         url_override: Optional[str] = None,
+        sandbox: bool = False,
     ) -> None:
         """
         Instantiates a Historical Data Client.
@@ -56,20 +57,29 @@ class StockHistoricalDataClient(RESTClient):
             api_key (Optional[str], optional): Alpaca API key. Defaults to None.
             secret_key (Optional[str], optional): Alpaca API secret key. Defaults to None.
             oauth_token (Optional[str]): The oauth token if authenticating via OAuth. Defaults to None.
-            use_basic_auth (bool, optional): If true, API requests will use basic authorization headers.
+            use_basic_auth (bool, optional): If true, API requests will use basic authorization headers. Set to true if using
+              broker api sandbox credentials
             raw_data (bool, optional): If true, API responses will not be wrapped and raw responses will be returned from
               methods. Defaults to False. This has not been implemented yet.
             url_override (Optional[str], optional): If specified allows you to override the base url the client points
               to for proxy/testing.
+            sandbox (bool): True if using sandbox mode. Defaults to False.
         """
+
+        base_url = (
+            url_override
+            if url_override is not None
+            else BaseURL.DATA_SANDBOX if sandbox else BaseURL.DATA
+        )
+
         super().__init__(
             api_key=api_key,
             secret_key=secret_key,
             oauth_token=oauth_token,
             use_basic_auth=use_basic_auth,
             api_version="v2",
-            base_url=url_override if url_override is not None else BaseURL.DATA,
-            sandbox=False,
+            base_url=base_url,
+            sandbox=sandbox,
             raw_data=raw_data,
         )
 


### PR DESCRIPTION
## **Context**

- Adds sandbox data endpoint support to the historical clients
- Adds `use_basic_auth` argument to the crypto historical client as it required for use with broker API credentials

## **Changes**

- added `DATA_SANDBOX` to `BaseURL` enum
- added `sandbox` argument to historical clients. 
- added `use_basic_auth` argument to crypto historical client
- Updated docs to indicate `use_basic_auth` as to be True when using broker API credentials