### PR TITLE
feat: Add position_intent into order model

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -13,6 +13,7 @@ from alpaca.trading.enums import (
     OrderType,
     OrderClass,
     PDTCheck,
+    PositionIntent,
     TimeInForce,
     OrderSide,
     PositionSide,
@@ -204,6 +205,7 @@ class Order(ModelWithID):
         trail_percent (Optional[str]): The percent value away from the high water mark for trailing stop orders.
         trail_price (Optional[str]): The dollar value away from the high water mark for trailing stop orders.
         hwm (Optional[str]): The highest (lowest) market price seen since the trailing stop order was submitted.
+        position_intent  (PositionIntent): Represents the desired position strategy.
     """
 
     client_order_id: str
@@ -237,6 +239,7 @@ class Order(ModelWithID):
     trail_percent: Optional[str] = None
     trail_price: Optional[str] = None
     hwm: Optional[str] = None
+    position_intent: PositionIntent
 
     def __init__(self, **data: Any) -> None:
         if "order_class" not in data or data["order_class"] == "":

--- a/tests/broker/broker_client/test_trading_routes.py
+++ b/tests/broker/broker_client/test_trading_routes.py
@@ -260,6 +260,7 @@ def test_close_all_positions_for_account(reqmock, client: BrokerClient):
                     "trail_percent": null,
                     "trail_price": null,
                     "hwm": null,
+                    "position_intent": "buy_to_open",
                     "subtag": null,
                     "source": null
                 }
@@ -336,6 +337,7 @@ def test_close_position_for_account_with_id(reqmock, client: BrokerClient):
               "trail_percent": null,
               "trail_price": null,
               "hwm": null,
+              "position_intent": "buy_to_open",
               "commission": 1.25
             }}
         """,
@@ -389,6 +391,7 @@ def test_close_position_for_account_with_symbol(reqmock, client: BrokerClient):
               "trail_percent": null,
               "trail_price": null,
               "hwm": null,
+              "position_intent": "buy_to_open",
               "commission": 1.25
             }}
         """,
@@ -442,6 +445,7 @@ def test_close_position_for_account_with_qty(reqmock, client: BrokerClient):
           "trail_percent": null,
           "trail_price": null,
           "hwm": null,
+          "position_intent": "buy_to_open",
           "commission": 1.25
         }
     """,
@@ -495,6 +499,7 @@ def test_close_position_for_account_with_percentage(reqmock, client: BrokerClien
           "trail_percent": null,
           "trail_price": null,
           "hwm": null,
+          "position_intent": "buy_to_open",
           "commission": 1.25
         }
     """,

--- a/tests/common/factories/trading.py
+++ b/tests/common/factories/trading.py
@@ -4,6 +4,7 @@ from alpaca.trading.enums import (
     OrderClass,
     OrderSide,
     OrderType,
+    PositionIntent,
     TimeInForce,
 )
 
@@ -72,4 +73,5 @@ def create_dummy_order() -> Order:
         trail_percent=None,
         trail_price=None,
         hwm=None,
+        position_intent=PositionIntent.BUY_TO_OPEN,
     )

--- a/tests/common/test_common_models.py
+++ b/tests/common/test_common_models.py
@@ -15,6 +15,7 @@ from alpaca.trading.enums import (
     AssetExchange,
     OrderType,
     OrderClass,
+    PositionIntent,
     TimeInForce,
     OrderSide,
     PositionSide,
@@ -173,6 +174,7 @@ def test_order_legs():
         trail_percent=None,
         trail_price=None,
         hwm=None,
+        position_intent=PositionIntent.BUY_TO_OPEN,
     )
 
     assert isinstance(order_with_legs.legs, list)

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -61,6 +61,7 @@ def test_market_order(reqmock, trading_client):
           "trail_percent": null,
           "trail_price": null,
           "hwm": null,
+          "position_intent": "buy_to_open",
           "commission": 1.25
         }
         """,
@@ -115,7 +116,8 @@ def test_get_orders(reqmock, trading_client: TradingClient):
                 "extended_hours": true,
                 "trail_percent": null,
                 "trail_price": null,
-                "hwm": "string"
+                "hwm": "string",
+                "position_intent": "buy_to_open"
             }
         ]
         """,
@@ -168,6 +170,7 @@ def test_get_order_by_id(reqmock, trading_client: TradingClient):
         "trail_percent": null,
         "trail_price": null,
         "hwm": null,
+        "position_intent": "buy_to_open",
         "commission": 1.25
     }
     """,
@@ -219,6 +222,7 @@ def test_get_order_by_client_id(reqmock, trading_client: TradingClient):
         "trail_percent": null,
         "trail_price": null,
         "hwm": null,
+        "position_intent": "buy_to_open",
         "commission": 1.25
     }
     """,
@@ -268,6 +272,7 @@ def test_replace_order(reqmock, trading_client: TradingClient):
         "trail_percent": null,
         "trail_price": null,
         "hwm": null,
+        "position_intent": "buy_to_open",
         "commission": 1.25
     }
     """,
@@ -423,6 +428,7 @@ def test_limit_order(reqmock, trading_client):
           "trail_percent": null,
           "trail_price": null,
           "hwm": null,
+          "position_intent": "buy_to_open",
           "commission": 1.25
         }
         """,
@@ -540,8 +546,8 @@ def test_order_position_intent(reqmock, trading_client: TradingClient):
           "trail_percent": null,
           "trail_price": null,
           "hwm": null,
-          "commission": 1.25,
-          "position_intent": "buy_to_open"
+          "position_intent": "buy_to_open",
+          "commission": 1.25
         }
         """,
     )
@@ -597,6 +603,7 @@ def test_order_position_intent(reqmock, trading_client: TradingClient):
           "trail_percent": null,
           "trail_price": null,
           "hwm": null,
+          "position_intent": "sell_to_open",
           "commission": 1.25
         }
         """,

--- a/tests/trading/trading_client/test_position_routes.py
+++ b/tests/trading/trading_client/test_position_routes.py
@@ -188,6 +188,7 @@ def test_close_all_positions(reqmock, trading_client: TradingClient):
                 "trail_percent": null,
                 "trail_price": null,
                 "hwm": null,
+                "position_intent": "sell_to_close",
                 "subtag": null,
                 "source": null
             }
@@ -263,6 +264,7 @@ def test_close_position_with_id(reqmock, trading_client: TradingClient):
               "trail_percent": null,
               "trail_price": null,
               "hwm": null,
+              "position_intent": "buy_to_open",
               "commission": 1.25
             }}
         """,
@@ -315,6 +317,7 @@ def test_close_position_with_symbol(reqmock, trading_client: TradingClient):
               "trail_percent": null,
               "trail_price": null,
               "hwm": null,
+              "position_intent": "buy_to_open",
               "commission": 1.25
             }}
         """,
@@ -367,6 +370,7 @@ def test_close_position_with_qty(reqmock, trading_client: TradingClient):
           "trail_percent": null,
           "trail_price": null,
           "hwm": null,
+          "position_intent": "buy_to_open",
           "commission": 1.25
         }
     """,
@@ -419,6 +423,7 @@ def test_close_position_with_percentage(reqmock, trading_client: TradingClient):
           "trail_percent": null,
           "trail_price": null,
           "hwm": null,
+          "position_intent": "buy_to_open",
           "commission": 1.25
         }
     """,


### PR DESCRIPTION
Closes https://github.com/alpacahq/alpaca-py/issues/539

Context:
- position_intent is missing in order object

Changes:
- add position_intent into order object
