### PR TITLE
M1-372: alpaca-py meta image

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@
    api_reference/index
 
 .. meta::
+   :image: https://alpaca.markets/static/images/meta-image-alpaca-py.png
    :description: The Official Python SDK for Alpaca's Suite of APIs
    
 


### PR DESCRIPTION
adds meta image to docs 

https://alpaca.markets/static/images/meta-image-alpaca-py.png