### PR TITLE
feat: Add account_type/account_sub_type

### DIFF
--- a/alpaca/broker/enums.py
+++ b/alpaca/broker/enums.py
@@ -1,6 +1,32 @@
 from enum import Enum
 
 
+class AccountSubType(str, Enum):
+    """
+    The sub type of account
+    IRA Account only
+
+    see https://docs.alpaca.markets/reference/createaccount
+    """
+
+    TRADITIONAL = "traditional"
+    ROTH = "roth"
+
+
+class AccountType(str, Enum):
+    """
+    The type of account
+
+    see https://docs.alpaca.markets/reference/createaccount
+    """
+
+    TRADING = "trading"
+    CUSTODIAL = "custodial"
+    DONOR_ADVISED = "donor_advised"
+    IRA = "ira"
+    HSA = "hsa"
+
+
 class TaxIdType(str, Enum):
     """The various country specific tax identification numbers
 

--- a/alpaca/broker/models/accounts.py
+++ b/alpaca/broker/models/accounts.py
@@ -1,10 +1,12 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
 from pydantic import TypeAdapter, ValidationInfo, field_validator, model_validator
 
 from alpaca.broker.enums import (
+    AccountSubType,
+    AccountType,
     AgreementType,
     ClearingBroker,
     EmploymentStatus,
@@ -234,6 +236,8 @@ class Account(ModelWithID):
     Attributes:
         id (str): The account uuid used to reference this account
         account_number (str): A more human friendly identifier for this account
+        account_type (Optional[Union[AccountType, str]]): The type of account
+        account_sub_type (Optional[Union[AccountSubType, str]]): The sub type of account
         status (AccountStatus): The approval status of this account
         crypto_status (Optional[AccountStatus]): The crypto trading status. Only present if crypto trading is enabled.
         kyc_results (Optional[KycResult]): Hold information about the result of KYC.
@@ -249,6 +253,8 @@ class Account(ModelWithID):
     """
 
     account_number: str
+    account_type: Optional[Union[AccountType, str]] = None
+    account_sub_type: Optional[Union[AccountSubType, str]] = None
     status: AccountStatus
     crypto_status: Optional[AccountStatus] = None
     kyc_results: Optional[KycResults] = None
@@ -266,6 +272,8 @@ class Account(ModelWithID):
         super().__init__(
             id=(UUID(response["id"])),
             account_number=(response["account_number"]),
+            account_type=response.get("account_type", None),
+            account_sub_type=response.get("account_sub_type", None),
             status=(response["status"]),
             crypto_status=(
                 response["crypto_status"] if "crypto_status" in response else None

--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -6,6 +6,8 @@ from pydantic import field_serializer, field_validator, model_validator
 
 from alpaca.broker.enums import (
     AccountEntities,
+    AccountSubType,
+    AccountType,
     BankAccountType,
     CalendarSubType,
     DocumentType,
@@ -120,6 +122,8 @@ class CreateAccountRequest(NonEmptyRequest):
     """Class used to format data necessary for making a request to create a brokerage account
 
     Attributes:
+        account_type (Optional[AccountType]): The type of account
+        account_sub_type (Optional[AccountSubType]): The sub type of account
         contact (Contact): The contact details for the account holder
         identity (Identity): The identity details for the account holder
         disclosures (Disclosures): The account holder's political disclosures
@@ -128,6 +132,8 @@ class CreateAccountRequest(NonEmptyRequest):
         trusted_contact (TrustedContact): The account holder's trusted contact details
     """
 
+    account_type: Optional[Union[AccountType, str]] = None
+    account_sub_type: Optional[Union[AccountSubType, str]] = None
     contact: Contact
     identity: Identity
     disclosures: Disclosures


### PR DESCRIPTION
Context:
- account_type/account_sub_type parameters are not implemented
    - ref. https://docs.alpaca.markets/reference/createaccount

Changes:
- add account_type/account_sub_type