### PR TITLE
feat: Allow `str` values for `since_id`  in `GetEventsRequest` model

### DIFF
--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -987,8 +987,8 @@ class GetEventsRequest(NonEmptyRequest):
     id: Optional[str] = None
     since: Optional[Union[date, str]] = None
     until: Optional[Union[date, str]] = None
-    since_id: Optional[int] = None
-    until_id: Optional[int] = None
+    since_id: Optional[Union[int, str]] = None
+    until_id: Optional[Union[int, str]] = None
 
 
 # ############################## Rebalancing ################################# #


### PR DESCRIPTION
Allow `str` values for `since_id` and `until_id` in `GetEventsRequest` to handle ULID id types.

E.g. endpoint [https://broker-api.sandbox.alpaca.markets/v2/events/trades](https://docs.alpaca.markets/reference/subscribetotradev2sse) requires string as `since_id` and `until_id` query params