### PR TITLE
doc: Remove beta for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Alpaca’s APIs allow you to do everything from building algorithmic trading str
 
 To view full descriptions and examples view the [documentation page](https://alpaca.markets/sdks/python/).
 
-**Market Data API**: Access live and historical market data for 5000+ stocks, 20+ crypto, and options(beta).
+**Market Data API**: Access live and historical market data for 5000+ stocks, 20+ crypto, and options.
 
 **Trading API**: Trade stock and crypto with lightning fast execution speeds.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -19,9 +19,9 @@ Alpaca's APIs allow you to do everything from building algorithmic trading strat
 a full brokerage experience for your own end users.
 Here are some things you can do with Alpaca-py.
 
-**Market Data API**: Access live and historical market data for 5000+ stocks, 20+ crypto, and options(beta).
+**Market Data API**: Access live and historical market data for 5000+ stocks, 20+ crypto, and options.
 
-**Trading API**: Trade stock, crypto, and options(beta) with lightning fast execution speeds.
+**Trading API**: Trade stock, crypto, and options with lightning fast execution speeds.
 
 **Broker API & Connect**: Build investment apps - from robo-advisors to brokerages.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,7 +65,7 @@ Market Data
 
 .. image:: images/icons/market-data.png
 
-The Market Data API gives you access to real time and historical data for equities, crypto and options(beta).
+The Market Data API gives you access to real time and historical data for equities, crypto and options.
 Learn more on the :ref:`market-data` page.
 
 


### PR DESCRIPTION
Context:
- options trading in Alpaca is no longer beta

Changes:
- remove beta for options