### PR TITLE
Handle timeout/cancellation gracefully in DataStream _run_forever

### DIFF
--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -348,6 +348,12 @@ class DataStream:
                 await self.close()
                 self._running = False
                 log.warning("data websocket error, restarting connection: " + str(wse))
+            except (asyncio.TimeoutError, TimeoutError) as te:
+                await self.close()
+                self._running = False
+                log.warning(
+                    "data websocket timeout, restarting connection: " + str(te)
+                )
             except ValueError as ve:
                 if "insufficient subscription" in str(ve):
                     await self.close()
@@ -355,6 +361,11 @@ class DataStream:
                     log.exception(f"error during websocket communication: {str(ve)}")
                     return
                 log.exception(f"error during websocket communication: {str(ve)}")
+            except asyncio.CancelledError:
+                await self.close()
+                self._running = False
+                log.info("data websocket task cancelled")
+                return
             except Exception as e:
                 log.exception(f"error during websocket communication: {str(e)}")
             finally:

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -351,9 +351,7 @@ class DataStream:
             except (asyncio.TimeoutError, TimeoutError) as te:
                 await self.close()
                 self._running = False
-                log.warning(
-                    "data websocket timeout, restarting connection: " + str(te)
-                )
+                log.warning("data websocket timeout, restarting connection: " + str(te))
             except ValueError as ve:
                 if "insufficient subscription" in str(ve):
                     await self.close()

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -363,7 +363,7 @@ class DataStream:
                 await self.close()
                 self._running = False
                 log.info("data websocket task cancelled")
-                return
+                raise
             except Exception as e:
                 log.exception(f"error during websocket communication: {str(e)}")
             finally:

--- a/tests/data/test_websockets.py
+++ b/tests/data/test_websockets.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime
+from unittest.mock import AsyncMock
 
 import pytest
 from msgpack.ext import Timestamp
@@ -254,7 +255,7 @@ async def test_run_forever_handles_timeout_without_traceback(
 
 
 @pytest.mark.asyncio
-async def test_run_forever_handles_cancelled_error_gracefully(
+async def test_run_forever_reraises_cancelled_error_and_cleans_up(
     ws_client: DataStream, caplog
 ):
     ws_client._handlers["trades"]["AAPL"] = object()
@@ -263,8 +264,12 @@ async def test_run_forever_handles_cancelled_error_gracefully(
         raise asyncio.CancelledError()
 
     ws_client._start_ws = _start_ws_cancelled
+    ws_client.close = AsyncMock()
 
     with caplog.at_level("INFO"):
-        await ws_client._run_forever()
+        with pytest.raises(asyncio.CancelledError):
+            await ws_client._run_forever()
 
+    ws_client.close.assert_awaited_once()
+    assert ws_client._running is False
     assert "data websocket task cancelled" in caplog.text

--- a/tests/data/test_websockets.py
+++ b/tests/data/test_websockets.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime
 
 import pytest
@@ -232,3 +233,38 @@ async def test_dispatch(ws_client: DataStream, timestamp: Timestamp):
     assert len(articles_b) == 1
     assert len(articles_star) == 2
     assert articles_star[1].headline == "c"
+
+
+@pytest.mark.asyncio
+async def test_run_forever_handles_timeout_without_traceback(
+    ws_client: DataStream, caplog
+):
+    ws_client._handlers["trades"]["AAPL"] = object()
+
+    async def _start_ws_timeout_once():
+        ws_client._should_run = False
+        raise TimeoutError("connect timeout")
+
+    ws_client._start_ws = _start_ws_timeout_once
+
+    with caplog.at_level("WARNING"):
+        await ws_client._run_forever()
+
+    assert "data websocket timeout, restarting connection" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_forever_handles_cancelled_error_gracefully(
+    ws_client: DataStream, caplog
+):
+    ws_client._handlers["trades"]["AAPL"] = object()
+
+    async def _start_ws_cancelled():
+        raise asyncio.CancelledError()
+
+    ws_client._start_ws = _start_ws_cancelled
+
+    with caplog.at_level("INFO"):
+        await ws_client._run_forever()
+
+    assert "data websocket task cancelled" in caplog.text


### PR DESCRIPTION
## Summary
- handle websocket connection timeouts as recoverable restart events in `DataStream._run_forever`
- handle `asyncio.CancelledError` explicitly to avoid uncaught task cancellation tracebacks
- add regression tests for timeout and cancellation paths

Fixes #643

## Validation
- `python3 -m pytest -q tests/data/test_websockets.py`
