### PR TITLE
fix: Add type for the parameters of TimeFrame()

### DIFF
--- a/alpaca/data/timeframe.py
+++ b/alpaca/data/timeframe.py
@@ -36,7 +36,7 @@ class TimeFrame:
     amount_value: int
     unit_value: TimeFrameUnit
 
-    def __init__(self, amount, unit) -> None:
+    def __init__(self, amount: int, unit: TimeFrameUnit) -> None:
         self.validate_timeframe(amount, unit)
         self.amount_value = amount
         self.unit_value = unit


### PR DESCRIPTION
Context:
- the missing of type hint for TimeFrame() might be confusing
    - ref. https://github.com/alpacahq/alpaca-py/issues/610

Changes:
- add type for the parameters of TimeFrame()