### PR TITLE
fix: Set position_intent optional

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -205,7 +205,7 @@ class Order(ModelWithID):
         trail_percent (Optional[str]): The percent value away from the high water mark for trailing stop orders.
         trail_price (Optional[str]): The dollar value away from the high water mark for trailing stop orders.
         hwm (Optional[str]): The highest (lowest) market price seen since the trailing stop order was submitted.
-        position_intent  (PositionIntent): Represents the desired position strategy.
+        position_intent  (Optional[PositionIntent]): Represents the desired position strategy.
     """
 
     client_order_id: str
@@ -239,7 +239,7 @@ class Order(ModelWithID):
     trail_percent: Optional[str] = None
     trail_price: Optional[str] = None
     hwm: Optional[str] = None
-    position_intent: PositionIntent
+    position_intent: Optional[PositionIntent] = None
 
     def __init__(self, **data: Any) -> None:
         if "order_class" not in data or data["order_class"] == "":

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -116,8 +116,7 @@ def test_get_orders(reqmock, trading_client: TradingClient):
                 "extended_hours": true,
                 "trail_percent": null,
                 "trail_price": null,
-                "hwm": "string",
-                "position_intent": "buy_to_open"
+                "hwm": "string"
             }
         ]
         """,


### PR DESCRIPTION
Context:
- merged a PR to add position_intent into order model
    - https://github.com/alpacahq/alpaca-py/pull/540
- position_intent is empty for orders before introducing it
- Therefore, it should be optional

Changes:
- set position_intent optional