### PR TITLE
feat: Support ID/CUSIPs of corporate action

### DIFF
--- a/alpaca/data/historical/corporate_actions.py
+++ b/alpaca/data/historical/corporate_actions.py
@@ -57,8 +57,12 @@ class CorporateActionsClient(RESTClient):
 
         if request_params.symbols:
             params["symbols"] = ",".join(request_params.symbols)
+        if request_params.cusips:
+            params["cusips"] = ",".join(request_params.cusips)
         if request_params.types:
             params["types"] = ",".join(request_params.types)
+        if request_params.ids:
+            params["ids"] = ",".join(request_params.ids)
 
         response = self._get_marketdata(
             path="/corporate-actions",

--- a/alpaca/data/models/corporate_actions.py
+++ b/alpaca/data/models/corporate_actions.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Dict, List, Optional, Union
 
-from alpaca.common.models import ValidateBaseModel as BaseModel
+from alpaca.common.models import ModelWithID as BaseModel
 from alpaca.common.types import RawData
 from alpaca.data.models.base import BaseDataSet, TimeSeriesMixin
 
@@ -9,6 +9,7 @@ from alpaca.data.models.base import BaseDataSet, TimeSeriesMixin
 class ForwardSplit(BaseModel):
     corporate_action_type: str
     symbol: str
+    cusip: str
     new_rate: float
     old_rate: float
     process_date: date
@@ -21,6 +22,8 @@ class ForwardSplit(BaseModel):
 class ReverseSplit(BaseModel):
     corporate_action_type: str
     symbol: str
+    old_cusip: str
+    new_cusip: str
     new_rate: float
     old_rate: float
     process_date: date
@@ -32,10 +35,13 @@ class ReverseSplit(BaseModel):
 class UnitSplit(BaseModel):
     corporate_action_type: str
     old_symbol: str
+    old_cusip: str
     old_rate: float
     new_symbol: str
+    new_cusip: str
     new_rate: float
     alternate_symbol: str
+    alternate_cusip: str
     alternate_rate: float
     process_date: date
     effective_date: date
@@ -45,6 +51,7 @@ class UnitSplit(BaseModel):
 class StockDividend(BaseModel):
     corporate_action_type: str
     symbol: str
+    cusip: str
     rate: float
     process_date: date
     ex_date: date
@@ -55,6 +62,7 @@ class StockDividend(BaseModel):
 class CashDividend(BaseModel):
     corporate_action_type: str
     symbol: str
+    cusip: str
     rate: float
     special: bool
     foreign: bool
@@ -69,12 +77,13 @@ class CashDividend(BaseModel):
 class SpinOff(BaseModel):
     corporate_action_type: str
     source_symbol: str
+    source_cusip: str
     source_rate: float
     new_symbol: str
+    new_cusip: str
     new_rate: float
     process_date: date
     ex_date: date
-    payable_date: Optional[date] = None
     record_date: Optional[date] = None
     payable_date: Optional[date] = None
     due_bill_redemption_date: Optional[date] = None
@@ -83,7 +92,9 @@ class SpinOff(BaseModel):
 class CashMerger(BaseModel):
     corporate_action_type: str
     acquirer_symbol: Optional[str] = None
+    acquirer_cusip: Optional[str] = None
     acquiree_symbol: str
+    acquiree_cusip: str
     rate: float
     process_date: date
     effective_date: date
@@ -93,8 +104,10 @@ class CashMerger(BaseModel):
 class StockMerger(BaseModel):
     corporate_action_type: str
     acquirer_symbol: str
+    acquirer_cusip: str
     acquirer_rate: float
     acquiree_symbol: str
+    acquiree_cusip: str
     acquiree_rate: float
     process_date: date
     effective_date: date
@@ -104,8 +117,10 @@ class StockMerger(BaseModel):
 class StockAndCashMerger(BaseModel):
     corporate_action_type: str
     acquirer_symbol: str
+    acquirer_cusip: str
     acquirer_rate: float
     acquiree_symbol: str
+    acquiree_cusip: str
     acquiree_rate: float
     cash_rate: float
     process_date: date
@@ -116,6 +131,7 @@ class StockAndCashMerger(BaseModel):
 class Redemption(BaseModel):
     corporate_action_type: str
     symbol: str
+    cusip: str
     rate: float
     process_date: date
     payable_date: Optional[date] = None
@@ -124,20 +140,25 @@ class Redemption(BaseModel):
 class NameChange(BaseModel):
     corporate_action_type: str
     old_symbol: str
+    old_cusip: str
     new_symbol: str
+    new_cusip: str
     process_date: date
 
 
 class WorthlessRemoval(BaseModel):
     corporate_action_type: str
     symbol: str
+    cusip: str
     process_date: date
 
 
 class RightsDistribution(BaseModel):
     corporate_action_type: str
     source_symbol: str
+    source_cusip: str
     new_symbol: str
+    new_cusip: str
     rate: float
     process_date: date
     ex_date: date

--- a/alpaca/data/requests.py
+++ b/alpaca/data/requests.py
@@ -561,16 +561,20 @@ class CorporateActionsRequest(NonEmptyRequest):
 
     Attributes:
         symbols (Optional[List[str]]): The list of ticker identifiers.
+        cusips (Optional[List[str]]): The list of CUSIPs.
         types (Optional[List[CorporateActionsType]]): The types of corporate actions to filter by. (default: all types)
         start (Optional[date]): The inclusive start of the interval. Format: YYYY-MM-DD. (default: current day)
         end (Optional[date])): The inclusive end of the interval. Format: YYYY-MM-DD. (default: current day)
