### PR TITLE
fix: Fix limit order request validation for oco

### DIFF
--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -359,16 +359,24 @@ class LimitOrderRequest(OrderRequest):
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         take_profit (Optional[TakeProfitRequest]): For orders with multiple legs, an order to exit a profitable trade.
         stop_loss (Optional[StopLossRequest]): For orders with multiple legs, an order to exit a losing trade.
-        limit_price (float): The worst fill price for a limit or stop limit order.
+        limit_price (Optional[float]): The worst fill price for a limit or stop limit order.
         position_intent (Optional[PositionIntent]): An enum to indicate the desired position strategy: BTO, BTC, STO, STC.
     """
 
-    limit_price: float
+    limit_price: Optional[float] = None
 
     def __init__(self, **data: Any) -> None:
         data["type"] = OrderType.LIMIT
 
         super().__init__(**data)
+
+    @model_validator(mode="before")
+    def root_validator(cls, values: dict) -> dict:
+        if values.get("order_class", "") != OrderClass.OCO:
+            limit_price = values.get("limit_price", None)
+            if limit_price is None:
+                raise ValueError("limit_price is required")
+        return values
 
 
 class StopLimitOrderRequest(OrderRequest):

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -1,9 +1,16 @@
+from tracemalloc import stop
 import pytest
 
 from alpaca.common.enums import BaseURL
 from alpaca.common.exceptions import APIError
 from alpaca.trading.client import TradingClient
-from alpaca.trading.enums import OrderSide, OrderStatus, PositionIntent, TimeInForce
+from alpaca.trading.enums import (
+    OrderClass,
+    OrderSide,
+    OrderStatus,
+    PositionIntent,
+    TimeInForce,
+)
 from alpaca.trading.models import Order
 from alpaca.trading.requests import (
     CancelOrderResponse,
@@ -12,6 +19,8 @@ from alpaca.trading.requests import (
     LimitOrderRequest,
     MarketOrderRequest,
     ReplaceOrderRequest,
+    StopLossRequest,
+    TakeProfitRequest,
 )
 
 
@@ -419,6 +428,68 @@ def test_limit_order(reqmock, trading_client):
     lo_response = trading_client.submit_order(lo)
 
     assert lo_response.status == OrderStatus.ACCEPTED
+
+
+def test_limit_order_request_validation() -> None:
+    # missing limit_price for non-OCOC
+    with pytest.raises(ValueError):
+        # order_class is not specified (default: simple)
+        LimitOrderRequest(
+            symbol="AAPL",
+            qty=1,
+            side=OrderSide.SELL,
+            time_in_force=TimeInForce.DAY,
+        )
+    with pytest.raises(ValueError):
+        # simple
+        LimitOrderRequest(
+            symbol="AAPL",
+            qty=1,
+            side=OrderSide.SELL,
+            time_in_force=TimeInForce.DAY,
+            order_class=OrderClass.SIMPLE,
+        )
+    with pytest.raises(ValueError):
+        # oto with take_profit
+        LimitOrderRequest(
+            symbol="AAPL",
+            qty=1,
+            side=OrderSide.SELL,
+            time_in_force=TimeInForce.DAY,
+            order_class=OrderClass.OTO,
+            take_profit=TakeProfitRequest(limit_price=100),
+        )
+    with pytest.raises(ValueError):
+        # oto with stop_loss
+        LimitOrderRequest(
+            symbol="AAPL",
+            qty=1,
+            side=OrderSide.SELL,
+            time_in_force=TimeInForce.DAY,
+            order_class=OrderClass.OTO,
+            stop_loss=StopLossRequest(stop_price=300),
+        )
+    with pytest.raises(ValueError):
+        # bracket
+        LimitOrderRequest(
+            symbol="AAPL",
+            qty=1,
+            side=OrderSide.SELL,
+            time_in_force=TimeInForce.DAY,
+            order_class=OrderClass.BRACKET,
+            take_profit=TakeProfitRequest(limit_price=100),
+            stop_loss=StopLossRequest(stop_price=300),
+        )
+    # no limit_price for OCO
+    LimitOrderRequest(
+        symbol="AAPL",
+        qty=1,
+        side=OrderSide.SELL,
+        time_in_force=TimeInForce.DAY,
+        order_class=OrderClass.OCO,
+        take_profit=TakeProfitRequest(limit_price=300),
+        stop_loss=StopLossRequest(stop_price=100),
+    )
 
 
 def test_order_position_intent(reqmock, trading_client: TradingClient):

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -1,4 +1,3 @@
-from tracemalloc import stop
 import pytest
 
 from alpaca.common.enums import BaseURL


### PR DESCRIPTION
fixes https://github.com/alpacahq/alpaca-py/issues/401

Context:
- limit_price is not required for oco limit order but  current validation of LimitOrderRequest requires

Changes:
- set limit_price optional for oco order