### PR TITLE
feat: support Idempotency-Key header on BrokerClient writes

### DIFF
--- a/alpaca/broker/client.py
+++ b/alpaca/broker/client.py
@@ -120,6 +120,10 @@ from .requests import (
 )
 
 
+def _idempotency_headers(idempotency_key: Optional[str]) -> Optional[Dict[str, str]]:
+    return {"Idempotency-Key": idempotency_key} if idempotency_key else None
+
+
 class BrokerClient(RESTClient):
     """
     Client for accessing Broker API services
@@ -242,12 +246,15 @@ class BrokerClient(RESTClient):
     def create_account(
         self,
         account_data: CreateAccountRequest,
+        idempotency_key: Optional[str] = None,
     ) -> Union[Account, RawData]:
         """
         Create an account.
 
         Args:
             account_data (CreateAccountRequest): The data representing the Account you wish to create
+            idempotency_key (Optional[str]): If supplied, sent as the ``Idempotency-Key`` header so
+              that retried requests with the same key are deduplicated server-side.
 
         Returns:
             Account: The newly created Account instance as returned from the API. Should now have id
@@ -255,7 +262,9 @@ class BrokerClient(RESTClient):
         """
 
         data = account_data.to_request_fields()
-        response = self.post("/accounts", data)
+        response = self.post(
+            "/accounts", data, extra_headers=_idempotency_headers(idempotency_key)
+        )
 
         return Account(**response)
 
@@ -416,6 +425,7 @@ class BrokerClient(RESTClient):
         self,
         account_id: Union[UUID, str],
         document_data: List[Union[UploadDocumentRequest, UploadW8BenDocumentRequest]],
+        idempotency_key: Optional[str] = None,
     ) -> None:
         """
         Allows you to upload up to 10 documents at a time for an Account.
@@ -429,6 +439,8 @@ class BrokerClient(RESTClient):
             account_id (Union[UUID, str]): The id of the Account you wish to upload the document data to.
             document_data (List[UploadDocumentRequest]): List of UploadDocumentRequest's that contain the relevant
               Document data
+            idempotency_key (Optional[str]): If supplied, sent as the ``Idempotency-Key`` header so
+              that retried requests with the same key are deduplicated server-side.
 
         Returns:
             None: This function returns nothing on success and will raise an APIError in case of a failure
@@ -447,6 +459,7 @@ class BrokerClient(RESTClient):
         self.post(
             f"/accounts/{account_id}/documents/upload",
             [document.to_request_fields() for document in document_data],
+            extra_headers=_idempotency_headers(idempotency_key),
         )
 
     def get_trade_configuration_for_account(
@@ -800,6 +813,7 @@ class BrokerClient(RESTClient):
         self,
         account_id: Union[UUID, str],
         ach_data: Union[CreateACHRelationshipRequest, CreatePlaidRelationshipRequest],
+        idempotency_key: Optional[str] = None,
     ) -> Union[ACHRelationship, RawData]:
         """
         Creates a single ACH relationship for the given account.
@@ -808,6 +822,8 @@ class BrokerClient(RESTClient):
             account_id (Union[UUID, str]): The ID of the Account that has the ACH Relationship.
             ach_data (Union[CreateACHRelationshipRequest, CreatePlaidRelationshipRequest]): The request data used to
               create the ACH relationship.
+            idempotency_key (Optional[str]): If supplied, sent as the ``Idempotency-Key`` header so
+              that retried requests with the same key are deduplicated server-side.
 
         Returns:
             ACHRelationship: The ACH relationship that was created.
@@ -823,7 +839,9 @@ class BrokerClient(RESTClient):
             )
 
         response = self.post(
-            f"/accounts/{account_id}/ach_relationships", ach_data.to_request_fields()
+            f"/accounts/{account_id}/ach_relationships",
+            ach_data.to_request_fields(),
+            extra_headers=_idempotency_headers(idempotency_key),
         )
 
         if self._use_raw_data:
@@ -949,6 +967,7 @@ class BrokerClient(RESTClient):
         self,
         account_id: Union[UUID, str],
         transfer_data: Union[CreateACHTransferRequest, CreateBankTransferRequest],
+        idempotency_key: Optional[str] = None,
     ) -> Union[Transfer, RawData]:
         """
         Creates a single Transfer for the given account.
@@ -957,13 +976,17 @@ class BrokerClient(RESTClient):
             account_id (Union[UUID, str]): The ID of the Account to create the bank connection for.
             transfer_data (Union[CreateACHTransferRequest, CreateBankTransferRequest]): The request data used to
               create the bank connection.
