### PR TITLE
feat: Add options/custodial_customer agreements

### DIFF
--- a/alpaca/broker/enums.py
+++ b/alpaca/broker/enums.py
@@ -106,13 +106,15 @@ class AgreementType(str, Enum):
     """
     The types of agreements that are to be signed by the user
 
-    see https://alpaca.markets/docs/broker/api-references/accounts/accounts/#agreements
+    see https://docs.alpaca.markets/reference/createaccount
     """
 
     MARGIN = "margin_agreement"
     ACCOUNT = "account_agreement"
     CUSTOMER = "customer_agreement"
     CRYPTO = "crypto_agreement"
+    OPTIONS = "options_agreement"
+    CUSTODIAL_CUSTOMER = "custodial_customer_agreement"
 
 
 class DocumentType(str, Enum):


### PR DESCRIPTION
Context:
- options/custodial_customer agreements are added in the API
    - https://docs.alpaca.markets/reference/createaccount

Changes:
- add options_agreement
- add custodial_customer_agreement