### PR TITLE
feat: add PENDING_NEW trade event to TradeEvent enum

### DIFF
--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -318,6 +318,7 @@ class CorporateActionDateType(str, Enum):
 class TradeEvent(str, Enum):
     FILL = "fill"
     CANCELED = "canceled"
+    PENDING_NEW = "pending_new"
     NEW = "new"
     PARTIAL_FILL = "partial_fill"
 


### PR DESCRIPTION
I noticed the websocket returning the string "pending_new" for TradeEvent and had to hard code around it being missing from `TradeEvent`