### PR TITLE
fix: Add pr write permission to stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   stale:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9


### PR DESCRIPTION
Context:
- added stale github actions
    - https://github.com/alpacahq/alpaca-py/pull/562
- required permission is missing and had an error
    - `[#324] Error when adding a label: Resource not accessible by integration`
    - ref. https://github.com/actions/stale?tab=readme-ov-file#stale-pr-label
    - ref. https://github.com/actions/stale?tab=readme-ov-file#close-pr-message
- ref. https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions

Changes:
- add pr write permission to stale github actions job