### PR TITLE
Add duration parameter to DataStream run method

### DIFF
--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -360,6 +360,11 @@ class DataStream:
             finally:
                 await asyncio.sleep(0)
 
+    async def _run(self, duration: timedelta = None) -> None:
+        timeout_seconds = duration.total_seconds() if duration != None else None
+        run_task = asyncio.create_task(self._run_forever())
+        await asyncio.wait([run_task], timeout=timeout_seconds)
+
     def run(self, duration: timedelta = None) -> None:
         """Starts up the websocket connection's event loop
 
@@ -368,9 +373,9 @@ class DataStream:
         duration: timedelta, default 'None'
             Duration of event loop before timeout."""
         try:
-            timeout_seconds = duration.total_seconds() if duration != None else 0
-            asyncio.run(asyncio.wait([self._run_forever()], timeout=timeout_seconds))
-        except TypeError:
+            asyncio.run(self._run(duration))
+        except TypeError as e:
+            print(e)
             print("invalid duration type entered")
             pass
         except KeyboardInterrupt:

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -3,6 +3,7 @@ import logging
 import queue
 from collections import defaultdict
 from typing import Callable, Dict, List, Optional, Tuple, Union
+from datetime import timedelta
 
 import msgpack
 import websockets
@@ -359,10 +360,19 @@ class DataStream:
             finally:
                 await asyncio.sleep(0)
 
-    def run(self) -> None:
-        """Starts up the websocket connection's event loop"""
+    def run(self, duration: timedelta = None) -> None:
+        """Starts up the websocket connection's event loop
+
+        Parameters:
+        -----------
+        duration: timedelta, default 'None'
+            Duration of event loop before timeout."""
         try:
-            asyncio.run(self._run_forever())
+            timeout_seconds = duration.total_seconds() if duration != None else 0
+            asyncio.run(asyncio.wait([self._run_forever()], timeout=timeout_seconds))
+        except TypeError:
+            print("invalid duration type entered")
+            pass
         except KeyboardInterrupt:
             print("keyboard interrupt, bye")
             pass

--- a/tests/data/test_websockets.py
+++ b/tests/data/test_websockets.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 from msgpack.ext import Timestamp
@@ -232,3 +232,18 @@ async def test_dispatch(ws_client: DataStream, timestamp: Timestamp):
     assert len(articles_b) == 1
     assert len(articles_star) == 2
     assert articles_star[1].headline == "c"
+
+
+@pytest.mark.parametrize("duration_seconds", [(1), (2), (3)])
+def test_run(ws_client: DataStream, duration_seconds: int) -> None:
+    """Testing for different durations.
+
+    Parameters:
+    -----------
+    ws_client (DataStream): DataStream to test.
+    duration_seconds (int): Duration to test.
+    """
+    start_time = datetime.now()
+    duration = timedelta(seconds=duration_seconds)
+    ws_client.run(duration)
+    assert round((datetime.now() - start_time).total_seconds()) >= duration_seconds


### PR DESCRIPTION
Added a duration parameter to the `DataStream.run()` method, allowing users to input a `timedelta` object to specify how long the `DataStream` should run for.  

To implement this I've created a separate method called `_run` which takes the `timedelta` object and converts it into seconds. An aynscio task is then created using `asyncio.create_task(self._run_forever())` and then this task is waited for using `asyncio.wait()`. The asyncio wait function has a timeout parameter in seconds which in this case is used to cancel the running of `_run_forever` when the  duration is exceeded.

I've also added a unit test with a number of durations to test this feature.