+            idempotency_key (Optional[str]): If supplied, sent as the ``Idempotency-Key`` header so
+              that retried requests with the same key are deduplicated server-side.
 
         Returns:
             Transfer: The Transfer that was created.
         """
         account_id = validate_uuid_id_param(account_id)
         response = self.post(
-            f"/accounts/{account_id}/transfers", transfer_data.to_request_fields()
+            f"/accounts/{account_id}/transfers",
+            transfer_data.to_request_fields(),
+            extra_headers=_idempotency_headers(idempotency_key),
         )
 
         if self._use_raw_data:

--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -89,6 +89,7 @@ class RESTClient(ABC):
         data: Optional[Union[dict, str]] = None,
         base_url: Optional[Union[BaseURL, str]] = None,
         api_version: Optional[str] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> HTTPResult:
         """Prepares and submits HTTP requests to given API endpoint and returns response.
         Handles retrying if 429 (Rate Limit) error arises.
@@ -100,6 +101,8 @@ class RESTClient(ABC):
              of values to be converted to appropriate format based on `method`. Defaults to None.
             base_url (Optional[Union[BaseURL, str]]): The base URL of the API. Defaults to None.
             api_version (Optional[str]): The API version. Defaults to None.
+            extra_headers (Optional[Dict[str, str]]): Additional headers to merge onto the default
+             headers for this request. Useful for per-call headers such as ``Idempotency-Key``.
 
         Returns:
             HTTPResult: The response from the API
@@ -109,6 +112,8 @@ class RESTClient(ABC):
         url: str = base_url + "/" + version + path
 
         headers = self._get_default_headers()
