### PR TITLE
fix: Incorrect documentation for timestamp property of PortfolioHistory model

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -296,7 +296,7 @@ class PortfolioHistory(BaseModel):
     Contains information about the value of a portfolio over time.
 
     Attributes:
-        timestamp (List[int]): Time of each data element, left-labeled (the beginning of time window).
+        timestamp (List[int]): Time of each data element, right-labeled (the end of the time window).
         equity (List[float]): Equity value of the account in dollar amount as of the end of each time window.
         profit_loss (List[float]): Profit/loss in dollar from the base value.
         profit_loss_pct (List[Optional[float]]): Profit/loss in percentage from the base value.


### PR DESCRIPTION
The timestamp is the end of the time window, not the start. I verified this by checking the API response against the timestamp of a cash deposit in my account.

For example:
- The actual timestamp of the cash deposit was `2025-01-22T13:49:48-08:00`.
- `get_portfolio_history` with 1-hour granularity shows the cash deposit at timestamp `2025-01-22T14:00:00-08:00`.