### PR TITLE
chore: Add stale github actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
+          days-before-issue-stale: -1
+          days-before-pr-stale: 30
+          days-before-issue-close: -1
+          days-before-pr-close: 5


### PR DESCRIPTION
Context:
- add [stale github actions](https://github.com/actions/stale)
    - current setup is only for PR
        - stale: 30 days of no activity
        - close: 5 days after stale with no activity
    - issue is out of scope (currently)

Changes:
- add stale github actions