### PR TITLE
fix: Adjust docstring of TradingClient.cancel_order_by_id()

### DIFF
--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -222,7 +222,7 @@ class TradingClient(RESTClient):
             order_id (Union[UUID, str]): The unique uuid identifier of the order being cancelled.
 
         Returns:
-            CancelOrderResponse: The HTTP response from the cancel request.
+            None
         """
         order_id = validate_uuid_id_param(order_id, "order_id")
 


### PR DESCRIPTION
Context:
- The docstring of `TradingClient.cancel_order_by_id()` mentioned `CancelOrderResponse` as response
- However, the TradingClient.cancel_order_by_id() returns `None` currently.
- The docstring should be aligned with actual behaviour of TradingClient.cancel_order_by_id()

Changes:
- adjust docstring `Retruns` to None for TradingClient.cancel_order_by_id()