### PR TITLE
fix: In-notebook install command no longer triggered if `alpaca` already importable

### DIFF
--- a/examples/crypto-trading-basic.ipynb
+++ b/examples/crypto-trading-basic.ipynb
@@ -48,13 +48,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-01-16T15:16:19.009655Z",
+     "start_time": "2025-01-16T15:16:19.007625Z"
+    }
+   },
    "source": [
-    "# install alpaca-py\n",
-    "! python3 -m pip install alpaca-py"
-   ]
+    "# install alpaca-py if it is not available\n",
+    "try:\n",
+    "    import alpaca\n",
+    "except ImportError:\n",
+    "    !pip install alpaca-py\n",
+    "    import alpaca"
+   ],
+   "outputs": [],
+   "execution_count": 13
   },
   {
    "cell_type": "code",
@@ -66,7 +75,6 @@
     "from datetime import datetime, timedelta\n",
     "from zoneinfo import ZoneInfo\n",
     "\n",
-    "import alpaca\n",
     "from alpaca.trading.client import TradingClient\n",
     "from alpaca.data.timeframe import TimeFrame, TimeFrameUnit\n",
     "from alpaca.data.historical.crypto import CryptoHistoricalDataClient\n",

--- a/examples/options-trading-basic.ipynb
+++ b/examples/options-trading-basic.ipynb
@@ -54,8 +54,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# install alpaca-py\n",
-    "! python3 -m pip install alpaca-py"
+    "# install alpaca-py if it is not available\n",
+    "try:\n",
+    "    import alpaca\n",
+    "except ImportError:\n",
+    "    !pip install alpaca-py\n",
+    "    import alpaca"
    ]
   },
   {
@@ -68,7 +72,6 @@
     "from datetime import datetime, timedelta\n",
     "from zoneinfo import ZoneInfo\n",
     "\n",
-    "import alpaca\n",
     "from alpaca.trading.client import TradingClient\n",
     "from alpaca.data.timeframe import TimeFrame, TimeFrameUnit\n",
     "from alpaca.data.historical.option import OptionHistoricalDataClient\n",

--- a/examples/stocks-trading-basic.ipynb
+++ b/examples/stocks-trading-basic.ipynb
@@ -54,8 +54,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# install alpaca-py\n",
-    "! python3 -m pip install alpaca-py"
+    "# install alpaca-py if it is not available\n",
+    "try:\n",
+    "    import alpaca\n",
+    "except ImportError:\n",
+    "    !pip install alpaca-py\n",
+    "    import alpaca"
    ]
   },
   {
@@ -67,7 +71,6 @@
     "from datetime import datetime, timedelta\n",
     "from zoneinfo import ZoneInfo\n",
     "\n",
-    "import alpaca\n",
     "from alpaca.trading.client import TradingClient\n",
     "from alpaca.data.timeframe import TimeFrame, TimeFrameUnit\n",
     "from alpaca.data.historical.corporate_actions import CorporateActionsClient\n",


### PR DESCRIPTION
Fixes https://github.com/alpacahq/alpaca-py/issues/549 by calling the pip install command only when importing fails.