### PR TITLE
fix: Fix position_intent for mleg order

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -249,7 +249,7 @@ class Order(ModelWithID):
 
         # mleg responses will give ''s that will need to be converted to None
         # to avoid validation errors from pydantic
-        for k in ["asset_id", "symbol", "asset_class", "side", "type", "order_type"]:
+        for k in ["asset_id", "symbol", "asset_class", "side", "position_intent", "type", "order_type"]:
             if k in data and data[k] == "":
                 data[k] = None
 

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -249,7 +249,15 @@ class Order(ModelWithID):
 
         # mleg responses will give ''s that will need to be converted to None
         # to avoid validation errors from pydantic
-        for k in ["asset_id", "symbol", "asset_class", "side", "position_intent", "type", "order_type"]:
+        for k in [
+            "asset_id",
+            "symbol",
+            "asset_class",
+            "side",
+            "position_intent",
+            "type",
+            "order_type",
+        ]:
             if k in data and data[k] == "":
                 data[k] = None
 


### PR DESCRIPTION
Context:
- `TradingStream.subscribe_trade_updates()` causes a validation error for MLeg(multi-leg) orders
- position_intent of order in trade_updates is empty string ("")
```
ERROR:alpaca.trading.stream:error during websocket communication: 1 validation error for TradeUpdate
order.position_intent
  Input should be 'buy_to_open', 'buy_to_close', 'sell_to_open' or 'sell_to_close' [type=enum, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/enum
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/alpaca/trading/stream.py", line 173, in _run_forever
    await self._consume()
  File "/usr/local/lib/python3.11/dist-packages/alpaca/trading/stream.py", line 146, in _consume
    await self._dispatch(msg)
  File "/usr/local/lib/python3.11/dist-packages/alpaca/trading/stream.py", line 90, in _dispatch
    await self._trade_updates_handler(self._cast(msg))
                                      ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/alpaca/trading/stream.py", line 104, in _cast
    result = TradeUpdate(**msg.get("data"))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pydantic/main.py", line 214, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for TradeUpdate
order.position_intent
  Input should be 'buy_to_open', 'buy_to_close', 'sell_to_open' or 'sell_to_close' [type=enum, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/enum
```

Changes:
- allow position_intent to be empty string