+        ids (Optional[List[str]]): The list of corporate action IDs. This parameter is mutually exclusive with all other filters (symbols, types, start, end).
         limit (Optional[int]): Upper limit of number of data points to return. (default: 1000)
         sort (Optional[Sort]): The chronological order of response based on the timestamp. Defaults to ASC.
     """
 
     symbols: Optional[List[str]] = None
+    cusips: Optional[List[str]] = None
     types: Optional[List[CorporateActionsType]] = None
     start: Optional[date] = None
     end: Optional[date] = None
+    ids: Optional[List[str]] = None
     limit: Optional[int] = 1000
     sort: Optional[Sort] = Sort.ASC

--- a/tests/data/test_corporate_actions.py
+++ b/tests/data/test_corporate_actions.py
@@ -1,5 +1,6 @@
 import urllib
-from datetime import date, datetime, timezone
+from datetime import date
+from uuid import UUID
 
 from alpaca.data.enums import CorporateActionsType
 from alpaca.data.historical.corporate_actions import CorporateActionsClient
@@ -20,24 +21,34 @@ def test_get_corporate_actions(
     # requests and response may not match as to check requests parameter conversion
     symbols = ["AAPL", "TSLA"]
     _symbols_in_url = urllib.parse.quote_plus(",".join(symbols))
+    cusips = ["CUSIP1", "CUSIP2"]
+    _cusips_in_url = urllib.parse.quote_plus(",".join(cusips))
     types = [CorporateActionsType.CASH_DIVIDEND, CorporateActionsType.FORWARD_SPLIT]
     _types_in_url = urllib.parse.quote_plus(",".join(types))
     start = date(2022, 2, 1)
     _start_in_url = urllib.parse.quote_plus(
         start.isoformat(),
     )
+    ids = [
+        "a7932b15-f816-4f83-921e-998b524487b0",
+        "a7932b15-f816-4f83-921e-998b524487b1",
+    ]
+    _ids_in_url = urllib.parse.quote_plus(",".join(ids))
     sort = "asc"
     limit = 1000
     reqmock.get(
-        f"https://data.alpaca.markets/v1/corporate-actions?symbols={_symbols_in_url}&types={_types_in_url}&start={_start_in_url}&sort={sort}&limit={limit}",
+        f"https://data.alpaca.markets/v1/corporate-actions?symbols={_symbols_in_url}&cusips={_cusips_in_url}&types={_types_in_url}&start={_start_in_url}&ids={_ids_in_url}&sort={sort}&limit={limit}",
         text="""
 {
   "corporate_actions": {
     "reverse_splits": [
       {
+        "id": "a7932b15-f816-4f83-921e-998b524487b0",
         "ex_date": "2023-08-24",
         "new_rate": 1,
         "old_rate": 50,
+        "new_cusip": "NEWCUSIP1",
+        "old_cusip": "OLDCUSIP1",
         "process_date": "2023-08-24",
         "record_date": "2023-08-24",
         "symbol": "MNTS"
@@ -45,6 +56,8 @@ def test_get_corporate_actions(
     ],
     "forward_splits": [
       {
+        "cusip": "CUSIP1",
+        "id": "a7932b15-f816-4f83-921e-998b524487b1",
         "due_bill_redemption_date": "2023-08-23",
         "ex_date": "2023-08-22",
         "new_rate": 2,
@@ -57,11 +70,15 @@ def test_get_corporate_actions(
     ],
     "unit_splits": [
       {
+        "id": "a7932b15-f816-4f83-921e-998b524487b2",
+        "alternate_cusip": "ALTCUSIP1",
         "alternate_rate": 0.3333,
         "alternate_symbol": "LVROW",
         "effective_date": "2023-03-01",
+        "new_cusip": "NEWCUSIP1",
         "new_rate": 1,
         "new_symbol": "LVRO",
+        "old_cusip": "OLDCUSIP1",
         "old_rate": 1,
         "old_symbol": "TPBAU",
         "process_date": "2023-03-01"
@@ -69,6 +86,8 @@ def test_get_corporate_actions(
     ],
     "stock_dividends": [
       {
+        "cusip": "CUSIP1",
+        "id": "a7932b15-f816-4f83-921e-998b524487b3",
         "ex_date": "2023-05-19",
         "payable_date": "2023-05-05",
         "process_date": "2023-05-19",
@@ -79,6 +98,8 @@ def test_get_corporate_actions(
     ],
     "cash_dividends": [
       {
+        "cusip": "CUSIP1",
+        "id": "a7932b15-f816-4f83-921e-998b524487b4",
         "ex_date": "2023-05-04",
         "foreign": false,
         "payable_date": "2023-05-19",
@@ -91,18 +112,23 @@ def test_get_corporate_actions(
     ],
     "spin_offs": [
       {
+        "id": "a7932b15-f816-4f83-921e-998b524487b5",
         "ex_date": "2023-08-15",
+        "new_cusip": "NEWCUSIP1",
         "new_rate": 1,
         "new_symbol": "SRM",
         "process_date": "2023-08-15",
         "record_date": "2023-08-15",
+        "source_cusip": "SOURCECUSIP1",
         "source_rate": 19.35,
         "source_symbol": "JUPW"
       }
     ],
     "cash_mergers": [
       {
+        "id": "a7932b15-f816-4f83-921e-998b524487b6",
         "acquiree_symbol": "GLOP",
+        "acquiree_cusip": "ACQUIREECUSIP1",
         "effective_date": "2023-07-17",
         "payable_date": "2023-07-17",
         "process_date": "2023-07-17",
@@ -111,8 +137,11 @@ def test_get_corporate_actions(
     ],
     "stock_mergers": [
       {
+        "id": "a7932b15-f816-4f83-921e-998b524487b7",
+        "acquiree_cusip": "ACQUIREECUSIP1",
         "acquiree_rate": 1,
         "acquiree_symbol": "LSI",
+        "acquirer_cusip": "ACQUIRERCUSIP1",
         "acquirer_rate": 0.895,
         "acquirer_symbol": "EXR",
         "effective_date": "2023-07-20",
@@ -122,8 +151,11 @@ def test_get_corporate_actions(
     ],
     "stock_and_cash_mergers": [
       {
+        "id": "a7932b15-f816-4f83-921e-998b524487b8",
+        "acquiree_cusip": "ACQUIREECUSIP1",
         "acquiree_rate": 1,
         "acquiree_symbol": "MLVF",
+        "acquirer_cusip": "ACQUIRERCUSIP1",
         "acquirer_rate": 0.7733,
         "acquirer_symbol": "FRBA",
         "cash_rate": 7.8,
@@ -134,28 +166,38 @@ def test_get_corporate_actions(
     ],
     "redemptions": [
       {
+        "id": "a7932b15-f816-4f83-921e-998b524487b9",
         "payable_date": "2023-06-13",
         "process_date": "2023-06-13",
+        "cusip": "CUSIP1",
         "rate": 0.141134,
         "symbol": "ORPHY"
       }
     ],
     "name_changes": [
       {
+        "id": "a7932b15-f816-4f83-921e-998b524487c0",
+        "new_cusip": "NEWCUSIP1",
         "new_symbol": "VFS",
+        "old_cusip": "OLDCUSIP1",
         "old_symbol": "BSAQ",
         "process_date": "2023-08-15"
       }
     ],
     "worthless_removals": [
       {
+        "id": "a7932b15-f816-4f83-921e-998b524487c1",
+        "cusip": "CUSIP1",
         "symbol": "ATNXQ",
         "process_date": "2023-10-11"
       }
     ],
     "rights_distributions": [
       {
+        "id": "a7932b15-f816-4f83-921e-998b524487c2",
+        "source_cusip": "SOURCECUSIP1",
         "source_symbol": "IFN",
+        "new_cusip": "NEWCUSIP1",
         "new_symbol": "IFN.RTWI",
         "rate": 1,
         "ex_date": "2024-04-17",
@@ -176,12 +218,14 @@ def test_get_corporate_actions(
     )
     _page_token_in_url = urllib.parse.quote_plus(page_token)
     reqmock.get(
-        f"https://data.alpaca.markets/v1/corporate-actions?symbols={_symbols_in_url}&types={_types_in_url}&start={_start_in_url}&sort={sort}&limit={limit2}&page_token={_page_token_in_url}",
+        f"https://data.alpaca.markets/v1/corporate-actions?symbols={_symbols_in_url}&cusips={_cusips_in_url}&types={_types_in_url}&start={_start_in_url}&ids={_ids_in_url}&sort={sort}&limit={limit2}&page_token={_page_token_in_url}",
         text="""
 {
   "corporate_actions": {
     "cash_dividends": [
       {
+        "cusip": "CUSIP1",
+        "id": "a7932b15-f816-4f83-921e-998b524487c3",
         "ex_date": "2024-08-07",
         "foreign": true,
         "payable_date": "2024-08-26",
@@ -202,6 +246,8 @@ def test_get_corporate_actions(
         symbols=symbols,
         types=types,
         start=start,
+        cusips=cusips,
+        ids=ids,
     )
 
     res = corporate_actions_client.get_corporate_actions(request_params=req)
@@ -209,7 +255,10 @@ def test_get_corporate_actions(
     assert isinstance(res, CorporateActionsSet)
 
     reverse_split: ReverseSplit = res["reverse_splits"][0]
+    assert reverse_split.id == UUID("a7932b15-f816-4f83-921e-998b524487b0")
     assert reverse_split.symbol == "MNTS"
+    assert reverse_split.new_cusip == "NEWCUSIP1"
+    assert reverse_split.old_cusip == "OLDCUSIP1"
     assert reverse_split.new_rate == 1
     assert reverse_split.old_rate == 50
     assert reverse_split.ex_date == date(2023, 8, 24)
@@ -217,7 +266,9 @@ def test_get_corporate_actions(
     assert reverse_split.record_date == date(2023, 8, 24)
 
     forward_split: ForwardSplit = res["forward_splits"][0]
+    assert forward_split.id == UUID("a7932b15-f816-4f83-921e-998b524487b1")
     assert forward_split.symbol == "SRE"
+    assert forward_split.cusip == "CUSIP1"
     assert forward_split.new_rate == 2
     assert forward_split.old_rate == 1
     assert forward_split.record_date == date(2023, 8, 14)
@@ -227,18 +278,23 @@ def test_get_corporate_actions(
     assert forward_split.due_bill_redemption_date == date(2023, 8, 23)
 
     unit_split: UnitSplit = res["unit_splits"][0]
+    assert unit_split.id == UUID("a7932b15-f816-4f83-921e-998b524487b2")
     assert unit_split.old_symbol == "TPBAU"
-    assert unit_split.alternate_rate == 0.3333
-    assert unit_split.alternate_symbol == "LVROW"
-    assert unit_split.effective_date == date(2023, 3, 1)
-    assert unit_split.new_rate == 1
-    assert unit_split.new_symbol == "LVRO"
+    assert unit_split.old_cusip == "OLDCUSIP1"
     assert unit_split.old_rate == 1
-    assert unit_split.old_symbol == "TPBAU"
+    assert unit_split.new_symbol == "LVRO"
+    assert unit_split.new_cusip == "NEWCUSIP1"
+    assert unit_split.new_rate == 1
+    assert unit_split.alternate_symbol == "LVROW"
+    assert unit_split.alternate_cusip == "ALTCUSIP1"
+    assert unit_split.alternate_rate == 0.3333
+    assert unit_split.effective_date == date(2023, 3, 1)
     assert unit_split.process_date == date(2023, 3, 1)
 
     stock_dividend: StockDividend = res["stock_dividends"][0]
+    assert stock_dividend.id == UUID("a7932b15-f816-4f83-921e-998b524487b3")
     assert stock_dividend.symbol == "MSBC"
+    assert stock_dividend.cusip == "CUSIP1"
     assert stock_dividend.rate == 0.05
     assert stock_dividend.payable_date == date(2023, 5, 5)
     assert stock_dividend.ex_date == date(2023, 5, 19)
@@ -246,6 +302,8 @@ def test_get_corporate_actions(
     assert stock_dividend.record_date == date(2023, 5, 22)
 
     cash_dividend: CashDividend = res["cash_dividends"][0]
+    assert cash_dividend.id == UUID("a7932b15-f816-4f83-921e-998b524487b4")
+    assert cash_dividend.cusip == "CUSIP1"
     assert cash_dividend.symbol == "FCF"
     assert cash_dividend.rate == 0.125
     assert not cash_dividend.foreign


### PR DESCRIPTION
closes https://github.com/alpacahq/alpaca-py/issues/584

Context:
- corporate actions response object now has id/cusip

Changes:
- support id/cusip for corporate actions
