### PR TITLE
fix: Fix BrokerClient.cancel_orders_for_account()

### DIFF
--- a/alpaca/broker/client.py
+++ b/alpaca/broker/client.py
@@ -1,6 +1,6 @@
 import base64
 import warnings
-from typing import Callable, Dict, Iterator, List, Optional, Union
+from typing import Callable, Iterator, List, Optional, Union
 from uuid import UUID
 
 import sseclient
@@ -43,6 +43,7 @@ from alpaca.trading.models import (
     Watchlist,
 )
 from alpaca.trading.requests import (
+    CancelOrderResponse,
     ClosePositionRequest,
     CreateWatchlistRequest,
     GetAssetsRequest,
@@ -59,7 +60,6 @@ from ..common import RawData
 from ..common.rest import HTTPResult, RESTClient
 from .enums import ACHRelationshipStatus
 from .requests import (
-    CancelOrderResponse,
     CreateAccountRequest,
     CreateACHRelationshipRequest,
     CreateACHTransferRequest,

--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -13,7 +13,6 @@ from alpaca.broker.models.accounts import (
     TrustedContact,
 )
 from alpaca.broker.models.documents import W8BenDocument
-from alpaca.broker.models.trading import Order
 from alpaca.broker.enums import (
     AccountEntities,
     BankAccountType,
@@ -43,7 +42,6 @@ from alpaca.trading.requests import (
     StopOrderRequest as BaseStopOrderRequest,
     StopLimitOrderRequest as BaseStopLimitOrderRequest,
     TrailingStopOrderRequest as BaseTrailingStopOrderRequest,
-    CancelOrderResponse as BaseCancelOrderResponse,
 )
 
 
@@ -808,17 +806,6 @@ class TrailingStopOrderRequest(BaseTrailingStopOrderRequest):
     """
 
     commission: Optional[float] = None
-
-
-class CancelOrderResponse(BaseCancelOrderResponse):
-    """
-    See base alpaca.trading.models.CancelOrderResponse model for more information.
-
-    Attributes:
-        body (Order): The order being cancelled.
-    """
-
-    body: Order
 
 
 # ############################## Journals ################################# #

--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -261,7 +261,7 @@ class RESTClient(ABC):
         """
         return self._request("PATCH", path, data)
 
-    def delete(self, path, data: Union[dict, str] = None) -> dict:
+    def delete(self, path, data: Optional[Union[dict, str]] = None) -> dict:
         """Performs a single DELETE request
 
         Args:

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime, timedelta
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 from pydantic import model_validator
@@ -235,9 +235,11 @@ class CancelOrderResponse(ModelWithID):
     Attributes:
         id (UUID): The order id
         status (int): The HTTP status returned after attempting to cancel the order.
+        body (Dict[str, Any]): an error description
     """
 
     status: int
+    body: Optional[Dict[str, Any]] = None
 
 
 class OrderRequest(NonEmptyRequest):

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -1,3 +1,4 @@
+from uuid import UUID
 import pytest
 
 from alpaca.common.enums import BaseURL
@@ -362,7 +363,12 @@ def test_cancel_orders(reqmock, trading_client: TradingClient):
           {
             "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
             "status": 200
-          }
+          },
+          {
+            "id": "72249bb6-6c89-4ea7-b8cf-73f1a140812b",
+            "status": 404,
+            "body": {"code": 40410000, "message": "order not found"}
+           }
         ]
         """,
     )
@@ -372,7 +378,12 @@ def test_cancel_orders(reqmock, trading_client: TradingClient):
     assert type(response) is list
     assert type(response[0]) is CancelOrderResponse
     assert response[0].status == 200
-
+    assert response[0].id == UUID("497f6eca-6276-4993-bfeb-53cbbbba6f08")
+    assert response[1].status == 404
+    assert response[1].id == UUID("72249bb6-6c89-4ea7-b8cf-73f1a140812b")
+    assert response[1].body is not None
+    assert response[1].body["code"] == 40410000
+    assert response[1].body["message"] == "order not found"
 
 def test_limit_order(reqmock, trading_client):
     reqmock.post(

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -385,6 +385,7 @@ def test_cancel_orders(reqmock, trading_client: TradingClient):
     assert response[1].body["code"] == 40410000
     assert response[1].body["message"] == "order not found"
 
+
 def test_limit_order(reqmock, trading_client):
     reqmock.post(
         f"{BaseURL.TRADING_PAPER.value}/v2/orders",


### PR DESCRIPTION
Context:
- while reviewing rebalance API endpoints PR, noticed that `BrokerClient.cancel_orders_for_account()` raises validation error when receiving response due to mismatch of response object

Changes:
- remove CancelOrderResponse from broker side
- add `body` fields into CancelOrderResponse of trading
- fix type of delete in common/rest.py