### PR TITLE
feat: Support get_portfolio_history for TradingClient

### DIFF
--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -345,7 +345,6 @@ class TradingClient(RESTClient):
             f"/positions/{symbol_or_contract_id}/exercise",
         )
 
-
     # ############################## Portfolio ################################# #
 
     def get_portfolio_history(

--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -17,6 +17,7 @@ from alpaca.trading.requests import (
     ClosePositionRequest,
     GetAssetsRequest,
     GetOptionContractsRequest,
+    GetPortfolioHistoryRequest,
     OrderRequest,
     GetOrdersRequest,
     ReplaceOrderRequest,
@@ -31,6 +32,7 @@ from alpaca.trading.models import (
     OptionContract,
     OptionContractsResponse,
     Order,
+    PortfolioHistory,
     Position,
     ClosePositionResponse,
     Asset,
@@ -342,6 +344,33 @@ class TradingClient(RESTClient):
         self.post(
             f"/positions/{symbol_or_contract_id}/exercise",
         )
+
+
+    # ############################## Portfolio ################################# #
+
+    def get_portfolio_history(
+        self,
+        history_filter: Optional[GetPortfolioHistoryRequest] = None,
+    ) -> Union[PortfolioHistory, RawData]:
+        """
+        Gets the portfolio history statistics for an account.
+
+        Args:
+            account_id (Union[UUID, str]): The ID of the Account to get the portfolio history for.
+            history_filter: The various portfolio history request parameters.
+
+        Returns:
+            PortfolioHistory: The portfolio history statistics for the account.
+        """
+        response = self.get(
+            f"/account/portfolio/history",
+            history_filter.to_request_fields() if history_filter else {},
+        )
+
+        if self._use_raw_data:
+            return response
+
+        return PortfolioHistory(**response)
 
     # ############################## Assets ################################# #
 

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -79,6 +79,7 @@ class GetPortfolioHistoryRequest(NonEmptyRequest):
     extended_hours: Optional[bool] = None
     cashflow_types: Optional[str] = None
 
+
 class GetCalendarRequest(NonEmptyRequest):
     """
     Represents the optional filtering you can do when requesting a Calendar object

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -58,17 +58,26 @@ class GetPortfolioHistoryRequest(NonEmptyRequest):
           week, M for month and A for year. Defaults to 1M.
         timeframe (Optional[str]): The resolution of time window. 1Min, 5Min, 15Min, 1H, or 1D. If omitted, 1Min for
           less than 7 days period, 15Min for less than 30 days, or otherwise 1D.
+        intraday_reporting (Optional[str]): this specfies which timestamps to return data points
+        start (Optional[datetime]): The timestamp the data is returned starting from in RFC3339 format (including timezone specification).
+        pnl_reset (Optional[str]): efines how we are calculating the baseline values for Profit And Loss (pnl) for queries with timeframe less than 1D (intraday queries).
+        end (Optional[datetime]): The timestamp the data is returned up to in RFC3339 format (including timezone specification).
         date_end (Optional[date]): The date the data is returned up to. Defaults to the current market date (rolls over
           at the market open if extended_hours is false, otherwise at 7am ET).
         extended_hours (Optional[bool]): If true, include extended hours in the result. This is effective only for
           timeframe less than 1D.
+        cashflow_types (Optional[str]): The cashflow activities to include in the report
     """
 
     period: Optional[str] = None
     timeframe: Optional[str] = None
+    intraday_reporting: Optional[str] = None
+    start: Optional[datetime] = None
+    pnl_reset: Optional[str] = None
+    end: Optional[datetime] = None
     date_end: Optional[date] = None
     extended_hours: Optional[bool] = None
-
+    cashflow_types: Optional[str] = None
 
 class GetCalendarRequest(NonEmptyRequest):
     """


### PR DESCRIPTION
fixes https://github.com/alpacahq/alpaca-py/issues/533

Context:
- get_portfolio_history is not implemented in TradingClient

Changes:
- add get_portfolio_history for TradingClient