### PR TITLE
feat: add get_account_activities to TradingClient

### DIFF
--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -13,25 +13,30 @@ from alpaca.common.utils import (
     validate_symbol_or_contract_id,
     validate_uuid_id_param,
 )
+from alpaca.trading.enums import ActivityType
 from alpaca.trading.models import (
     AccountConfiguration,
     Asset,
+    BaseActivity,
     Calendar,
     Clock,
     ClosePositionResponse,
     CorporateActionAnnouncement,
+    NonTradeActivity,
     OptionContract,
     OptionContractsResponse,
     Order,
     PortfolioHistory,
     Position,
     TradeAccount,
+    TradeActivity,
     Watchlist,
 )
 from alpaca.trading.requests import (
     CancelOrderResponse,
     ClosePositionRequest,
     CreateWatchlistRequest,
+    GetAccountActivitiesRequest,
     GetAssetsRequest,
     GetCalendarRequest,
     GetCorporateAnnouncementsRequest,
@@ -511,6 +516,93 @@ class TradingClient(RESTClient):
             return response
 
         return AccountConfiguration(**response)
+
+    # ############################## ACCOUNT ACTIVITIES ################################# #
+
+    def get_account_activities(
+        self,
+        activity_filter: Optional[GetAccountActivitiesRequest] = None,
+    ) -> Union[List[BaseActivity], RawData]:
+        """
+        Returns account activity entries for a specific type of activity.
+
+        The return type of this function is List[BaseActivity] however the list will contain concrete instances of one
+        of the child classes of BaseActivity, either TradeActivity or NonTradeActivity. It can be a mixed list depending
+        on what filtering criteria you pass through `activity_filter`.
+
+        Args:
+            activity_filter (Optional[GetAccountActivitiesRequest]): The various filtering fields you can specify to
+              restrict results.
+
+        Returns:
+            Union[List[BaseActivity], RawData]: A list of BaseActivity child classes (TradeActivity or NonTradeActivity).
+        """
+        params = activity_filter.to_request_fields() if activity_filter else {}
+
+        # Convert activity_types list to comma-separated string if present
+        if "activity_types" in params and isinstance(params["activity_types"], list):
+            params["activity_types"] = ",".join(
+                [
+                    at.value if isinstance(at, ActivityType) else at
+                    for at in params["activity_types"]
+                ]
+            )
+
+        response = self.get("/account/activities", params)
+
+        if self._use_raw_data:
+            return response
+
+        return [self._parse_activity(activity) for activity in response]
+
+    def get_account_activities_by_type(
+        self,
+        activity_type: ActivityType,
+        activity_filter: Optional[GetAccountActivitiesRequest] = None,
+    ) -> Union[List[BaseActivity], RawData]:
+        """
+        Returns account activity entries for a specific type of activity.
+
+        Args:
+            activity_type (ActivityType): The type of activity to retrieve.
+            activity_filter (Optional[GetAccountActivitiesRequest]): The various filtering fields you can specify to
+              restrict results.
+
+        Returns:
+            Union[List[BaseActivity], RawData]: A list of BaseActivity child classes (TradeActivity or NonTradeActivity).
+        """
+        params = activity_filter.to_request_fields() if activity_filter else {}
+
+        response = self.get(f"/account/activities/{activity_type.value}", params)
+
+        if self._use_raw_data:
+            return response
+
+        return [self._parse_activity(activity) for activity in response]
+
+    @staticmethod
+    def _parse_activity(data: dict) -> Union[TradeActivity, NonTradeActivity]:
+        """
+        Parse raw activity data into the appropriate Activity type.
+
+        Args:
+            data (dict): A dict of raw data to convert into an Activity instance.
+
+        Returns:
+            Union[TradeActivity, NonTradeActivity]: The parsed activity instance.
+
+        Raises:
+            ValueError: If `data` doesn't contain an `activity_type` field.
+        """
+        if "activity_type" not in data or data["activity_type"] is None:
+            raise ValueError(
+                "Failed parsing raw activity data, `activity_type` is not present in fields"
+            )
+
+        if ActivityType.is_str_trade_activity(data["activity_type"]):
+            return TypeAdapter(TradeActivity).validate_python(data)
+        else:
+            return TypeAdapter(NonTradeActivity).validate_python(data)
 
     # ############################## WATCHLIST ################################# #
 

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -8,6 +8,7 @@ from alpaca.common.enums import Sort
 from alpaca.common.models import ModelWithID
 from alpaca.common.requests import NonEmptyRequest
 from alpaca.trading.enums import (
+    ActivityType,
     AssetClass,
     AssetExchange,
     AssetStatus,
@@ -611,3 +612,57 @@ class GetOptionContractsRequest(NonEmptyRequest):
 
     limit: Optional[int] = None
     page_token: Optional[str] = None
+
+
+class GetAccountActivitiesRequest(NonEmptyRequest):
+    """
+    Represents the filtering values you can specify when getting AccountActivities.
+
+    Please see https://docs.alpaca.markets/reference/getaccountactivities for more information.
+
+    Attributes:
+        activity_types (Optional[List[ActivityType]]): A list of ActivityType's to filter results down to.
+        category (Optional[str]): The activity category. Cannot be used with 'activity_types' parameter.
+            Valid values are 'trade_activity' or 'non_trade_activity'.
+        date (Optional[date]): Filter activities by the activity date. Both formats YYYY-MM-DD and
+            YYYY-MM-DDTHH:MM:SSZ are supported.
+        until (Optional[datetime]): Get activities created before this date. Both formats YYYY-MM-DD and
+            YYYY-MM-DDTHH:MM:SSZ are supported.
+        after (Optional[datetime]): Get activities created after this date. Both formats YYYY-MM-DD and
+            YYYY-MM-DDTHH:MM:SSZ are supported.
+        direction (Optional[Sort]): The chronological order of response based on the activity datetime.
+            Defaults to desc.
+        page_size (Optional[int]): The maximum number of entries to return in the response.
+            Defaults to 100, maximum is 100.
+        page_token (Optional[str]): Token used for pagination. Provide the ID of the last activity from
+            the last page to retrieve the next set of results.
+    """
+
+    activity_types: Optional[List[ActivityType]] = None
+    category: Optional[str] = None
+    date: Optional[Union[date, datetime]] = None
+    until: Optional[datetime] = None
+    after: Optional[datetime] = None
+    direction: Optional[Sort] = None
+    page_size: Optional[int] = None
+    page_token: Optional[str] = None
+
+    @model_validator(mode="before")
+    def root_validator(cls, values: dict) -> dict:
+        activity_types = values.get("activity_types", None)
+        category = values.get("category", None)
+
+        if activity_types is not None and category is not None:
+            raise ValueError(
+                "Cannot specify both 'activity_types' and 'category' parameters."
+            )
+
+        if category is not None and category not in [
+            "trade_activity",
+            "non_trade_activity",
+        ]:
+            raise ValueError(
+                "category must be one of 'trade_activity' or 'non_trade_activity'."
+            )
+
+        return values

--- a/tests/trading/trading_client/test_account_activities_routes.py
+++ b/tests/trading/trading_client/test_account_activities_routes.py
@@ -1,0 +1,207 @@
+from typing import List
+
+from requests_mock import Mocker
+
+from alpaca.common.enums import BaseURL
+from alpaca.trading.client import TradingClient
+from alpaca.trading.enums import ActivityType
+from alpaca.trading.models import BaseActivity, NonTradeActivity, TradeActivity
+from alpaca.trading.requests import GetAccountActivitiesRequest
+
+
+def test_get_account_activities(reqmock: Mocker, trading_client: TradingClient):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/account/activities",
+        text="""
+        [
+          {
+            "id": "20220419000000000::fd84741b-59c5-4ddd-a303-69f70eb7753f",
+            "account_id": "aba134b6-217d-4fd2-b460-e3c80bbfb9b4",
+            "activity_type": "CSD",
+            "date": "2022-04-19",
+            "net_amount": "33324.35",
+            "description": "",
+            "status": "executed"
+          },
+          {
+            "id": "20220304095318500::092cd749-b783-49cb-a36e-4d8666be201f",
+            "account_id": "6e8cb861-e8b9-4278-8ed2-c8452535a165",
+            "activity_type": "FILL",
+            "transaction_time": "2022-03-04T14:53:18.500245Z",
+            "type": "fill",
+            "price": "2630.95",
+            "qty": "9",
+            "side": "buy",
+            "symbol": "GOOGL",
+            "leaves_qty": "0",
+            "order_id": "b677e464-c2d0-4fdd-a4b1-8830b386aa50",
+            "cum_qty": "10.177047834",
+            "order_status": "filled"
+          }
+        ]
+        """,
+    )
+
+    activities = trading_client.get_account_activities()
+
+    assert reqmock.called_once
+    assert isinstance(activities, List)
+    assert len(activities) == 2
+    assert isinstance(activities[0], NonTradeActivity)
+    assert isinstance(activities[1], TradeActivity)
+
+
+def test_get_account_activities_with_filter(
+    reqmock: Mocker, trading_client: TradingClient
+):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/account/activities",
+        text="""
+        [
+          {
+            "id": "20220304095318500::092cd749-b783-49cb-a36e-4d8666be201f",
+            "account_id": "6e8cb861-e8b9-4278-8ed2-c8452535a165",
+            "activity_type": "FILL",
+            "transaction_time": "2022-03-04T14:53:18.500245Z",
+            "type": "fill",
+            "price": "2630.95",
+            "qty": "9",
+            "side": "buy",
+            "symbol": "GOOGL",
+            "leaves_qty": "0",
+            "order_id": "b677e464-c2d0-4fdd-a4b1-8830b386aa50",
+            "cum_qty": "10.177047834",
+            "order_status": "filled"
+          }
+        ]
+        """,
+    )
+
+    filter = GetAccountActivitiesRequest(activity_types=[ActivityType.FILL])
+    activities = trading_client.get_account_activities(activity_filter=filter)
+
+    assert reqmock.called_once
+    assert isinstance(activities, List)
+    assert len(activities) == 1
+    assert isinstance(activities[0], TradeActivity)
+
+    # Verify activity_types was passed as comma-separated string
+    request = reqmock.request_history[0]
+    assert "activity_types" in request.qs
+    assert request.qs["activity_types"] == ["FILL"]
+
+
+def test_get_account_activities_by_type(
+    reqmock: Mocker, trading_client: TradingClient
+):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/account/activities/DIV",
+        text="""
+        [
+          {
+            "id": "20220419000000000::fd84741b-59c5-4ddd-a303-69f70eb7753f",
+            "account_id": "aba134b6-217d-4fd2-b460-e3c80bbfb9b4",
+            "activity_type": "DIV",
+            "date": "2022-04-19",
+            "net_amount": "100.00",
+            "description": "Dividend payment",
+            "status": "executed",
+            "symbol": "AAPL",
+            "qty": "10",
+            "per_share_amount": "10.00"
+          }
+        ]
+        """,
+    )
+
+    activities = trading_client.get_account_activities_by_type(ActivityType.DIV)
+
+    assert reqmock.called_once
+    assert isinstance(activities, List)
+    assert len(activities) == 1
+    assert isinstance(activities[0], NonTradeActivity)
+    assert activities[0].activity_type == ActivityType.DIV
+
+
+def test_get_account_activities_with_category(
+    reqmock: Mocker, trading_client: TradingClient
+):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/account/activities",
+        text="""
+        [
+          {
+            "id": "20220304095318500::092cd749-b783-49cb-a36e-4d8666be201f",
+            "account_id": "6e8cb861-e8b9-4278-8ed2-c8452535a165",
+            "activity_type": "FILL",
+            "transaction_time": "2022-03-04T14:53:18.500245Z",
+            "type": "fill",
+            "price": "2630.95",
+            "qty": "9",
+            "side": "buy",
+            "symbol": "GOOGL",
+            "leaves_qty": "0",
+            "order_id": "b677e464-c2d0-4fdd-a4b1-8830b386aa50",
+            "cum_qty": "10.177047834",
+            "order_status": "filled"
+          }
+        ]
+        """,
+    )
+
+    filter = GetAccountActivitiesRequest(category="trade_activity")
+    activities = trading_client.get_account_activities(activity_filter=filter)
+
+    assert reqmock.called_once
+    assert isinstance(activities, List)
+    assert len(activities) == 1
+    assert isinstance(activities[0], TradeActivity)
+
+    # Verify category was passed
+    request = reqmock.request_history[0]
+    assert "category" in request.qs
+    assert request.qs["category"] == ["trade_activity"]
+
+
+def test_get_account_activities_empty_response(
+    reqmock: Mocker, trading_client: TradingClient
+):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/account/activities",
+        text="[]",
+    )
+
+    activities = trading_client.get_account_activities()
+
+    assert reqmock.called_once
+    assert isinstance(activities, List)
+    assert len(activities) == 0
+
+
+def test_get_account_activities_raw_data(reqmock: Mocker):
+    trading_client = TradingClient(
+        api_key="key-id", secret_key="secret-key", paper=True, raw_data=True
+    )
+
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/account/activities",
+        text="""
+        [
+          {
+            "id": "20220419000000000::fd84741b-59c5-4ddd-a303-69f70eb7753f",
+            "account_id": "aba134b6-217d-4fd2-b460-e3c80bbfb9b4",
+            "activity_type": "CSD",
+            "date": "2022-04-19",
+            "net_amount": "33324.35",
+            "description": "",
+            "status": "executed"
+          }
+        ]
+        """,
+    )
+
+    activities = trading_client.get_account_activities()
+
+    assert reqmock.called_once
+    assert isinstance(activities, List)
+    assert isinstance(activities[0], dict)


