### PR TITLE
Reraise generic exceptions

### DIFF
--- a/alpaca/trading/stream.py
+++ b/alpaca/trading/stream.py
@@ -183,6 +183,7 @@ class TradingStream:
                 log.exception(
                     "error during websocket " "communication: {}".format(str(e))
                 )
+                raise e
             finally:
                 await asyncio.sleep(0.01)
 


### PR DESCRIPTION
Currently the alpaca api quietly consumes exceptions, but logs it. 

This seems strange? It prevents users of the API from handling it themselves? 

This PR just reraises the caught exception. 