### PR TITLE
feat: Add BrokerClient.close_account

### DIFF
--- a/alpaca/broker/client.py
+++ b/alpaca/broker/client.py
@@ -1,4 +1,5 @@
 import base64
+import warnings
 from typing import Callable, Dict, Iterator, List, Optional, Union
 from uuid import UUID
 
@@ -223,14 +224,37 @@ class BrokerClient(RESTClient):
         account_id: Union[UUID, str],
     ) -> None:
         """
-        Delete an Account by its id.
-
-        As the api itself returns a 204 on success this function returns nothing in the successful case and will raise
-        and exception in any other case.
+        DEPRECATED:
+            delete_account is deprecated and will be removed in a future version.
+            Please use `close_account(account_id)` instead
 
         Args:
-            account_id (Union[UUID, str]): the id of the Account you wish to delete. str values will attempt to be
-            upcast to UUID to validate.
+            account_id (Union[UUID, str]): The id of the account to be closed
+
+        Returns:
+            None:
+        """
+        warnings.warn(
+            "delete_account is deprecated and will be removed in a future version."
+            "Please use `close_account(account_id)` instead",
+            DeprecationWarning,
+        )
+
+        self.close_account(account_id)
+
+    def close_account(
+        self,
+        account_id: Union[UUID, str],
+    ) -> None:
+        """
+        This operation closes an active account. The underlying records and information of the account are not deleted by this operation.
+
+        Before closing an account, you are responsible for closing all the positions and withdrawing all the money associated with that account.
+
+        ref. https://docs.alpaca.markets/reference/post-v1-accounts-account_id-actions-close-1
+
+        Args:
+            account_id (Union[UUID, str]): The id of the account to be closed
 
         Returns:
             None:
@@ -238,7 +262,7 @@ class BrokerClient(RESTClient):
 
         account_id = validate_uuid_id_param(account_id)
 
-        self.delete(f"/accounts/{account_id}")
+        self.post(f"/accounts/{account_id}/actions/close")
 
     def list_accounts(
         self,

--- a/tests/broker/broker_client/test_accounts_routes.py
+++ b/tests/broker/broker_client/test_accounts_routes.py
@@ -503,21 +503,42 @@ def test_update_account_validates_non_empty_request(reqmock, client: BrokerClien
 def test_delete_account(reqmock, client: BrokerClient):
     account_id = "0d969814-40d6-4b2b-99ac-2e37427f1ad2"
 
-    reqmock.delete(
-        f"https://broker-api.sandbox.alpaca.markets/v1/accounts/{account_id}",
+    reqmock.post(
+        f"https://broker-api.sandbox.alpaca.markets/v1/accounts/{account_id}/actions/close",
         status_code=204,
     )
 
-    assert client.delete_account(account_id) is None
+    with pytest.deprecated_call():
+        assert client.delete_account(account_id) is None
     assert reqmock.called_once
 
 
 def test_delete_account_validates_account_id(reqmock, client: BrokerClient):
-    with pytest.raises(ValueError):
+    with pytest.deprecated_call(), pytest.raises(ValueError):
         client.delete_account("not a uuid")
 
-    with pytest.raises(ValueError):
+    with pytest.deprecated_call(), pytest.raises(ValueError):
         client.delete_account(4)
+
+
+def test_close_account(reqmock, client: BrokerClient):
+    account_id = "0d969814-40d6-4b2b-99ac-2e37427f1ad2"
+
+    reqmock.post(
+        f"https://broker-api.sandbox.alpaca.markets/v1/accounts/{account_id}/actions/close",
+        status_code=204,
+    )
+
+    assert client.close_account(account_id) is None
+    assert reqmock.called_once
+
+
+def test_close_account_validates_account_id(reqmock, client: BrokerClient):
+    with pytest.raises(ValueError):
+        client.close_account("not a uuid")
+
+    with pytest.raises(ValueError):
+        client.close_account(4)
 
 
 def test_list_accounts_no_params(reqmock, client: BrokerClient):


### PR DESCRIPTION
Context:
- close_account was introduced and delete_account was deprecated
    - https://docs.alpaca.markets/reference/post-v1-accounts-account_id-actions-close-1

Changes:
- add `BrokerClient.close_account()`
- set `BrokerClient.delete_account()` deprecated. Please use `BrokerClient.close_account()` instead