### PR TITLE
Fix/#561 remove legacy websockets

### DIFF
--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -7,6 +7,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 import msgpack
 import websockets
 from pydantic import BaseModel
+
 try:
     from websockets.asyncio import client as ws_client
 except ImportError:

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -7,7 +7,11 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 import msgpack
 import websockets
 from pydantic import BaseModel
-from websockets.legacy import client as websockets_legacy
+try:
+    from websockets.asyncio import client as ws_client
+except ImportError:
+    from websockets import client as ws_client
+
 
 from alpaca import __version__
 from alpaca.common.types import RawData
@@ -95,7 +99,7 @@ class DataStream:
         }
 
         log.info(f"connecting to {self._endpoint}")
-        self._ws = await websockets_legacy.connect(
+        self._ws = await ws_client.connect(
             self._endpoint,
             extra_headers=extra_headers,
             **self._websocket_params,

--- a/alpaca/trading/stream.py
+++ b/alpaca/trading/stream.py
@@ -6,7 +6,10 @@ from typing import Callable, Dict, Optional, Union
 
 import websockets
 from pydantic import BaseModel
-from websockets.legacy import client as websockets_legacy
+try:
+    from websockets.asyncio import client as ws_client
+except ImportError:
+    from websockets import client as ws_client
 
 from alpaca.common import RawData
 from alpaca.common.enums import BaseURL
@@ -57,7 +60,7 @@ class TradingStream:
             self._websocket_params = websocket_params
 
     async def _connect(self):
-        self._ws = await websockets_legacy.connect(
+        self._ws = await ws_client.connect(
             self._endpoint, **self._websocket_params
         )
 

--- a/alpaca/trading/stream.py
+++ b/alpaca/trading/stream.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Optional, Union
 
 import websockets
 from pydantic import BaseModel
+
 try:
     from websockets.asyncio import client as ws_client
 except ImportError:
@@ -60,9 +61,7 @@ class TradingStream:
             self._websocket_params = websocket_params
 
     async def _connect(self):
-        self._ws = await ws_client.connect(
-            self._endpoint, **self._websocket_params
-        )
+        self._ws = await ws_client.connect(self._endpoint, **self._websocket_params)
 
     async def _auth(self):
         await self._ws.send(


### PR DESCRIPTION
- Replaced deprecated websockets.legacy import with recommended import.
- Fixes DeprecationWarning on websockets 14+ (see #561).
- Compatible with both old and new versions of websockets.
