### PR TITLE
fix: show NewsSet data in repr

### DIFF
--- a/alpaca/data/models/news.py
+++ b/alpaca/data/models/news.py
@@ -88,3 +88,9 @@ class NewsSet(BaseDataSet, TimeSeriesMixin):
         next_page_token = raw_data.get("next_page_token")
 
         super().__init__(data=parsed_news, next_page_token=next_page_token)
+
+    def __repr__(self) -> str:
+        import pprint
+
+        payload = {"data": self.dict(), "next_page_token": self.next_page_token}
+        return pprint.pformat(payload, indent=4)

--- a/alpaca/data/models/news.py
+++ b/alpaca/data/models/news.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from alpaca.common.models import ValidateBaseModel as BaseModel
 from alpaca.common.types import RawData
@@ -69,6 +69,7 @@ class NewsSet(BaseDataSet, TimeSeriesMixin):
         next_page_token (Optional[str]): The token to get the next page of data.
     """
 
+    data: Dict[str, List[News]] = {}
     next_page_token: Optional[str]
 
     def __init__(self, raw_data: RawData) -> None:
@@ -89,8 +90,3 @@ class NewsSet(BaseDataSet, TimeSeriesMixin):
 
         super().__init__(data=parsed_news, next_page_token=next_page_token)
 
-    def __repr__(self) -> str:
-        import pprint
-
-        payload = {"data": self.dict(), "next_page_token": self.next_page_token}
-        return pprint.pformat(payload, indent=4)

--- a/alpaca/data/models/news.py
+++ b/alpaca/data/models/news.py
@@ -89,4 +89,3 @@ class NewsSet(BaseDataSet, TimeSeriesMixin):
         next_page_token = raw_data.get("next_page_token")
 
         super().__init__(data=parsed_news, next_page_token=next_page_token)
-


### PR DESCRIPTION
## Summary
- type NewsSet `data` to align with other *Set models
- fix notebook display showing empty news items without custom repr

## Why
NewsSet notebook display showed `{}` for each news item even though `.data` was populated, which confused users.

## Change
Type `NewsSet.data` as `Dict[str, List[News]]` so `model_dump()`/repr includes nested news fields. This matches other dataset classes and keeps API/data unchanged.

## Before
```
{   'data': {   'news': [   {},
                            {},
                            {},
                            ...]},
    'next_page_token': None}
```

## After
`news_response` cell in Jupyter shows full article fields (headline, source, dates, etc.).

## Test plan
- [x] Verified in notebook: evaluating `news_response` now shows full fields