+        if extra_headers:
+            headers.update(extra_headers)
 
         opts = {
             "headers": headers,
@@ -225,7 +230,10 @@ class RESTClient(ABC):
         return self._request("GET", path, data, **kwargs)
 
     def post(
-        self, path: str, data: Optional[Union[dict, List[dict]]] = None
+        self,
+        path: str,
+        data: Optional[Union[dict, List[dict]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> HTTPResult:
         """Performs a single POST request
 
@@ -233,37 +241,50 @@ class RESTClient(ABC):
             path (str): The API endpoint path
             data (Optional[Union[dict, List[dict]]): The json payload as a dict of values to be converted.
              Defaults to None.
+            extra_headers (Optional[Dict[str, str]]): Additional headers to merge onto the request.
 
         Returns:
             dict: The response
         """
-        return self._request("POST", path, data)
+        return self._request("POST", path, data, extra_headers=extra_headers)
 
-    def put(self, path: str, data: Optional[dict] = None) -> dict:
+    def put(
+        self,
+        path: str,
+        data: Optional[dict] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> dict:
         """Performs a single PUT request
 
         Args:
             path (str): The API endpoint path
             data (Optional[dict]): The json payload as a dict of values to be converted.
              Defaults to None.
+            extra_headers (Optional[Dict[str, str]]): Additional headers to merge onto the request.
 
         Returns:
             dict: The response
         """
-        return self._request("PUT", path, data)
+        return self._request("PUT", path, data, extra_headers=extra_headers)
 
-    def patch(self, path: str, data: Optional[dict] = None) -> dict:
+    def patch(
+        self,
+        path: str,
+        data: Optional[dict] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> dict:
         """Performs a single PATCH request
 
         Args:
             path (str): The API endpoint path
             data (Optional[dict]): The json payload as a dict of values to be converted.
              Defaults to None.
+            extra_headers (Optional[Dict[str, str]]): Additional headers to merge onto the request.
 
         Returns:
             dict: The response
         """
-        return self._request("PATCH", path, data)
+        return self._request("PATCH", path, data, extra_headers=extra_headers)
 
     def delete(self, path, data: Optional[Union[dict, str]] = None) -> dict:
         """Performs a single DELETE request

--- a/tests/broker/broker_client/test_accounts_routes.py
+++ b/tests/broker/broker_client/test_accounts_routes.py
@@ -25,6 +25,63 @@ from alpaca.trading.models import AccountConfiguration as TradeAccountConfigurat
 from tests.broker.factories import accounts as factory
 
 
+def test_create_account_forwards_idempotency_key(reqmock, client: BrokerClient):
+    reqmock.post(
+        "https://broker-api.sandbox.alpaca.markets/v1/accounts",
+        json={
+            "id": "0d969814-40d6-4b2b-99ac-2e37427f1ad2",
+            "account_number": "682389557",
+            "status": "SUBMITTED",
+            "crypto_status": "INACTIVE",
+            "currency": "USD",
+            "last_equity": "0",
+            "created_at": "2022-04-12T17:24:31.30283Z",
+            "contact": {
+                "email_address": "cool_alpaca@example.com",
+                "phone_number": "555-666-7788",
+                "street_address": ["20 N San Mateo Dr"],
+                "city": "San Mateo",
+                "state": "CA",
+                "postal_code": "94401",
+            },
+            "identity": {
+                "given_name": "John",
+                "family_name": "Doe",
+                "date_of_birth": "1990-01-01",
+                "tax_id_type": "USA_SSN",
+                "country_of_citizenship": "USA",
+                "country_of_birth": "USA",
+                "country_of_tax_residence": "USA",
+                "funding_source": ["employment_income"],
+            },
+            "disclosures": {
+                "is_control_person": False,
+                "is_affiliated_exchange_or_finra": False,
+                "is_politically_exposed": False,
+                "immediate_family_exposed": False,
+                "is_discretionary": False,
+            },
+            "agreements": [],
+            "account_type": "trading",
+        },
+    )
+
+    create_data = CreateAccountRequest(
+        agreements=factory.create_dummy_agreements(),
+        contact=factory.create_dummy_contact(),
+        disclosures=factory.create_dummy_disclosures(),
+        documents=factory.create_dummy_account_documents(),
+        identity=factory.create_dummy_identity(),
+    )
+
+    client.create_account(create_data, idempotency_key="acct-key-1")
+    client.create_account(create_data)
+
+    assert len(reqmock.request_history) == 2
+    assert reqmock.request_history[0].headers["Idempotency-Key"] == "acct-key-1"
+    assert "Idempotency-Key" not in reqmock.request_history[1].headers
+
+
 def test_create_account(reqmock, client: BrokerClient):
     created_id = "0d969814-40d6-4b2b-99ac-2e37427f1ad2"
 

--- a/tests/broker/broker_client/test_documents_routes.py
+++ b/tests/broker/broker_client/test_documents_routes.py
@@ -75,6 +75,36 @@ def test_get_trade_documents_for_account_validates_account_id(
         )
 
 
+def test_upload_documents_forwards_idempotency_key(reqmock, client: BrokerClient):
+    account_id = "2a87c088-ffb6-472b-a4a3-cd9305c8605c"
+    reqmock.post(
+        BaseURL.BROKER_SANDBOX.value + f"/v1/accounts/{account_id}/documents/upload",
+        json={},
+        status_code=202,
+    )
+
+    document_data = [
+        UploadDocumentRequest(
+            document_type=DocumentType.ACCOUNT_APPROVAL_LETTER,
+            content="fake base64",
+            mime_type=UploadDocumentMimeType.PDF,
+        )
+    ]
+
+    client.upload_documents_to_account(
+        account_id=account_id,
+        document_data=document_data,
+        idempotency_key="doc-key",
+    )
+    client.upload_documents_to_account(
+        account_id=account_id, document_data=document_data
+    )
+
+    assert len(reqmock.request_history) == 2
+    assert reqmock.request_history[0].headers["Idempotency-Key"] == "doc-key"
+    assert "Idempotency-Key" not in reqmock.request_history[1].headers
+
+
 def test_upload_documents_to_account(reqmock, client: BrokerClient):
     account_id = "2a87c088-ffb6-472b-a4a3-cd9305c8605c"
     reqmock.post(

--- a/tests/broker/broker_client/test_funding_routes.py
+++ b/tests/broker/broker_client/test_funding_routes.py
@@ -24,6 +24,79 @@ from alpaca.broker.requests import (
 from alpaca.common.enums import BaseURL, PaginationType
 
 
+def test_create_ach_relationship_forwards_idempotency_key(
+    reqmock, client: BrokerClient
+):
+    account_id = "2a87c088-ffb6-472b-a4a3-cd9305c8605c"
+    reqmock.post(
+        f"{BaseURL.BROKER_SANDBOX.value}/v1/accounts/{account_id}/ach_relationships",
+        json={
+            "id": "15ef9978-cb1e-4872-9565-bd0a720b8b76",
+            "account_id": account_id,
+            "created_at": "2022-04-14T15:51:14.523349Z",
+            "updated_at": "2022-04-14T15:51:14.523349Z",
+            "status": "QUEUED",
+            "account_owner_name": "John Doe",
+            "bank_account_type": "SAVINGS",
+            "bank_account_number": "123456789abc",
+            "bank_routing_number": "123456789",
+        },
+    )
+
+    ach_data = CreateACHRelationshipRequest(
+        account_owner_name="John Doe",
+        bank_account_type="SAVINGS",
+        bank_account_number="123456789abc",
+        bank_routing_number="123456789",
+    )
+    client.create_ach_relationship_for_account(
+        account_id, ach_data, idempotency_key="ach-rel-key"
+    )
+    client.create_ach_relationship_for_account(account_id, ach_data)
+
+    assert len(reqmock.request_history) == 2
+    assert reqmock.request_history[0].headers["Idempotency-Key"] == "ach-rel-key"
+    assert "Idempotency-Key" not in reqmock.request_history[1].headers
+
+
+def test_create_transfer_forwards_idempotency_key(reqmock, client: BrokerClient):
+    account_id = "2a87c088-ffb6-472b-a4a3-cd9305c8605c"
+    reqmock.post(
+        f"{BaseURL.BROKER_SANDBOX.value}/v1/accounts/{account_id}/transfers",
+        json={
+            "id": "be3c368a-4c7c-4384-808e-f02c9f5a8afe",
+            "relationship_id": "0f08c6bc-8e9f-463d-a73f-fd047fdb5e94",
+            "account_id": account_id,
+            "type": "ach",
+            "status": "COMPLETE",
+            "reason": None,
+            "amount": "498",
+            "direction": "INCOMING",
+            "created_at": "2021-05-05T07:55:31.190788Z",
+            "updated_at": "2021-05-05T08:13:33.029539Z",
+            "expires_at": "2021-05-12T07:55:31.190719Z",
+            "requested_amount": "500",
+            "fee": "2",
+            "fee_payment_method": "user",
+        },
+    )
+
+    transfer_data = CreateACHTransferRequest(
+        relationship_id="0f08c6bc-8e9f-463d-a73f-fd047fdb5e94",
+        amount="100.0",
+        direction=TransferDirection.INCOMING,
+        timing=TransferTiming.IMMEDIATE,
+    )
+    client.create_transfer_for_account(
+        account_id, transfer_data, idempotency_key="xfer-key"
+    )
+    client.create_transfer_for_account(account_id, transfer_data)
+
+    assert len(reqmock.request_history) == 2
+    assert reqmock.request_history[0].headers["Idempotency-Key"] == "xfer-key"
+    assert "Idempotency-Key" not in reqmock.request_history[1].headers
+
+
 def test_create_ach_relationship_for_account(reqmock, client: BrokerClient):
     account_id = "2a87c088-ffb6-472b-a4a3-cd9305c8605c"
 


### PR DESCRIPTION
## Summary

- Adds an optional `idempotency_key` kwarg to four `BrokerClient` write methods so retried requests can be safely deduplicated server-side: `create_account`, `create_ach_relationship_for_account`, `create_transfer_for_account`, and `upload_documents_to_account`.
- Threads a generic `extra_headers` kwarg through `RESTClient._request` and the `post`/`put`/`patch` helpers so future per-call header needs can reuse the same plumbing without re-widening the API.
- Header sent on the wire is exactly `Idempotency-Key`. When the kwarg is omitted, no header is added — fully backward compatible.

## Why these four methods

These are the broker POSTs most likely to need retry-safety in real callers: account creation (already a known 409-conflict pain point), ACH relationship creation, money movement (transfers), and document upload. Read-only endpoints and naturally-idempotent DELETEs are intentionally left alone.

## Public API additions

```python
broker_client.create_account(account_data, idempotency_key="...")
broker_client.create_ach_relationship_for_account(account_id, ach_data, idempotency_key="...")
broker_client.create_transfer_for_account(account_id, transfer_data, idempotency_key="...")
broker_client.upload_documents_to_account(account_id, document_data, idempotency_key="...")
```

API docs in `docs/api_reference/broker/{accounts,funding}.rst` use Sphinx `automethod`, so the new kwarg appears in the published reference automatically.

## Test plan

- [x] `python -m pytest` — 241/241 passing locally
- [x] `black --check` clean on all 5 modified files
- [x] Added header-forwarding tests for each of the four methods that assert:
  - `Idempotency-Key` header is present when the kwarg is set
  - `Idempotency-Key` header is absent when the kwarg is omitted
- [ ] CI lint/test/doc jobs to confirm in the project's pinned environment

## Notes

- Draft because we want to gather initial feedback before marking ready for review.
- The same `extra_headers` mechanism could be reused for `TradingClient.submit_order` and the broker journal endpoints (which Alpaca also documents as idempotent) in a follow-up if desired — plumbing is now in place; it's a one-line change per method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)