### PR TITLE
fix: Remove model_config for sphinx

### DIFF
--- a/alpaca/data/models/bars.py
+++ b/alpaca/data/models/bars.py
@@ -35,8 +35,6 @@ class Bar(BaseModel):
     trade_count: Optional[float]
     vwap: Optional[float]
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
     def __init__(self, symbol: str, raw_data: RawData) -> None:
         """Instantiates a bar
 

--- a/alpaca/data/models/base.py
+++ b/alpaca/data/models/base.py
@@ -41,7 +41,6 @@ class BaseDataSet(BaseModel):
     """
 
     data: Dict[str, List[BaseModel]] = {}
-    model_config = ConfigDict(protected_namespaces=tuple())
 
     def __getitem__(self, symbol: str) -> Any:
         """Gives dictionary-like access to multi-symbol data

--- a/alpaca/data/models/orderbooks.py
+++ b/alpaca/data/models/orderbooks.py
@@ -14,8 +14,6 @@ class OrderbookQuote(BaseModel):
     price: float = Field(alias="p")
     size: float = Field(alias="s")
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
 
 class Orderbook(BaseModel):
     """Level 2 ask/bid pair orderbook data.
@@ -31,8 +29,6 @@ class Orderbook(BaseModel):
     timestamp: datetime
     bids: List[OrderbookQuote]
     asks: List[OrderbookQuote]
-
-    model_config = ConfigDict(protected_namespaces=tuple())
 
     def __init__(self, symbol: str, raw_data: RawData) -> None:
         """Instantiates an Orderbook.

--- a/alpaca/data/models/quotes.py
+++ b/alpaca/data/models/quotes.py
@@ -37,8 +37,6 @@ class Quote(BaseModel):
     conditions: Optional[Union[List[str], str]] = None
     tape: Optional[str] = None
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
     def __init__(self, symbol: str, raw_data: RawData) -> None:
         """Instantiates a Quote
 

--- a/alpaca/data/models/screener.py
+++ b/alpaca/data/models/screener.py
@@ -21,8 +21,6 @@ class ActiveStock(BaseModel):
     volume: float
     trade_count: float
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
 
 class MostActives(BaseModel):
     """
@@ -36,8 +34,6 @@ class MostActives(BaseModel):
 
     most_actives: List[ActiveStock]
     last_updated: datetime
-
-    model_config = ConfigDict(protected_namespaces=tuple())
 
 
 class Mover(BaseModel):
@@ -54,8 +50,6 @@ class Mover(BaseModel):
     percent_change: float
     change: float
     price: float
-
-    model_config = ConfigDict(protected_namespaces=tuple())
 
 
 class Movers(BaseModel):
@@ -74,5 +68,3 @@ class Movers(BaseModel):
     losers: List[Mover]
     market_type: MarketType
     last_updated: datetime
-
-    model_config = ConfigDict(protected_namespaces=tuple())

--- a/alpaca/data/models/snapshots.py
+++ b/alpaca/data/models/snapshots.py
@@ -28,8 +28,6 @@ class Snapshot(BaseModel):
     daily_bar: Optional[Bar] = None
     previous_daily_bar: Optional[Bar] = None
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
     def __init__(self, symbol: str, raw_data: Dict[str, RawData]) -> None:
         """Instantiates a Snapshot.
 
@@ -81,8 +79,6 @@ class OptionsGreeks(BaseModel):
     theta: float
     vega: float
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
     def __init__(self, raw_data: RawData) -> None:
         """Instantiates an OptionGreeks object.
 
@@ -109,8 +105,6 @@ class OptionsSnapshot(BaseModel):
     latest_quote: Optional[Quote] = None
     implied_volatility: Optional[float] = None
     greeks: Optional[OptionsGreeks] = None
-
-    model_config = ConfigDict(protected_namespaces=tuple())
 
     def __init__(self, symbol: str, raw_data: Dict[str, RawData]) -> None:
         """Instantiates a Snapshot.

