### PR TITLE
Fix Production API URL

### DIFF
--- a/alpaca/broker/client.py
+++ b/alpaca/broker/client.py
@@ -161,7 +161,7 @@ class BrokerClient(RESTClient):
         base_url = (
             url_override
             if url_override is not None
-            else BaseURL.BROKER_SANDBOX.value if sandbox else BaseURL.BROKER_PRODUCTION
+            else BaseURL.BROKER_SANDBOX.value if sandbox else BaseURL.BROKER_PRODUCTION.value
         )
 
         super().__init__(


### PR DESCRIPTION
Fix base URL for production environment API to avoid exception

> requests.exceptions.MissingSchema: Invalid URL 'BaseURL.BROKER_PRODUCTION/v1/accounts/{censored}/documents/{censored}/download': No scheme supplied. Perhaps you meant https://BaseURL.BROKER_PRODUCTION/v1/accounts/{censored}/documents/{censored}/download