### PR TITLE
feat: Allow use v2 API for Trade events SSE endpoint

### DIFF
--- a/alpaca/broker/client.py
+++ b/alpaca/broker/client.py
@@ -1895,12 +1895,18 @@ class BrokerClient(RESTClient):
         for event in client.events():
             yield event.data
 
-    def get_trade_events(self, filter: Optional[GetEventsRequest] = None) -> Iterator:
+    def get_trade_events(
+        self,
+        filter: Optional[GetEventsRequest] = None,
+        api_version: Optional[str] = None,
+    ) -> Iterator:
         """
         Subscribes to SSE stream for trade events.
 
         Args:
             filter: The arguments for filtering the events stream.
+            api_version: The API version for the endpoint.
+                If None, the value specified when the BrokerClient instance was created is used.
 
         Returns:
             Iterator: Yields events as they arrive
@@ -1910,7 +1916,9 @@ class BrokerClient(RESTClient):
         if filter:
             params = filter.to_request_fields()
 
-        url = self._base_url + "/" + self._api_version + "/events/trades"
+        url = (
+            self._base_url + "/" + (api_version or self._api_version) + "/events/trades"
+        )
 
         response = self._session.get(
             url=url,


### PR DESCRIPTION
There is a new endpoint [https://broker-api.sandbox.alpaca.markets/v2/events/trades](https://docs.alpaca.markets/reference/subscribetotradev2sse) that should be used for new integrations.

The motivation for this pull request is to add the ability to use the new v2 endpoint while continue using the v1 versions for other endpoints, and to maintain backwards compatibility with existing code. Enables iterative upgrades for existing customers.

