### PR TITLE
feat: Add DELAYED_SIP for DataFeed

### DIFF
--- a/alpaca/data/enums.py
+++ b/alpaca/data/enums.py
@@ -59,11 +59,13 @@ class DataFeed(str, Enum):
     Attributes:
         IEX (str): Investor's exchange data feed
         SIP (str): Securities Information Processor feed
+        DELAYED_SIP (str): SIP data with a 15 minute delay
         OTC (str): Over the counter feed
     """
 
     IEX = "iex"
     SIP = "sip"
+    DELAYED_SIP = "delayed_sip"
     OTC = "otc"
 
 


### PR DESCRIPTION
closes https://github.com/alpacahq/alpaca-py/issues/571

Context:
- The latest data API endpoints of MarketData API support delayed_sip for feed parameter

Changes:
- add DELAYED_SIP for DataFeed enum