### PR DESCRIPTION
## Summary

This PR adds the `get_account_activities()` and `get_account_activities_by_type()` methods to `TradingClient`, resolving issue #595.

The `get_activities()` functionality was available in the old SDK (alpaca-trade-api) but was missing in alpaca-py.

## Changes

### New Request Class: `GetAccountActivitiesRequest`

Added to `alpaca/trading/requests.py` with support for:
- `activity_types`: Filter by specific activity types (e.g., FILL, DIV, etc.)
- `category`: Filter by category (`trade_activity` or `non_trade_activity`)
- `date`: Filter by specific date
- `until`/`after`: Date range filtering
- `direction`: Sort order (asc/desc)
- `page_size`/`page_token`: Pagination support

### New Methods in `TradingClient`

1. **`get_account_activities(activity_filter=None)`**
   - Returns a list of account activities
   - Supports filtering via `GetAccountActivitiesRequest`
   - Returns mixed list of `TradeActivity` and `NonTradeActivity` objects

2. **`get_account_activities_by_type(activity_type, activity_filter=None)`**
   - Returns activities for a specific activity type
   - Uses the `/v2/account/activities/{activity_type}` endpoint

### Tests

Added comprehensive tests in `tests/trading/trading_client/test_account_activities_routes.py`:
- Test basic retrieval
- Test filtering by activity types
- Test filtering by category
- Test activity type-specific endpoint
- Test empty response handling
- Test raw data mode

## API Reference

Based on the OpenAPI spec: https://docs.alpaca.markets/reference/getaccountactivities

## Fixes

Closes #595