### PR TITLE
doc: Add a comment to reset paper account when qty must be integer

### DIFF
--- a/examples/stocks-trading-basic.ipynb
+++ b/examples/stocks-trading-basic.ipynb
@@ -242,6 +242,9 @@
     "# you can specify:\n",
     "# fractional qty (e.g. 0.01 qty) in the order request (which is shown in this example)\n",
     "# or notional value (e.g. 100 USD) (which is in the next example)\n",
+    "#\n",
+    "# If you have an error of `qty must be integer`,\n",
+    "# please try to `Reset Account` of your paper account via the Alpaca Trading API dashboard\n",
     "req = MarketOrderRequest(\n",
     "    symbol = symbol,\n",
     "    qty = 5.5,\n",
@@ -674,7 +677,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes https://github.com/alpacahq/alpaca-py/issues/499

Context:
- To enable features recently added (i.e. fractional/options trading) for paper account, resetting the paper account is required.
    - this process is only required for old paper accounts not for recent paper accounts/live accounts

Changes:
- add a comment to reset paper account when facing an error of `qty must be integer`