### PR TITLE
Change Visa_Type to match API expectations.

### DIFF
--- a/alpaca/broker/enums.py
+++ b/alpaca/broker/enums.py
@@ -69,7 +69,7 @@ class VisaType(str, Enum):
     H1B = "H1B"
     J1 = "J1"
     L1 = "L1"
-    Other = "Other"
+    Other = "OTHER"
     O1 = "O1"
     TN1 = "TN1"
 


### PR DESCRIPTION
Hello,

On June 27th, 2024 at 8:47PM EST, we received this error from the Alpaca API:

```
APIError : {\"code\":40010001,\"message\":\"visa_type must be one of: [E1 E2 E3 F1 H1B TN1 O1 J1 L1 B1 B2 DACA G4 OTHER]\"}"}
```

We attempted to make a request to the Broker create an account endpoint and passed `VisaType.Other` as the input to the `Identity.visa_type` field.

We believe that it is because the API expects value `"OTHER"` not `"Other"`.