### PR TITLE
fix: correct regt buying power formula text

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -488,7 +488,7 @@ class TradeAccount(ModelWithID):
         buying_power (Optional[str]): Current available cash buying power. If multiplier = 2 then
           buying_power = max(equity-initial_margin(0) * 2). If multiplier = 1 then buying_power = cash.
         regt_buying_power (Optional[str]): User’s buying power under Regulation T
-          (excess equity - (equity - margin value) - * margin multiplier)
+          (excess equity - (equity - margin value) * margin multiplier)
         daytrading_buying_power (Optional[str]): The buying power for day trades for the account
         non_marginable_buying_power (Optional[str]): The non marginable buying power for the account
         cash (Optional[str]): Cash balance in the account

--- a/tests/trading/test_trading_models.py
+++ b/tests/trading/test_trading_models.py
@@ -10,7 +10,7 @@ from alpaca.trading.enums import (
     TimeInForce,
     TradeEvent,
 )
-from alpaca.trading.models import TradeUpdate
+from alpaca.trading.models import TradeAccount, TradeUpdate
 from alpaca.trading.requests import (
     LimitOrderRequest,
     MarketOrderRequest,
@@ -214,6 +214,14 @@ def test_mleg_options() -> None:
                     OptionLegRequest(symbol=symbols[0], ratio_qty=1, side=OrderSide.BUY)
                 ],
             )
+
+
+def test_trade_account_regt_buying_power_docstring_formula() -> None:
+    assert "- * margin multiplier" not in TradeAccount.__doc__
+    assert (
+        "(excess equity - (equity - margin value) * margin multiplier)"
+        in TradeAccount.__doc__
+    )
 
 
 def test_trade_update_events() -> None:


### PR DESCRIPTION
## Summary
- correct the `TradeAccount.regt_buying_power` formula text by removing the stray `-` before `* margin multiplier`
- add a focused regression test around the model docstring that feeds the generated API reference

## Why
The current docstring says `(excess equity - (equity - margin value) - * margin multiplier)`, which renders as a malformed formula in the SDK reference and matches #642.

Fixes #642.

## Verification
- RED: `python -m pytest tests/trading/test_trading_models.py -q -k regt_buying_power` failed on the existing `- * margin multiplier` text
- GREEN: `python -m pytest tests/trading/test_trading_models.py -q -k regt_buying_power` -> `1 passed, 5 deselected`
- `python -m pytest tests/trading/test_trading_models.py -q` -> `6 passed`
- `python -m black --check alpaca/trading/models.py tests/trading/test_trading_models.py`
- `git diff --check`