### PR TITLE
fix: Support websockets 14

### DIFF
--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -7,6 +7,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 import msgpack
 import websockets
 from pydantic import BaseModel
+from websockets.legacy import client as websockets_legacy
 
 from alpaca import __version__
 from alpaca.common.types import RawData
@@ -94,7 +95,7 @@ class DataStream:
         }
 
         log.info(f"connecting to {self._endpoint}")
-        self._ws = await websockets.connect(
+        self._ws = await websockets_legacy.connect(
             self._endpoint,
             extra_headers=extra_headers,
             **self._websocket_params,

--- a/alpaca/trading/stream.py
+++ b/alpaca/trading/stream.py
@@ -1,11 +1,12 @@
-import json
-import queue
-from typing import Optional, Dict, Callable, Union
 import asyncio
-import websockets
+import json
 import logging
+import queue
+from typing import Callable, Dict, Optional, Union
 
+import websockets
 from pydantic import BaseModel
+from websockets.legacy import client as websockets_legacy
 
 from alpaca.common import RawData
 from alpaca.common.enums import BaseURL
@@ -38,7 +39,9 @@ class TradingStream:
         self._endpoint = (
             url_override
             if url_override
-            else BaseURL.TRADING_STREAM_PAPER if paper else BaseURL.TRADING_STREAM_LIVE
+            else BaseURL.TRADING_STREAM_PAPER
+            if paper
+            else BaseURL.TRADING_STREAM_LIVE
         )
         self._ws = None
         self._running = False
@@ -56,7 +59,9 @@ class TradingStream:
             self._websocket_params = websocket_params
 
     async def _connect(self):
-        self._ws = await websockets.connect(self._endpoint, **self._websocket_params)
+        self._ws = await websockets_legacy.connect(
+            self._endpoint, **self._websocket_params
+        )
 
     async def _auth(self):
         await self._ws.send(

--- a/alpaca/trading/stream.py
+++ b/alpaca/trading/stream.py
@@ -39,9 +39,7 @@ class TradingStream:
         self._endpoint = (
             url_override
             if url_override
-            else BaseURL.TRADING_STREAM_PAPER
-            if paper
-            else BaseURL.TRADING_STREAM_LIVE
+            else BaseURL.TRADING_STREAM_PAPER if paper else BaseURL.TRADING_STREAM_LIVE
         )
         self._ws = None
         self._running = False


### PR DESCRIPTION
Context:
- websockets 14 changes import paths for deprecated functions
    - https://websockets.readthedocs.io/en/stable/project/changelog.html#id4
- according to upgrade guide, we can use `websockets.legacy.client.connect()` instead of `websockets.connect()` for a while
    - https://websockets.readthedocs.io/en/stable/howto/upgrade.html#import-paths

Changes:
- use `websockets.legacy.client.connect()`