### PR TITLE
fix: Add new asset classes for perpetual crypto and ASCX exchange

### DIFF
--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -183,6 +183,7 @@ class AssetClass(str, Enum):
     US_EQUITY = "us_equity"
     US_OPTION = "us_option"
     CRYPTO = "crypto"
+    CRYPTO_PERP = "crypto_perp"
 
 
 class AssetStatus(str, Enum):
@@ -201,6 +202,7 @@ class AssetExchange(str, Enum):
 
     AMEX = "AMEX"
     ARCA = "ARCA"
+    ASCX = "ASCX"
     BATS = "BATS"
     NYSE = "NYSE"
     NASDAQ = "NASDAQ"


### PR DESCRIPTION
https://github.com/alpacahq/alpaca-py/issues/624

### How to Proceed
Here are a few options on how to proceed, based on your judgement. 
1. If the issue is due to Alpaca adding a new AssetClass type and AssetExchange type, then we should merge this PR. 
2. However, if this is a data corruption issue, then we don't need to proceed with this PR. 

For folks experiencing the same issue, you can temporarily change your alpaca-py dependency from
```
pip install alpaca-py
```
to
```
pip install git+https://github.com/yushdotkapoor/alpaca-py.git
```

### Verification
The steps that were failing in the [Issue](https://github.com/alpacahq/alpaca-py/issues/624) are now passing
```
from alpaca.trading.client import TradingClient
alpaca = TradingClient(api_key={api_key}, secret_key={secret_key}, paper={is_mock})
alpaca.get_all_assets()
```
now list all the assets without Validation errors