### PR TITLE
fix: add missing "other" value to DocumentType enum

### DIFF
--- a/alpaca/broker/enums.py
+++ b/alpaca/broker/enums.py
@@ -168,6 +168,7 @@ class DocumentType(str, Enum):
     SOCIAL_SECURITY_NUMBER_VERIFICATION = "social_security_number_verification"
     NULL = ""
     CIP_RESULT = "cip_result"
+    OTHER = "other"
 
 
 class AccountEntities(str, Enum):


### PR DESCRIPTION
## Summary
- The Alpaca Broker API returns `document_type: "other"` on some `AccountDocument` responses, which caused `list[AccountDocument]` validation to fail with:
  ```
  1 validation error for list[AccountDocument]
  0.document_type
  Input should be 'identity_verification', 'address_verification', ...
  [type=enum, input_value='other', input_type=str]
  ```
- Adds `OTHER = "other"` to `DocumentType` in `alpaca/broker/enums.py` so these responses deserialize cleanly.
- Same class of fix as #273 and #303, where the server-side enum had grown beyond what the SDK modeled — surfaces when calling endpoints like `get_account_by_id` on accounts that have an "other" document uploaded.

## Test plan
- [ ] `get_account_by_id` no longer raises `ValidationError` for accounts with an `"other"` document
- [ ] Existing `DocumentType` consumers (e.g. the W8BEN validator in `requests.py`) still behave the same — the new value isn't referenced by any branching logic
- [ ] `pytest tests/broker` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)