### PR TITLE
fix: replace pytz with stdlib datetime.timezone

### DIFF
--- a/alpaca/data/requests.py
+++ b/alpaca/data/requests.py
@@ -1,7 +1,5 @@
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any, List, Optional, Union
-
-import pytz
 from pydantic import ConfigDict
 
 from alpaca.common.enums import Sort, SupportedCurrencies
@@ -47,7 +45,7 @@ class BaseTimeseriesDataRequest(NonEmptyRequest):
             and isinstance(data["start"], datetime)
             and data["start"].tzinfo is not None
         ):
-            data["start"] = data["start"].astimezone(pytz.utc).replace(tzinfo=None)
+            data["start"] = data["start"].astimezone(timezone.utc).replace(tzinfo=None)
 
         if (
             "end" in data
@@ -55,7 +53,7 @@ class BaseTimeseriesDataRequest(NonEmptyRequest):
             and isinstance(data["end"], datetime)
             and data["end"].tzinfo is not None
         ):
-            data["end"] = data["end"].astimezone(pytz.utc).replace(tzinfo=None)
+            data["end"] = data["end"].astimezone(timezone.utc).replace(tzinfo=None)
 
         super().__init__(**data)
 

--- a/tests/data/test_websockets.py
+++ b/tests/data/test_websockets.py
@@ -1,8 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from msgpack.ext import Timestamp
-from pytz import utc
 
 from alpaca.data.enums import Exchange
 from alpaca.data.models import Bar, Trade, News
@@ -136,7 +135,7 @@ def test_cast(ws_client: DataStream, raw_ws_client: DataStream, timestamp: Times
     assert cancel.exchange == "D"
     assert cancel.price == 36.18
 
-    created_at = datetime(2024, 6, 17, 14, 11, 0, tzinfo=utc)
+    created_at = datetime(2024, 6, 17, 14, 11, 0, tzinfo=timezone.utc)
     news = ws_client._cast(
         {
             "T": "n",


### PR DESCRIPTION
## Summary

- Replace `import pytz` with `from datetime import timezone` in `alpaca/data/requests.py`
- Replace `pytz.utc` with `timezone.utc` (available since Python 3.2, well within the project's `^3.8.0` requirement)
- Update `tests/data/test_websockets.py` to use `timezone.utc` as well
- `pytz` was imported but never listed in `[tool.poetry.dependencies]`, causing `ModuleNotFoundError` on clean installs

Fixes #644