### PR TITLE
Fix `Account` pydantic model

### DIFF
--- a/alpaca/broker/models/accounts.py
+++ b/alpaca/broker/models/accounts.py
@@ -262,56 +262,6 @@ class Account(ModelWithID):
     documents: Optional[List[AccountDocument]] = None
     trusted_contact: Optional[TrustedContact] = None
 
-    def __init__(self, **response):
-        super().__init__(
-            id=(UUID(response["id"])),
-            account_number=(response["account_number"]),
-            status=(response["status"]),
-            crypto_status=(
-                response["crypto_status"] if "crypto_status" in response else None
-            ),
-            kyc_results=(
-                TypeAdapter(KycResults).validate_python(response["kyc_results"])
-                if "kyc_results" in response and response["kyc_results"] is not None
-                else None
-            ),
-            currency=(response["currency"]),
-            last_equity=(response["last_equity"]),
-            created_at=(response["created_at"]),
-            contact=(
-                TypeAdapter(Contact).validate_python(response["contact"])
-                if "contact" in response
-                else None
-            ),
-            identity=(
-                TypeAdapter(Identity).validate_python(response["identity"])
-                if "identity" in response
-                else None
-            ),
-            disclosures=(
-                TypeAdapter(Disclosures).validate_python(response["disclosures"])
-                if "disclosures" in response
-                else None
-            ),
-            agreements=(
-                TypeAdapter(List[Agreement]).validate_python(response["agreements"])
-                if "agreements" in response
-                else None
-            ),
-            documents=(
-                TypeAdapter(List[AccountDocument]).validate_python(
-                    response["documents"]
-                )
-                if "documents" in response
-                else None
-            ),
-            trusted_contact=(
-                TypeAdapter(TrustedContact).validate_python(response["trusted_contact"])
-                if "trusted_contact" in response
-                else None
-            ),
-        )
-
 
 class TradeAccount(BaseTradeAccount):
     """

--- a/tests/broker/factories/accounts.py
+++ b/tests/broker/factories/accounts.py
@@ -1,4 +1,6 @@
 from typing import List
+
+from alpaca.broker import Account
 from alpaca.trading.enums import DTBPCheck, PDTCheck
 from alpaca.trading.models import AccountConfiguration as TradeAccountConfiguration
 
@@ -142,4 +144,22 @@ def create_dummy_trade_account_configuration() -> TradeAccountConfiguration:
         suspend_trade=False,
         trade_confirm_email="all",
         ptp_no_exception_entry=False,
+    )
+
+
+def create_dummy_account() -> Account:
+    """
+    Create a basic account instance with prefilled data
+
+    Returns:
+        Account: a prefilled Account instance for testing
+    """
+
+    return Account(
+        id="2d6cab28-c5d1-4ff8-91c6-b6404a9ee114",
+        account_number="551081356",
+        status="ACTIVE",
+        currency="USD",
+        last_equity="0",
+        created_at="2024-07-10T18:35:52.244506Z",
     )

--- a/tests/broker/test_models.py
+++ b/tests/broker/test_models.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 
+from alpaca.broker import Account
+from tests.broker.factories import accounts as factory
+
 import pytest
 
 from alpaca.broker.requests import (
@@ -466,3 +469,10 @@ def test_journal_with_amount_and_qty():
         )
 
     assert "Cash journals must contain an amount to transfer." in str(e.value)
+
+
+def test_account_serialization_deserialization():
+    account = factory.create_dummy_account()
+    json_str = account.model_dump_json()
+    account2 = Account.model_validate_json(json_str)
+    assert account2 == account


### PR DESCRIPTION
Fix `Account` pydantic model to properly handle serialization and deserialization.

The custom __init__ method for the account model makes no sense, as it partially duplicates the default built-in pydantic behaviour, but breaks model serialisation and deserialisation.

