### PR TITLE
Add `SETTLED` to `TransferStatus` enum

### DIFF
--- a/alpaca/broker/enums.py
+++ b/alpaca/broker/enums.py
@@ -361,6 +361,7 @@ class TransferStatus(str, Enum):
     REJECTED = "REJECTED"
     CANCELED = "CANCELED"
     APPROVED = "APPROVED"
+    SETTLED = "SETTLED"
     COMPLETE = "COMPLETE"
     RETURNED = "RETURNED"
 


### PR DESCRIPTION
In fact, Alpaca server returns transfer status "SETTLED", at least from transfer events SSE endpoint, e.g.
```
data: {"status_to": "CANCELED", "status_from": "SETTLED", "transfer_id": "bf438b6d-4ea3-4241-9e1c-a0e55b47f4e0", "account_id": "2d6cab28-c5d1-4ff8-91c6-b6404a9ee114", "at": "2024-07-22T08:22:29.990176Z", "event_ulid": "01J3CRHXB6ZHG4K120EWYQDB5X"}
```