### PR TITLE
fix: Revert "Use 10 000 as the default page limit for marketdata queries"

### DIFF
--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -378,7 +378,7 @@ class RESTClient(ABC):
         page_token = params.get("page_token")
 
         while True:
-            actual_limit = page_limit
+            actual_limit = None
 
             # adjusts the limit parameter value if it is over the page_limit
             if limit:


### PR DESCRIPTION
Reverts alpacahq/alpaca-py#578
=> introduced an issue of `alpaca.common.exceptions.APIError: {"message":"unexpected query parameter(s): limit"}` for some marketdata API endpoints. mainly for `/latest` and `/snapshots`
I have tried to fix to filter those endpoints but seems it might take sometime. so, revert the change first then later considering proper way

fixes https://github.com/alpacahq/alpaca-py/issues/581