### PR TITLE
fix: add __contains__ to BaseDataSet

### DIFF
--- a/alpaca/data/models/base.py
+++ b/alpaca/data/models/base.py
@@ -65,6 +65,17 @@ class BaseDataSet(BaseModel):
 
         return self.data[symbol]
 
+    def __contains__(self, symbol: str) -> bool:
+        """Checks if data for the given symbol exists in the dataset.
+
+        Args:
+            symbol (str): The ticker identifier to check for.
+
+        Returns:
+            bool: True if the symbol has data in this dataset.
+        """
+        return symbol in self.data
+
     def dict(self, **kwargs) -> dict:
         """
         Gives dictionary representation of data.

--- a/tests/data/test_historical_stock_data.py
+++ b/tests/data/test_historical_stock_data.py
@@ -71,6 +71,9 @@ def test_get_bars(reqmock, stock_client: StockHistoricalDataClient):
     assert barset[symbol][0].open == 174
     assert barset[symbol][0].high == 174.84
 
+    assert symbol in barset
+    assert "NONEXISTENT" not in barset
+
     assert barset.df.index.nlevels == 2
 
     assert reqmock.called_once


### PR DESCRIPTION
## Summary
- Fixes #641 — `"SPY" in bars` returned `False` even when data exists
- Root cause: `BaseDataSet` defined `__getitem__` but not `__contains__`, so Python's default fallback iteration didn't work correctly
- Fix: added `__contains__` method to `BaseDataSet` that delegates to `self.data`, fixing it for all subclasses (`BarSet`, `QuoteSet`, `TradeSet`, `NewsSet`, `CorporateActionsSet`)

## Changes
- `alpaca/data/models/base.py` — added `__contains__` method
- `tests/data/test_historical_stock_data.py` — added assertions for `in` operator

## Test plan
- [x] All 56 data tests pass
- [x] `"SPY" in bars` now returns `True` when data exists
- [x] Black formatting clean