--- a/alpaca/data/models/trades.py
+++ b/alpaca/data/models/trades.py
@@ -33,8 +33,6 @@ class Trade(BaseModel):
     conditions: Optional[Union[List[str], str]] = None
     tape: Optional[str] = None
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
     def __init__(self, symbol: str, raw_data: RawData) -> None:
         """Instantiates a Trade history object
 

--- a/alpaca/data/requests.py
+++ b/alpaca/data/requests.py
@@ -38,8 +38,6 @@ class BaseTimeseriesDataRequest(NonEmptyRequest):
     currency: Optional[SupportedCurrencies] = None  # None = USD
     sort: Optional[Sort] = None  # None = asc
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
     def __init__(self, **data: Any) -> None:
         # convert timezone aware datetime to timezone naive UTC datetime
         if (
@@ -233,8 +231,6 @@ class BaseStockLatestDataRequest(NonEmptyRequest):
     feed: Optional[DataFeed] = None
     currency: Optional[SupportedCurrencies] = None  # None = USD
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
 
 class StockLatestTradeRequest(BaseStockLatestDataRequest):
     """
@@ -289,8 +285,6 @@ class BaseCryptoLatestDataRequest(NonEmptyRequest):
 
     symbol_or_symbols: Union[str, List[str]]
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
 
 class CryptoLatestTradeRequest(BaseCryptoLatestDataRequest):
     """
@@ -344,8 +338,6 @@ class BaseOptionLatestDataRequest(NonEmptyRequest):
     symbol_or_symbols: Union[str, List[str]]
     feed: Optional[OptionsFeed] = None
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
 
 class OptionLatestQuoteRequest(BaseOptionLatestDataRequest):
     """
@@ -392,8 +384,6 @@ class StockSnapshotRequest(NonEmptyRequest):
     feed: Optional[DataFeed] = None
     currency: Optional[SupportedCurrencies] = None  # None = USD
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
 
 class CryptoSnapshotRequest(NonEmptyRequest):
     """
@@ -404,8 +394,6 @@ class CryptoSnapshotRequest(NonEmptyRequest):
     """
 
     symbol_or_symbols: Union[str, List[str]]
-
-    model_config = ConfigDict(protected_namespaces=tuple())
 
 
 class OptionSnapshotRequest(NonEmptyRequest):
@@ -419,8 +407,6 @@ class OptionSnapshotRequest(NonEmptyRequest):
 
     symbol_or_symbols: Union[str, List[str]]
     feed: Optional[OptionsFeed] = None
-
-    model_config = ConfigDict(protected_namespaces=tuple())
 
 
 class OptionChainRequest(NonEmptyRequest):
@@ -449,8 +435,6 @@ class OptionChainRequest(NonEmptyRequest):
     expiration_date_lte: Optional[Union[date, str]] = None
     root_symbol: Optional[str] = None
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
 
 # ############################## Orderbooks ################################# #
 
@@ -465,8 +449,6 @@ class CryptoLatestOrderbookRequest(NonEmptyRequest):
 
     symbol_or_symbols: Union[str, List[str]]
 
-    model_config = ConfigDict(protected_namespaces=tuple())
-
 
 # ############################## Screener #################################### #
 
@@ -480,8 +462,6 @@ class ScreenerRequest(NonEmptyRequest):
     """
 
     top: int = 10
-
-    model_config = ConfigDict(protected_namespaces=tuple())
 
 
 class MostActivesRequest(ScreenerRequest):
@@ -534,5 +514,3 @@ class NewsRequest(NonEmptyRequest):
     include_content: Optional[bool] = None
     exclude_contentless: Optional[bool] = None
     page_token: Optional[str] = None
-
-    model_config = ConfigDict(protected_namespaces=tuple())

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,11 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../"))
 
+# import a module here to avoid an error of:
+# NameError: Field "model_fields" conflicts with member {} of protected namespace "model_".
+# ref. https://github.com/pydantic/pydantic/discussions/7763#discussioncomment-8417097
+import alpaca.data.models.screener
+
 # -- Project information -----------------------------------------------------
 
 project = "alpaca-py"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.abspath("../"))
 # import a module here to avoid an error of:
 # NameError: Field "model_fields" conflicts with member {} of protected namespace "model_".
 # ref. https://github.com/pydantic/pydantic/discussions/7763#discussioncomment-8417097
-import alpaca.data.models.screener
+import alpaca.data.models.screener  # noqa # pylint: disable=unused-import
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Context:
- we have added `model_config = ConfigDict(protected_namespaces=tuple())` to avoid an error of sphinx
- `NameError: Field "model_fields" conflicts with member {} of protected namespace "model_".`
- found a workaround to avoid putting the member variable

Changes:
- import a module in conf.py to remove model_config