### PR TITLE
fix: Change PortfolioHistory.base_value to Optional[float]

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -310,7 +310,7 @@ class PortfolioHistory(BaseModel):
         equity (List[float]): Equity value of the account in dollar amount as of the end of each time window.
         profit_loss (List[float]): Profit/loss in dollar from the base value.
         profit_loss_pct (List[Optional[float]]): Profit/loss in percentage from the base value.
-        base_value (float): Basis in dollar of the profit loss calculation.
+        base_value (Optional[float]): Basis in dollar of the profit loss calculation.
         timeframe (str): Time window size of each data element.
         cashflow (Dict[ActivityType, List[float]]): Cash flow amounts per activity type, if any.
     """
@@ -319,7 +319,7 @@ class PortfolioHistory(BaseModel):
     equity: List[float]
     profit_loss: List[float]
     profit_loss_pct: List[Optional[float]]
-    base_value: float
+    base_value: Optional[float] = None
     timeframe: str
     cashflow: Dict[ActivityType, List[float]] = {}
 

--- a/tests/broker/broker_client/test_trading_routes.py
+++ b/tests/broker/broker_client/test_trading_routes.py
@@ -563,6 +563,30 @@ def test_get_portfolio_history_with_null_pl_pct(reqmock, client: BrokerClient):
     assert isinstance(portfolio_history, PortfolioHistory)
 
 
+def test_get_portfolio_history_with_null_base_value(reqmock, client: BrokerClient):
+    account_id = "2a87c088-ffb6-472b-a4a3-cd9305c8605c"
+
+    reqmock.get(
+        f"{BaseURL.BROKER_SANDBOX.value}/v1/trading/accounts/{account_id}/account/portfolio/history",
+        text="""
+        {
+          "timestamp": [1580826600000, 1580827500000, 1580828400000],
+          "equity": [27423.73, 27408.19, 27515.97],
+          "profit_loss": [11.8, -3.74, 104.04],
+          "profit_loss_pct": [11.8, -3.74, 104.04],
+          "base_value": null,
+          "timeframe": "15Min"
+        }
+        """,
+    )
+
+    portfolio_history = client.get_portfolio_history_for_account(account_id)
+
+    assert reqmock.called_once
+    assert reqmock.request_history[0].qs == {}
+    assert isinstance(portfolio_history, PortfolioHistory)
+
+
 def test_get_portfolio_history_with_filter(reqmock, client: BrokerClient):
     account_id = "2a87c088-ffb6-472b-a4a3-cd9305c8605c"
 


### PR DESCRIPTION
fixes https://github.com/alpacahq/alpaca-py/issues/596

Context:
- PortfolioHistory.base_value encountered validation error is reported
```
1 validation error for PortfolioHistory
base_value
  Input should be a valid number [type=float_type, input_value=None, input_type=NoneType]
```

Changes:
- change PortfolioHistory.base_value to Optional[float]