### PR TITLE
fix: extended_hours docstring type should be bool not float

### DIFF
--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -669,7 +669,7 @@ class OrderRequest(BaseOrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[float]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         take_profit (Optional[TakeProfitRequest]): For orders with multiple legs, an order to exit a profitable trade.
@@ -712,7 +712,7 @@ class MarketOrderRequest(BaseMarketOrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[float]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         take_profit (Optional[TakeProfitRequest]): For orders with multiple legs, an order to exit a profitable trade.
@@ -735,7 +735,7 @@ class LimitOrderRequest(BaseLimitOrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[float]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         take_profit (Optional[TakeProfitRequest]): For orders with multiple legs, an order to exit a profitable trade.
@@ -759,7 +759,7 @@ class StopOrderRequest(BaseStopOrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[float]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         take_profit (Optional[TakeProfitRequest]): For orders with multiple legs, an order to exit a profitable trade.
@@ -784,7 +784,7 @@ class StopLimitOrderRequest(BaseStopLimitOrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[float]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         take_profit (Optional[TakeProfitRequest]): For orders with multiple legs, an order to exit a profitable trade.
@@ -810,7 +810,7 @@ class TrailingStopOrderRequest(BaseTrailingStopOrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[float]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         take_profit (Optional[TakeProfitRequest]): For orders with multiple legs, an order to exit a profitable trade.

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -293,7 +293,7 @@ class OrderRequest(NonEmptyRequest):
         side (Optional[OrderSide]): Whether the order will buy or sell the asset. Either side or position_intent is required for all order classes other than mleg.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[str]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         legs (Optional[List[OptionLegRequest]]): For multi-leg option orders, the legs of the order If specified (must contain at least 2 but no more than 4 legs for options).
@@ -369,7 +369,7 @@ class MarketOrderRequest(OrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset. Required for all order classes other than mleg.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[str]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         legs (Optional[List[OptionLegRequest]]): For multi-leg option orders, the legs of the order. At most 4 legs are allowed for options.
@@ -396,7 +396,7 @@ class StopOrderRequest(OrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[str]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         legs (Optional[List[OptionLegRequest]]): For multi-leg option orders, the legs of the order. At most 4 legs are allowed for options.
@@ -427,7 +427,7 @@ class LimitOrderRequest(OrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[str]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         legs (Optional[List[OptionLegRequest]]): For multi-leg option orders, the legs of the order. At most 4 legs are allowed for options.
@@ -469,7 +469,7 @@ class StopLimitOrderRequest(OrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[str]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         legs (Optional[List[OptionLegRequest]]): For multi-leg option orders, the legs of the order. At most 4 legs are allowed for options.
@@ -504,7 +504,7 @@ class TrailingStopOrderRequest(OrderRequest):
         side (OrderSide): Whether the order will buy or sell the asset.
         type (OrderType): The execution logic type of the order (market, limit, etc).
         time_in_force (TimeInForce): The expiration logic of the order.
-        extended_hours (Optional[float]): Whether the order can be executed during regular market hours.
+        extended_hours (Optional[bool]): Whether the order can be executed during extended hours.
         client_order_id (Optional[str]): A string to identify which client submitted the order.
         order_class (Optional[OrderClass]): The class of the order. Simple orders have no other legs.
         legs (Optional[List[OptionLegRequest]]): For multi-leg option orders, the legs of the order. At most 4 legs are allowed for options.


### PR DESCRIPTION
## Summary
The `extended_hours` field in order request classes is typed as `Optional[bool]` in the actual field definition, but all of the docstrings across `alpaca/trading/requests.py` and `alpaca/broker/requests.py` incorrectly list it as `Optional[float]`. The description also said "during regular market hours" when it should say "during extended hours". This corrects the type annotation in the docstrings for all affected request classes.

## How to reproduce
Open `alpaca/trading/requests.py` and look at any `OrderRequest` subclass (e.g. `MarketOrderRequest`). The field is declared as `extended_hours: Optional[bool] = None` but the docstring attributes section lists `extended_hours (Optional[float])`.

## Test plan
Search for `extended_hours (Optional[` in both `alpaca/trading/requests.py` and `alpaca/broker/requests.py` and confirm all occurrences now read `Optional[bool]`.