### PR TITLE
feat: add allium behavioral specs

### DIFF
--- a/.allium/broker-client.allium
+++ b/.allium/broker-client.allium
@@ -1,0 +1,1576 @@
+-- allium: 3
+-- broker-client.allium
+--
+-- B2B brokerage platform: a Correspondent (broker partner) onboards end users,
+-- holds and funds their BrokerageAccounts, journals assets between accounts,
+-- and optionally subscribes accounts to model portfolios that rebalance
+-- automatically. Trading mechanics (order placement, market data, corporate
+-- actions, activity streams) are deferred to the trading spec.
+--
+-- This spec captures behaviour from the correspondent's perspective. Most
+-- entity lifecycles (account review, transfer/journal clearing, rebalancing
+-- progression) are driven by the broker's internal operations; the client
+-- observes those states and acts on them but does not generally cause those
+-- transitions itself. Broker-driven transitions are modelled as opaque
+-- external stimuli so that the observable state space remains documented.
+--
+-- excluded: OAuth B2B integration flow (provided by a separate authorization
+--           service; not present in the surveyed code)
+-- excluded: order placement, positions, watchlists, calendar/clock, assets,
+--           corporate actions, account-activity streams (trading spec)
+
+------------------------------------------------------------
+-- External Entities
+------------------------------------------------------------
+
+external entity Correspondent {
+    -- B2B broker partner integrating with the brokerage platform to offer
+    -- accounts to its own end users
+    name: String
+}
+
+external entity AccountHolder {
+    -- Natural or legal person on whose behalf a brokerage account is held
+    contact_email: String
+}
+
+external entity KycProvider {
+    -- Third-party identity verification provider whose review outcomes the
+    -- correspondent submits as part of customer identification
+    name: String
+}
+
+external entity TradableSecurity {
+    -- A security held in journals, portfolio weights and rebalancing runs;
+    -- identified by its trading symbol
+    symbol: String
+}
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value PostalAddress {
+    street_address: List<String>
+    unit: String?
+    city: String
+    state: String?
+    postal_code: String?
+    country: String
+}
+
+value ContactDetails {
+    email_address: String
+    phone_number: String?
+    address: PostalAddress
+}
+
+value PersonalIdentity {
+    given_name: String
+    middle_name: String?
+    family_name: String
+    date_of_birth: String
+    country_of_tax_residence: String
+    country_of_citizenship: String?
+    country_of_birth: String?
+    tax_id: String?
+    tax_id_kind: String?
+    visa_kind: String?
+    visa_expiration_date: String?
+    permanent_resident: Boolean?
+    funding_sources: Set<FundingSource>
+}
+
+value RegulatoryDisclosures {
+    -- Disclosures the holder must affirm under broker-dealer regulations
+    is_control_person: Boolean
+    is_affiliated_exchange_or_finra: Boolean
+    is_politically_exposed: Boolean
+    immediate_family_exposed: Boolean
+    employment_status: EmploymentStatus?
+    employer_name: String?
+    employer_address: String?
+    employment_position: String?
+}
+
+value SignedAgreement {
+    -- An agreement the holder has electronically signed (margin, customer,
+    -- options, crypto, etc.)
+    kind: AgreementKind
+    signed_at: Timestamp
+    ip_address: String
+    revision: String?
+}
+
+value EmergencyContact {
+    -- Trusted contact the broker may reach if the holder cannot be reached
+    -- (regulatory requirement)
+    given_name: String
+    family_name: String
+    email_address: String?
+    phone_number: String?
+    address: PostalAddress?
+}
+
+value KycReviewOutcome {
+    -- Outcome of the customer identification review performed by a KYC provider
+    summary: KycSummary
+    additional_information: String?
+}
+
+value PortfolioWeight {
+    -- One target allocation in a model portfolio: either a security weight or
+    -- a residual cash weight
+    kind: WeightKind
+    symbol: String?
+    percent: Decimal
+}
+
+value RebalanceCondition {
+    -- When the rebalancer should re-evaluate a subscribed account: a
+    -- drift-band condition (target drift in percent) or a calendar cadence
+    kind: RebalanceConditionKind
+    drift_band_percent: Decimal?
+    calendar_cadence: CalendarCadence?
+}
+
+value JournalEntryRequest {
+    -- A single entry in a batch or reverse-batch journal request: identifies
+    -- one counterparty account and the amount of cash to journal
+    to_account: BrokerageAccount?
+    from_account: BrokerageAccount?
+    amount: Decimal
+    description: String?
+    transmitter_name: String?
+    transmitter_account_number: String?
+    transmitter_address: String?
+    transmitter_financial_institution: String?
+    transmitter_timestamp: String?
+}
+
+value AccountDocumentUpload {
+    -- A document the correspondent attaches to an application or upload
+    -- batch: identifies the document's kind for the broker's review
+    kind: AccountDocumentKind
+    sub_kind: String?
+}
+
+------------------------------------------------------------
+-- Enumerations
+------------------------------------------------------------
+
+enum AccountKind {
+    trading | custodial | donor_advised | ira | hsa
+}
+
+enum AccountSubKind {
+    traditional | roth
+}
+
+enum FundingSource {
+    employment_income | investments | inheritance
+    | business_income | savings | family
+}
+
+enum EmploymentStatus {
+    unemployed | employed | student | retired
+}
+
+enum AgreementKind {
+    margin | account | customer | crypto | options | custodial_customer
+}
+
+enum AccountDocumentKind {
+    identity_verification
+    | address_verification
+    | date_of_birth_verification
+    | tax_id_verification
+    | account_approval_letter
+    | limited_trading_authorization
+    | w8ben
+    | social_security_number_verification
+    | cip_result
+    | other
+}
+
+enum TradeDocumentKind {
+    account_statement
+    | trade_confirmation
+    | tax_statement
+    | account_application
+}
+
+enum KycSummary {
+    pass | fail | indeterminate
+}
+
+enum BankAccountKind {
+    checking | savings
+}
+
+enum BankIdentifierKind {
+    -- Routing identifier scheme: ABA for US domestic, BIC for international
+    aba | bic
+}
+
+enum TransferKind {
+    ach | wire
+}
+
+enum TransferDirection {
+    incoming | outgoing
+}
+
+enum FeePayer {
+    user | invoice
+}
+
+enum JournalKind {
+    cash | security
+}
+
+enum WeightKind {
+    cash | asset
+}
+
+enum RebalanceConditionKind {
+    drift_band | calendar
+}
+
+enum CalendarCadence {
+    weekly | monthly | quarterly | annually
+}
+
+enum RebalancingRunKind {
+    full_rebalance | invest_cash
+}
+
+enum RebalancingRunInitiator {
+    system | api
+}
+
+enum CryptoStatus {
+    signed_up | approval_pending | active | rejected | disabled
+}
+
+------------------------------------------------------------
+-- Entities and Variants
+------------------------------------------------------------
+
+entity BrokerageAccount {
+    -- An end-user account opened by a correspondent. The correspondent owns
+    -- the relationship with the holder; the broker owns the account's
+    -- regulatory lifecycle.
+    correspondent: Correspondent
+    holder: AccountHolder
+    kind: AccountKind
+    sub_kind: AccountSubKind?
+
+    -- Broker-assigned once the application is accepted into the pipeline
+    account_number: String?
+
+    -- Identity package: collected on application, may be partially updated
+    -- afterwards while the account remains open
+    contact: ContactDetails
+    identity: PersonalIdentity
+    disclosures: RegulatoryDisclosures
+    agreements: Set<SignedAgreement>
+    trusted_contact: EmergencyContact?
+
+    -- Current outcome of identity verification, if any has been recorded
+    kyc_review: KycReviewOutcome?
+
+    -- The status space the correspondent observes through the API. The
+    -- broker drives transitions between most of these values; the
+    -- correspondent only directly causes `submitted` (on application) and
+    -- `account_closed` (on close).
+    status: submitted
+            | action_required
+            | approval_pending
+            | aml_review
+            | approved
+            | active
+            | limited
+            | paper_only
+            | rejected
+            | disabled
+            | inactive
+            | account_closed
+
+    -- Independent crypto-trading authorisation; absent when not enabled
+    crypto_status: CryptoStatus?
+
+    created_at: Timestamp
+
+    -- Related collections
+    account_documents: AccountDocument with account = this
+    trade_documents: TradeDocument with account = this
+    cip_submissions: CipSubmission with account = this
+    ach_relationships: AchRelationship with account = this
+    recipient_banks: RecipientBank with account = this
+    transfers: Transfer with account = this
+    outgoing_journals: Journal with from_account = this
+    incoming_journals: Journal with to_account = this
+    subscriptions: AccountSubscription with account = this
+    rebalancing_runs: RebalancingRun with account = this
+}
+
+entity AccountDocument {
+    -- A holder-supplied document attached to the account (identity proof,
+    -- address proof, W-8BEN, etc.) used during onboarding and CIP
+    account: BrokerageAccount
+    kind: AccountDocumentKind
+    sub_kind: String?
+    uploaded_at: Timestamp
+}
+
+entity TradeDocument {
+    -- A broker-generated document about trading activity on the account
+    -- (account statement, trade confirmation, tax statement). Available for
+    -- download by the correspondent.
+    account: BrokerageAccount
+    name: String
+    kind: TradeDocumentKind
+    generated_for_date: Timestamp
+}
+
+entity CipSubmission {
+    -- A customer-identification report submitted by the correspondent against
+    -- an account. Bundles KYC findings, document checks, photo comparison,
+    -- identity-source lookups and watchlist results from a KYC provider.
+    account: BrokerageAccount
+    providers: Set<KycProvider>
+    submitted_at: Timestamp
+    updated_at: Timestamp
+}
+
+entity AchRelationship {
+    -- A linked US bank account used for ACH deposits and withdrawals. The
+    -- correspondent submits it; the broker validates and approves it; the
+    -- correspondent may unlink it.
+    account: BrokerageAccount
+    nickname: String?
+    bank_account_kind: BankAccountKind
+    status: queued | pending | approved | canceled
+}
+
+entity RecipientBank {
+    -- A linked external bank used as the destination for outbound wire
+    -- transfers (or origin for inbound, for international accounts)
+    account: BrokerageAccount
+    name: String
+    identifier_kind: BankIdentifierKind
+    address: PostalAddress?
+    status: queued | sent_to_clearing | approved | canceled
+}
+
+entity Transfer {
+    -- Money moving between an account and the outside world (an ACH bank
+    -- relationship or a recipient wire bank). The funding source determines
+    -- whether the transfer is ACH or wire. The broker (with its clearing
+    -- counterparty) drives the transfer's progression through clearing;
+    -- the correspondent requests transfers and may cancel them prior to
+    -- clearing.
+    account: BrokerageAccount
+    kind: TransferKind
+    direction: TransferDirection
+    amount: Decimal
+    requested_amount: Decimal?
+    fee: Decimal?
+    fee_payer: FeePayer?
+    reason: String?
+    ach_source: AchRelationship?
+    wire_source: RecipientBank?
+    requested_at: Timestamp
+    expires_at: Timestamp?
+    status: queued
+            | approval_pending
+            | pending
+            | sent_to_clearing
+            | approved
+            | settled
+            | complete
+            | rejected
+            | canceled
+            | returned
+
+    invariant FundingSourceMatchesKind {
+        kind = ach implies ach_source != null and wire_source = null
+    }
+
+    invariant WireSourceMatchesKind {
+        kind = wire implies wire_source != null and ach_source = null
+    }
+}
+
+entity Journal {
+    -- An internal transfer of cash or securities between two brokerage
+    -- accounts at this broker. Journals are off-market: they never touch
+    -- external rails, but still flow through clearing.
+    from_account: BrokerageAccount
+    to_account: BrokerageAccount
+    kind: JournalKind
+    -- Cash journal payload
+    cash_amount: Decimal?
+    base_currency: String?
+    -- Security journal payload
+    security: TradableSecurity?
+    quantity: Decimal?
+    price: Decimal?
+    -- Travel-rule fields (required by FinCEN for cash journals over the
+    -- regulatory threshold)
+    transmitter_name: String?
+    transmitter_account_number: String?
+    transmitter_address: String?
+    transmitter_financial_institution: String?
+    transmitter_timestamp: String?
+    description: String?
+    settle_date: Timestamp?
+    system_date: Timestamp?
+    error_message: String?
+    requested_at: Timestamp
+    status: queued
+            | sent_to_clearing
+            | pending
+            | executed
+            | correct
+            | rejected
+            | canceled
+            | refused
+            | deleted
+
+    invariant CashJournalPayload {
+        kind = cash implies cash_amount != null and security = null and quantity = null
+    }
+
+    invariant SecurityJournalPayload {
+        kind = security implies security != null and quantity != null and cash_amount = null
+    }
+
+    invariant DistinctParties {
+        from_account != to_account
+    }
+}
+
+entity ModelPortfolio {
+    -- A target allocation across securities and cash, defined by the
+    -- correspondent and reused across many subscribed accounts. When weights
+    -- or conditions change, subscribed accounts are re-evaluated for
+    -- rebalance at the next opportunity (subject to portfolio cooldown).
+    correspondent: Correspondent
+    name: String
+    description: String
+    weights: List<PortfolioWeight>
+    cooldown_days: Integer
+    rebalance_conditions: Set<RebalanceCondition>
+    status: active | inactive | needs_adjustment
+    created_at: Timestamp
+    updated_at: Timestamp
+
+    subscriptions: AccountSubscription with portfolio = this
+    runs: RebalancingRun with portfolio = this
+
+    @guidance
+        -- Weight percent values are expected to sum to 100%; the broker
+        -- normalises any rounding before placing rebalance orders. Stated
+        -- here as guidance rather than as a strict invariant because the
+        -- normalised representation is not surfaced to the correspondent.
+}
+
+entity AccountSubscription {
+    -- Records that a BrokerageAccount has elected to be rebalanced to a
+    -- ModelPortfolio's target weights. The brokerage produces rebalancing
+    -- runs against subscribed accounts when conditions are met.
+    account: BrokerageAccount
+    portfolio: ModelPortfolio
+    created_at: Timestamp
+    last_rebalanced_at: Timestamp?
+}
+
+entity RebalancingRun {
+    -- An attempt to bring a subscribed account's holdings in line with its
+    -- portfolio's target weights. May be triggered by a rebalance condition,
+    -- a portfolio update, or a manual run requested by the correspondent.
+    -- The broker drives the run's progression; the correspondent may cancel
+    -- a run before or during execution.
+    account: BrokerageAccount
+    portfolio: ModelPortfolio
+    kind: RebalancingRunKind
+    initiator: RebalancingRunInitiator?
+    weights: List<PortfolioWeight>
+    amount: Decimal?
+    reason: String?
+    created_at: Timestamp
+    updated_at: Timestamp
+    completed_at: Timestamp?
+    canceled_at: Timestamp?
+    status: queued
+            | in_progress
+            | canceled
+            | canceled_mid_run
+            | error
+            | timeout
+            | completed_success
+            | completed_adjusted
+}
+
+------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    -- Account application bundle size: how many supporting documents may
+    -- accompany a single application or be uploaded in one batch
+    max_documents_per_upload: Integer = 10
+
+    -- Cash journal threshold above which travel-rule transmitter fields must
+    -- be supplied (FinCEN obligation; expressed as the regulatory minimum)
+    travel_rule_threshold_amount: Decimal = 3000
+}
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+-- ##### Account lifecycle ##### --
+
+rule SubmitAccountApplication {
+    -- A correspondent submits a complete application bundle for a new
+    -- account on behalf of an end user, including contact, identity,
+    -- disclosures and signed agreements. The account enters the broker's
+    -- review pipeline.
+    when: SubmitAccountApplication(
+        correspondent,
+        holder,
+        kind,
+        sub_kind?,
+        contact,
+        identity,
+        disclosures,
+        agreements,
+        trusted_contact?,
+        supporting_documents?
+    )
+    requires: agreements.count > 0
+    ensures:
+        let account = BrokerageAccount.created(
+            correspondent: correspondent,
+            holder: holder,
+            kind: kind,
+            sub_kind: sub_kind,
+            contact: contact,
+            identity: identity,
+            disclosures: disclosures,
+            agreements: agreements,
+            trusted_contact: trusted_contact,
+            status: submitted,
+            created_at: now
+        )
+        for document in supporting_documents:
+            AccountDocument.created(
+                account: account,
+                kind: document.kind,
+                sub_kind: document.sub_kind,
+                uploaded_at: now
+            )
+}
+
+rule UpdateAccountInformation {
+    -- A correspondent updates a mutable subset of an open account's identity
+    -- package (contact, partial identity, disclosures, trusted contact).
+    -- Permitted only while the account is open; a closed account cannot
+    -- be edited.
+    when: UpdateAccountInformation(
+        correspondent,
+        account,
+        contact?,
+        identity?,
+        disclosures?,
+        trusted_contact?
+    )
+    requires: account.correspondent = correspondent
+    requires: account.status != account_closed
+    ensures:
+        if contact != null:
+            account.contact = contact
+        if identity != null:
+            account.identity = identity
+        if disclosures != null:
+            account.disclosures = disclosures
+        if trusted_contact != null:
+            account.trusted_contact = trusted_contact
+}
+
+rule UploadAccountDocuments {
+    -- The correspondent uploads one or more supporting documents (identity
+    -- verification, address proof, W-8BEN, etc.) for an open account. The
+    -- batch is capped to prevent oversized uploads.
+    when: UploadAccountDocuments(correspondent, account, documents)
+    requires: account.correspondent = correspondent
+    requires: account.status != account_closed
+    requires: documents.count <= config.max_documents_per_upload
+    ensures:
+        for document in documents:
+            AccountDocument.created(
+                account: account,
+                kind: document.kind,
+                sub_kind: document.sub_kind,
+                uploaded_at: now
+            )
+}
+
+rule SubmitCipResults {
+    -- The correspondent submits the results of a customer-identification
+    -- review performed by a KYC provider (or stack of providers). The
+    -- broker consumes these to advance the account through approval.
+    when: SubmitCipResults(correspondent, account, providers, review)
+    requires: account.correspondent = correspondent
+    requires: account.status in {submitted, action_required, aml_review, approval_pending}
+    ensures:
+        CipSubmission.created(
+            account: account,
+            providers: providers,
+            submitted_at: now,
+            updated_at: now
+        )
+        account.kyc_review = review
+}
+
+rule CloseAccount {
+    -- The correspondent closes an open account. Closing presumes positions
+    -- are flat and cash has been withdrawn; that gating lives upstream in
+    -- the trading and funding flows. Here we model the closure itself.
+    when: CloseAccount(correspondent, account)
+    requires: account.correspondent = correspondent
+    requires: account.status in {active, limited, paper_only, disabled, inactive, approved}
+    ensures: account.status = account_closed
+
+    @guidance
+        -- The underlying records of a closed account are retained for
+        -- regulatory recordkeeping; closure is a status change, not a delete.
+}
+
+-- ##### Broker-side account lifecycle (observed by the correspondent) ##### --
+
+rule BrokerProgressesAccountReview {
+    -- The broker accepts an application into its review pipeline after
+    -- initial pre-checks. Modelled as an opaque external stimulus because
+    -- the broker's decision logic is internal to it.
+    when: BrokerProgressedAccountReview(account)
+    requires: account.status = submitted
+    ensures: account.status = approval_pending
+}
+
+rule BrokerRequestsAccountAction {
+    -- The broker pauses review and asks the correspondent to supply
+    -- additional information or correct an earlier submission.
+    when: BrokerRequestedAccountAction(account)
+    requires: account.status in {submitted, approval_pending, aml_review}
+    ensures: account.status = action_required
+}
+
+rule BrokerEscalatesAccountForAmlReview {
+    -- The broker escalates an account for enhanced anti-money-laundering
+    -- review.
+    when: BrokerEscalatedAccountForAmlReview(account)
+    requires: account.status in {submitted, approval_pending, action_required}
+    ensures: account.status = aml_review
+}
+
+rule BrokerApprovesAccount {
+    -- The broker concludes its review and approves the account for funding
+    -- (but not yet for trading).
+    when: BrokerApprovedAccount(account)
+    requires: account.status in {submitted, approval_pending, action_required, aml_review}
+    ensures: account.status = approved
+}
+
+rule BrokerActivatesAccount {
+    -- The broker activates an approved account for trading, or restores a
+    -- previously-restricted account.
+    when: BrokerActivatedAccount(account)
+    requires: account.status in {approved, limited, paper_only, disabled, inactive}
+    ensures: account.status = active
+}
+
+rule BrokerLimitsAccount {
+    -- The broker restricts an account's trading authority (no new orders
+    -- or no opening positions, for example).
+    when: BrokerLimitedAccount(account)
+    requires: account.status in {active, approved}
+    ensures: account.status = limited
+}
+
+rule BrokerSetsAccountPaperOnly {
+    -- The broker restricts an account to paper trading.
+    when: BrokerSetAccountPaperOnly(account)
+    requires: account.status in {approved, active}
+    ensures: account.status = paper_only
+}
+
+rule BrokerInactivatesAccount {
+    -- The broker marks an account inactive due to dormancy or operational
+    -- reasons short of disabling it.
+    when: BrokerInactivatedAccount(account)
+    requires: account.status in {active, limited}
+    ensures: account.status = inactive
+}
+
+rule BrokerDisablesAccount {
+    -- The broker disables an account, blocking transactions while keeping
+    -- the account record intact.
+    when: BrokerDisabledAccount(account)
+    requires: account.status in {active, limited, inactive}
+    ensures: account.status = disabled
+}
+
+rule BrokerRejectsAccount {
+    -- The broker rejects an account application outright.
+    when: BrokerRejectedAccount(account)
+    requires: account.status in {submitted, approval_pending, action_required, aml_review}
+    ensures: account.status = rejected
+}
+
+-- ##### Funding sources: ACH ##### --
+
+rule EstablishAchRelationship {
+    -- Link a US bank account to a brokerage account so it can serve as a
+    -- source or destination for ACH transfers. Either direct entry of
+    -- routing and account numbers, or via a Plaid-supplied processor token.
+    when: EstablishAchRelationship(
+        correspondent,
+        account,
+        owner_name,
+        bank_account_kind,
+        bank_account_number?,
+        bank_routing_number?,
+        plaid_processor_token?,
+        nickname?
+    )
+    requires: account.correspondent = correspondent
+    requires: account.status in {approved, active, limited, paper_only}
+    requires:
+        (bank_account_number != null and bank_routing_number != null)
+        or plaid_processor_token != null
+    ensures:
+        AchRelationship.created(
+            account: account,
+            nickname: nickname,
+            bank_account_kind: bank_account_kind,
+            status: queued
+        )
+}
+
+rule RemoveAchRelationship {
+    -- The correspondent unlinks an ACH relationship from an account. The
+    -- relationship enters a canceled terminal state; outstanding transfers
+    -- that already reference it are unaffected.
+    when: RemoveAchRelationship(correspondent, account, relationship)
+    requires: account.correspondent = correspondent
+    requires: relationship.account = account
+    requires: relationship.status != canceled
+    ensures: relationship.status = canceled
+}
+
+rule BrokerApprovesAchRelationship {
+    -- The broker validates the linked bank account (penny verification or
+    -- equivalent) and approves it for ACH transfers.
+    when: BrokerApprovedAchRelationship(relationship)
+    requires: relationship.status in {queued, pending}
+    ensures: relationship.status = approved
+}
+
+rule BrokerMarksAchRelationshipPending {
+    -- The broker accepts the relationship for validation but verification
+    -- is still pending.
+    when: BrokerMarkedAchRelationshipPending(relationship)
+    requires: relationship.status = queued
+    ensures: relationship.status = pending
+}
+
+-- ##### Funding sources: wire ##### --
+
+rule RegisterRecipientBank {
+    -- Link an external bank as a destination for outgoing wire transfers
+    -- (or as a permitted source for incoming international wires). Domestic
+    -- banks are identified by ABA routing number; international by BIC
+    -- plus the bank's postal address.
+    when: RegisterRecipientBank(
+        correspondent,
+        account,
+        name,
+        identifier_kind,
+        bank_code,
+        bank_account_number,
+        address?
+    )
+    requires: account.correspondent = correspondent
+    requires: account.status in {approved, active, limited}
+    requires: identifier_kind = bic implies address != null
+    requires: identifier_kind = aba implies address = null
+    ensures:
+        RecipientBank.created(
+            account: account,
+            name: name,
+            identifier_kind: identifier_kind,
+            address: address,
+            status: queued
+        )
+}
+
+rule RemoveRecipientBank {
+    -- The correspondent unlinks a recipient wire bank.
+    when: RemoveRecipientBank(correspondent, account, bank)
+    requires: account.correspondent = correspondent
+    requires: bank.account = account
+    requires: bank.status != canceled
+    ensures: bank.status = canceled
+}
+
+rule BrokerSendsRecipientBankToClearing {
+    -- The broker submits a newly registered recipient bank to its clearing
+    -- counterparty for validation.
+    when: BrokerSentRecipientBankToClearing(bank)
+    requires: bank.status = queued
+    ensures: bank.status = sent_to_clearing
+}
+
+rule BrokerApprovesRecipientBank {
+    -- The clearing counterparty confirms the recipient bank's details, and
+    -- the broker approves it for wire transfers.
+    when: BrokerApprovedRecipientBank(bank)
+    requires: bank.status = sent_to_clearing
+    ensures: bank.status = approved
+}
+
+-- ##### Transfers ##### --
+
+rule RequestAchTransfer {
+    -- Move money in or out of an account over ACH using an approved
+    -- relationship. Wire-specific details (recipient bank) are not used.
+    when: RequestAchTransfer(
+        correspondent,
+        account,
+        relationship,
+        direction,
+        amount,
+        fee_payer?
+    )
+    requires: account.correspondent = correspondent
+    requires: relationship.account = account
+    requires: relationship.status = approved
+    requires: amount > 0
+    requires: account.status in {approved, active, limited, paper_only}
+    ensures:
+        Transfer.created(
+            account: account,
+            kind: ach,
+            direction: direction,
+            amount: amount,
+            requested_amount: amount,
+            fee_payer: fee_payer,
+            ach_source: relationship,
+            requested_at: now,
+            status: queued
+        )
+}
+
+rule RequestWireTransfer {
+    -- Move money in or out of an account over wire, against a registered
+    -- recipient bank. Optional additional information (memo, reference) is
+    -- forwarded with the wire instruction.
+    when: RequestWireTransfer(
+        correspondent,
+        account,
+        bank,
+        direction,
+        amount,
+        fee_payer?,
+        additional_information?
+    )
+    requires: account.correspondent = correspondent
+    requires: bank.account = account
+    requires: bank.status = approved
+    requires: amount > 0
+    requires: account.status in {approved, active, limited, paper_only}
+    ensures:
+        Transfer.created(
+            account: account,
+            kind: wire,
+            direction: direction,
+            amount: amount,
+            requested_amount: amount,
+            fee_payer: fee_payer,
+            wire_source: bank,
+            requested_at: now,
+            status: queued
+        )
+}
+
+rule CancelTransfer {
+    -- The correspondent cancels a transfer that has not yet been sent to
+    -- clearing. After clearing has been notified, cancellation is no longer
+    -- possible — the clearing counterparty owns the lifecycle from there.
+    when: CancelTransfer(correspondent, account, transfer)
+    requires: account.correspondent = correspondent
+    requires: transfer.account = account
+    requires: transfer.status in {queued, approval_pending, pending}
+    ensures: transfer.status = canceled
+}
+
+rule BrokerHoldsTransferForApproval {
+    -- The broker holds a transfer for manual approval (e.g. an outgoing
+    -- transfer above an internal threshold).
+    when: BrokerHeldTransferForApproval(transfer)
+    requires: transfer.status = queued
+    ensures: transfer.status = approval_pending
+}
+
+rule BrokerApprovesTransferForClearing {
+    -- The broker accepts a transfer (or finishes its hold review) and
+    -- queues it for submission to the clearing counterparty.
+    when: BrokerApprovedTransferForClearing(transfer)
+    requires: transfer.status in {queued, approval_pending}
+    ensures: transfer.status = pending
+}
+
+rule BrokerSendsTransferToClearing {
+    -- The broker hands the transfer to its clearing counterparty.
+    when: BrokerSentTransferToClearing(transfer)
+    requires: transfer.status = pending
+    ensures: transfer.status = sent_to_clearing
+}
+
+rule BrokerMarksTransferApproved {
+    -- The clearing counterparty has accepted the instruction.
+    when: BrokerMarkedTransferApproved(transfer)
+    requires: transfer.status = sent_to_clearing
+    ensures: transfer.status = approved
+}
+
+rule BrokerSettlesTransfer {
+    -- The transfer settles at the clearing counterparty: funds have moved.
+    when: BrokerSettledTransfer(transfer)
+    requires: transfer.status = approved
+    ensures: transfer.status = settled
+}
+
+rule BrokerCompletesTransfer {
+    -- The broker finalises the transfer in its books after settlement.
+    when: BrokerCompletedTransfer(transfer)
+    requires: transfer.status = settled
+    ensures: transfer.status = complete
+}
+
+rule BrokerRejectsTransfer {
+    -- The broker rejects a transfer for compliance, balance or other
+    -- operational reasons before settlement.
+    when: BrokerRejectedTransfer(transfer)
+    requires: transfer.status in {queued, approval_pending, pending}
+    ensures: transfer.status = rejected
+}
+
+rule BrokerReturnsTransfer {
+    -- The transfer is returned by the receiving institution (insufficient
+    -- funds, account closed at the counterparty, etc.).
+    when: BrokerReturnedTransfer(transfer)
+    requires: transfer.status in {sent_to_clearing, approved, settled}
+    ensures: transfer.status = returned
+}
+
+-- ##### Journals ##### --
+
+rule RequestJournal {
+    -- The correspondent journals cash or securities from one of its
+    -- accounts into another. For cash journals above the regulatory
+    -- travel-rule threshold, transmitter details must be supplied.
+    when: RequestJournal(
+        correspondent,
+        from_account,
+        to_account,
+        kind,
+        cash_amount?,
+        base_currency?,
+        security?,
+        quantity?,
+        price?,
+        description?,
+        transmitter_name?,
+        transmitter_account_number?,
+        transmitter_address?,
+        transmitter_financial_institution?,
+        transmitter_timestamp?
+    )
+    requires: from_account.correspondent = correspondent
+    requires: to_account.correspondent = correspondent
+    requires: from_account != to_account
+    requires: from_account.status in {active, limited}
+    requires: to_account.status in {approved, active, limited}
+    requires: kind = cash implies cash_amount != null and cash_amount > 0
+    requires: kind = security implies security != null and quantity != null and quantity > 0
+    requires:
+        kind = cash and cash_amount > config.travel_rule_threshold_amount
+            implies transmitter_name != null
+                    and transmitter_account_number != null
+                    and transmitter_address != null
+                    and transmitter_financial_institution != null
+                    and transmitter_timestamp != null
+    ensures:
+        Journal.created(
+            from_account: from_account,
+            to_account: to_account,
+            kind: kind,
+            cash_amount: cash_amount,
+            base_currency: base_currency,
+            security: security,
+            quantity: quantity,
+            price: price,
+            description: description,
+            transmitter_name: transmitter_name,
+            transmitter_account_number: transmitter_account_number,
+            transmitter_address: transmitter_address,
+            transmitter_financial_institution: transmitter_financial_institution,
+            transmitter_timestamp: transmitter_timestamp,
+            requested_at: now,
+            status: queued
+        )
+}
+
+rule RequestBatchJournal {
+    -- The correspondent journals cash out of one originating account into
+    -- many beneficiary accounts in a single request. Typically used to
+    -- distribute funds from a sweep firm account to many end-user accounts.
+    -- Each entry produces an independent journal whose lifecycle is tracked
+    -- separately; one bad entry does not roll back the others.
+    when: RequestBatchJournal(correspondent, from_account, entries)
+    requires: from_account.correspondent = correspondent
+    requires: entries.count > 0
+    ensures:
+        for entry in entries:
+            Journal.created(
+                from_account: from_account,
+                to_account: entry.to_account,
+                kind: cash,
+                cash_amount: entry.amount,
+                description: entry.description,
+                transmitter_name: entry.transmitter_name,
+                transmitter_account_number: entry.transmitter_account_number,
+                transmitter_address: entry.transmitter_address,
+                transmitter_financial_institution: entry.transmitter_financial_institution,
+                transmitter_timestamp: entry.transmitter_timestamp,
+                requested_at: now,
+                status: queued
+            )
+}
+
+rule RequestReverseBatchJournal {
+    -- The mirror of a batch journal: cash from many originating accounts
+    -- collected into a single beneficiary account (typically a sweep firm
+    -- account aggregating funds back from end users).
+    when: RequestReverseBatchJournal(correspondent, to_account, entries)
+    requires: to_account.correspondent = correspondent
+    requires: entries.count > 0
+    ensures:
+        for entry in entries:
+            Journal.created(
+                from_account: entry.from_account,
+                to_account: to_account,
+                kind: cash,
+                cash_amount: entry.amount,
+                description: entry.description,
+                transmitter_name: entry.transmitter_name,
+                transmitter_account_number: entry.transmitter_account_number,
+                transmitter_address: entry.transmitter_address,
+                transmitter_financial_institution: entry.transmitter_financial_institution,
+                transmitter_timestamp: entry.transmitter_timestamp,
+                requested_at: now,
+                status: queued
+            )
+}
+
+rule CancelJournal {
+    -- The correspondent cancels a journal that has not yet executed. After
+    -- execution the journal is final; remediation goes through a separate
+    -- correction or deletion path handled by the broker's operations team.
+    when: CancelJournal(correspondent, journal)
+    requires: journal.from_account.correspondent = correspondent
+    requires: journal.status in {queued, sent_to_clearing, pending}
+    ensures: journal.status = canceled
+}
+
+rule BrokerSendsJournalToClearing {
+    -- The broker hands a journal to clearing.
+    when: BrokerSentJournalToClearing(journal)
+    requires: journal.status = queued
+    ensures: journal.status = sent_to_clearing
+}
+
+rule BrokerMarksJournalPending {
+    -- Clearing acknowledges receipt of the journal.
+    when: BrokerMarkedJournalPending(journal)
+    requires: journal.status = sent_to_clearing
+    ensures: journal.status = pending
+}
+
+rule BrokerExecutesJournal {
+    -- Clearing books the journal: funds (or securities) have moved between
+    -- the two accounts.
+    when: BrokerExecutedJournal(journal)
+    requires: journal.status = pending
+    ensures: journal.status = executed
+}
+
+rule BrokerFinalisesJournal {
+    -- The broker marks an executed journal as correct, closing the entry.
+    when: BrokerFinalisedJournal(journal)
+    requires: journal.status = executed
+    ensures: journal.status = correct
+}
+
+rule BrokerRejectsJournal {
+    -- The broker rejects a journal before execution.
+    when: BrokerRejectedJournal(journal)
+    requires: journal.status in {queued, sent_to_clearing, pending}
+    ensures: journal.status = rejected
+}
+
+rule BrokerRefusesJournal {
+    -- The broker refuses a journal at intake (e.g. policy violation,
+    -- account state mismatch).
+    when: BrokerRefusedJournal(journal)
+    requires: journal.status = queued
+    ensures: journal.status = refused
+}
+
+rule BrokerDeletesJournal {
+    -- The broker reverses an executed journal as a corrective action by
+    -- operations.
+    when: BrokerDeletedJournal(journal)
+    requires: journal.status = executed
+    ensures: journal.status = deleted
+}
+
+-- ##### Portfolio rebalancing ##### --
+
+rule DefineModelPortfolio {
+    -- The correspondent publishes a model portfolio: a named target
+    -- allocation that subscribed accounts will be rebalanced to.
+    when: DefineModelPortfolio(
+        correspondent,
+        name,
+        description,
+        weights,
+        cooldown_days,
+        rebalance_conditions?
+    )
+    requires: weights.count > 0
+    requires: cooldown_days >= 0
+    ensures:
+        ModelPortfolio.created(
+            correspondent: correspondent,
+            name: name,
+            description: description,
+            weights: weights,
+            cooldown_days: cooldown_days,
+            rebalance_conditions: rebalance_conditions,
+            status: active,
+            created_at: now,
+            updated_at: now
+        )
+}
+
+rule UpdateModelPortfolio {
+    -- The correspondent updates a model portfolio. If weights or conditions
+    -- change, all subscribed accounts are re-evaluated for rebalancing at
+    -- the next opportunity, respecting the portfolio's cooldown.
+    when: UpdateModelPortfolio(
+        correspondent,
+        portfolio,
+        name?,
+        description?,
+        weights?,
+        cooldown_days?,
+        rebalance_conditions?
+    )
+    requires: portfolio.correspondent = correspondent
+    requires: portfolio.status in {active, needs_adjustment}
+    ensures:
+        if name != null:
+            portfolio.name = name
+        if description != null:
+            portfolio.description = description
+        if weights != null:
+            portfolio.weights = weights
+        if cooldown_days != null:
+            portfolio.cooldown_days = cooldown_days
+        if rebalance_conditions != null:
+            portfolio.rebalance_conditions = rebalance_conditions
+        portfolio.updated_at = now
+}
+
+rule InactivateModelPortfolio {
+    -- The correspondent retires a model portfolio. Only permitted when no
+    -- account is still subscribed to it. Inactive portfolios cannot be
+    -- linked in new subscriptions.
+    when: InactivateModelPortfolio(correspondent, portfolio)
+    requires: portfolio.correspondent = correspondent
+    requires: portfolio.subscriptions.count = 0
+    requires: portfolio.status != inactive
+    ensures: portfolio.status = inactive
+}
+
+rule BrokerFlagsPortfolioForAdjustment {
+    -- The broker flags a portfolio as needing adjustment, typically because
+    -- one of its weighted securities is no longer tradable or its weights
+    -- no longer sum to 100% after a corporate action. Drives downstream
+    -- re-evaluation by the correspondent.
+    when: BrokerFlaggedPortfolioForAdjustment(portfolio)
+    requires: portfolio.status = active
+    ensures: portfolio.status = needs_adjustment
+}
+
+rule SubscribeAccountToPortfolio {
+    -- An account is enrolled in a model portfolio. From that point on the
+    -- rebalancer treats the account's holdings as drift to be corrected.
+    when: SubscribeAccountToPortfolio(correspondent, account, portfolio)
+    requires: account.correspondent = correspondent
+    requires: portfolio.correspondent = correspondent
+    requires: account.status = active
+    requires: portfolio.status = active
+    requires: not exists AccountSubscription{account: account, portfolio: portfolio}
+    ensures:
+        AccountSubscription.created(
+            account: account,
+            portfolio: portfolio,
+            created_at: now
+        )
+}
+
+rule UnsubscribeAccount {
+    -- The correspondent removes an account's subscription. The rebalancer no
+    -- longer maintains target weights; in-flight runs are unaffected.
+    when: UnsubscribeAccount(correspondent, subscription)
+    requires: subscription.account.correspondent = correspondent
+    ensures: not exists subscription
+}
+
+rule RequestManualRebalancingRun {
+    -- The correspondent triggers an ad-hoc rebalance for one subscribed
+    -- account against one of its portfolios, optionally with custom weights
+    -- (e.g. to liquidate-and-reinvest on a specific cash event). The run
+    -- enters the queue alongside system-initiated runs.
+    when: RequestManualRebalancingRun(correspondent, subscription, kind, weights)
+    requires: subscription.account.correspondent = correspondent
+    requires: weights.count > 0
+    ensures:
+        RebalancingRun.created(
+            account: subscription.account,
+            portfolio: subscription.portfolio,
+            kind: kind,
+            initiator: api,
+            weights: weights,
+            created_at: now,
+            updated_at: now,
+            status: queued
+        )
+}
+
+rule CancelRebalancingRun {
+    -- The correspondent cancels a run before, during, or after it has
+    -- started placing orders. If orders have already been submitted, the
+    -- broker attempts to cancel them as well; the resulting state
+    -- distinguishes pre-execution cancellation (canceled) from
+    -- mid-execution (canceled_mid_run).
+    when: CancelRebalancingRun(correspondent, run)
+    requires: run.account.correspondent = correspondent
+    requires: run.status in {queued, in_progress}
+    ensures:
+        if run.status = queued:
+            run.status = canceled
+            run.canceled_at = now
+            run.updated_at = now
+        else:
+            run.status = canceled_mid_run
+            run.canceled_at = now
+            run.updated_at = now
+}
+
+rule BrokerStartsRebalancingRun {
+    -- The broker begins executing a queued rebalancing run by placing the
+    -- first orders.
+    when: BrokerStartedRebalancingRun(run)
+    requires: run.status = queued
+    ensures:
+        run.status = in_progress
+        run.updated_at = now
+}
+
+rule BrokerCompletesRebalancingRunSuccessfully {
+    -- The broker finishes the run with all target orders filled.
+    when: BrokerCompletedRebalancingRunSuccessfully(run)
+    requires: run.status = in_progress
+    ensures:
+        run.status = completed_success
+        run.completed_at = now
+        run.updated_at = now
+}
+
+rule BrokerCompletesRebalancingRunAdjusted {
+    -- The broker finishes the run, but with one or more orders skipped or
+    -- adjusted (e.g. due to fractional-share limits or a halted symbol).
+    when: BrokerCompletedRebalancingRunAdjusted(run)
+    requires: run.status = in_progress
+    ensures:
+        run.status = completed_adjusted
+        run.completed_at = now
+        run.updated_at = now
+}
+
+rule BrokerFailsRebalancingRun {
+    -- An unrecoverable error occurred during the run.
+    when: BrokerFailedRebalancingRun(run)
+    requires: run.status = in_progress
+    ensures:
+        run.status = error
+        run.updated_at = now
+}
+
+rule BrokerTimesOutRebalancingRun {
+    -- The run exceeded its allotted execution window.
+    when: BrokerTimedOutRebalancingRun(run)
+    requires: run.status = in_progress
+    ensures:
+        run.status = timeout
+        run.updated_at = now
+}
+
+-- ##### Document retrieval ##### --
+
+rule DownloadTradeDocument {
+    -- The correspondent fetches a generated trade document (statement,
+    -- confirmation, tax form) for an account. Read-only — modelled because
+    -- regulatory recordkeeping mandates these documents exist and remain
+    -- retrievable for the document's retention period.
+    when: DownloadTradeDocument(correspondent, account, document)
+    requires: account.correspondent = correspondent
+    requires: document.account = account
+    ensures: TradeDocumentRetrieved(
+        correspondent: correspondent,
+        account: account,
+        document: document,
+        retrieved_at: now
+    )
+}
+
+------------------------------------------------------------
+-- Invariants
+------------------------------------------------------------
+
+invariant AccountsBelongToOneCorrespondent {
+    for account in BrokerageAccounts:
+        account.correspondent != null
+}
+
+invariant AchTransfersStayWithinTheirAccount {
+    for transfer in Transfers:
+        transfer.ach_source != null implies transfer.ach_source.account = transfer.account
+}
+
+invariant WireTransfersStayWithinTheirAccount {
+    for transfer in Transfers:
+        transfer.wire_source != null implies transfer.wire_source.account = transfer.account
+}
+
+invariant JournalsAreCrossAccount {
+    for journal in Journals:
+        journal.from_account != journal.to_account
+}
+
+invariant SubscriptionPortfolioAndAccountShareCorrespondent {
+    for subscription in AccountSubscriptions:
+        subscription.account.correspondent = subscription.portfolio.correspondent
+}
+
+invariant RebalancingRunBelongsToSubscribedAccount {
+    for run in RebalancingRuns:
+        run.account.correspondent = run.portfolio.correspondent
+}
+
+------------------------------------------------------------
+-- Actor Declarations
+------------------------------------------------------------
+
+actor BrokerPartner {
+    -- The correspondent broker integrating with the platform. Authenticated
+    -- via API credentials issued at partnership onboarding; identity is
+    -- modelled as the Correspondent entity itself.
+    identified_by: Correspondent where name != ""
+}
+
+------------------------------------------------------------
+-- Surfaces
+------------------------------------------------------------
+
+surface PartnerOnboarding {
+    -- The boundary for creating new accounts for end users. Distinct from
+    -- AccountAdministration because the account does not yet exist.
+    facing partner: BrokerPartner
+
+    provides:
+        SubmitAccountApplication(
+            partner,
+            holder,
+            kind,
+            sub_kind?,
+            contact,
+            identity,
+            disclosures,
+            agreements,
+            trusted_contact?,
+            supporting_documents?
+        )
+}
+
+surface AccountAdministration {
+    -- The boundary the correspondent uses to manage a single account it
+    -- holds on behalf of an end user.
+    facing partner: BrokerPartner
+
+    context account: BrokerageAccount where correspondent = partner
+
+    exposes:
+        account.account_number
+        account.kind
+        account.sub_kind
+        account.status
+        account.crypto_status
+        account.kyc_review
+        account.contact
+        account.identity
+        account.disclosures
+        account.agreements
+        account.trusted_contact
+        account.account_documents
+        account.trade_documents
+
+    provides:
+        UpdateAccountInformation(partner, account, contact?, identity?, disclosures?, trusted_contact?)
+            when account.status != account_closed
+        UploadAccountDocuments(partner, account, documents)
+            when account.status != account_closed
+        SubmitCipResults(partner, account, providers, review)
+            when account.status in {submitted, action_required, aml_review, approval_pending}
+        CloseAccount(partner, account)
+            when account.status in {active, limited, paper_only, disabled, inactive, approved}
+        DownloadTradeDocument(partner, account, document)
+
+    related:
+        AccountFunding(account)
+        AccountRebalancing(account) when account.subscriptions.count > 0
+}
+
+surface AccountFunding {
+    -- The boundary for moving money in and out of an account, and for the
+    -- bank links used to do so.
+    facing partner: BrokerPartner
+
+    context account: BrokerageAccount where correspondent = partner
+
+    exposes:
+        account.ach_relationships
+        account.recipient_banks
+        account.transfers
+
+    provides:
+        EstablishAchRelationship(
+            partner, account, owner_name, bank_account_kind,
+            bank_account_number?, bank_routing_number?,
+            plaid_processor_token?, nickname?
+        ) when account.status in {approved, active, limited, paper_only}
+        RemoveAchRelationship(partner, account, relationship)
+        RegisterRecipientBank(
+            partner, account, name, identifier_kind,
+            bank_code, bank_account_number, address?
+        ) when account.status in {approved, active, limited}
+        RemoveRecipientBank(partner, account, bank)
+        RequestAchTransfer(partner, account, relationship, direction, amount, fee_payer?)
+            when account.status in {approved, active, limited, paper_only}
+        RequestWireTransfer(
+            partner, account, bank, direction, amount, fee_payer?, additional_information?
+        ) when account.status in {approved, active, limited, paper_only}
+        CancelTransfer(partner, account, transfer)
+}
+
+surface InterAccountJournals {
+    -- The boundary for moving cash and securities between two accounts that
+    -- the same correspondent holds. Distinct from funding because no
+    -- external rail is involved.
+    facing partner: BrokerPartner
+
+    provides:
+        RequestJournal(
+            partner, from_account, to_account, kind,
+            cash_amount?, base_currency?,
+            security?, quantity?, price?,
+            description?,
+            transmitter_name?, transmitter_account_number?,
+            transmitter_address?, transmitter_financial_institution?,
+            transmitter_timestamp?
+        )
+        RequestBatchJournal(partner, from_account, entries)
+        RequestReverseBatchJournal(partner, to_account, entries)
+        CancelJournal(partner, journal)
+}
+
+surface PortfolioCatalog {
+    -- The boundary the correspondent uses to define and maintain the set of
+    -- model portfolios it offers to its end users.
+    facing partner: BrokerPartner
+
+    let portfolios = ModelPortfolios where correspondent = partner
+
+    exposes:
+        portfolios
+
+    provides:
+        DefineModelPortfolio(
+            partner, name, description, weights,
+            cooldown_days, rebalance_conditions?
+        )
+        UpdateModelPortfolio(
+            partner, portfolio, name?, description?,
+            weights?, cooldown_days?, rebalance_conditions?
+        )
+        InactivateModelPortfolio(partner, portfolio)
+}
+
+surface AccountRebalancing {
+    -- The boundary for subscribing accounts to portfolios and managing
+    -- rebalancing runs.
+    facing partner: BrokerPartner
+
+    context account: BrokerageAccount where correspondent = partner
+
+    exposes:
+        account.subscriptions
+        account.rebalancing_runs
+
+    provides:
+        SubscribeAccountToPortfolio(partner, account, portfolio)
+            when account.status = active
+        UnsubscribeAccount(partner, subscription)
+        RequestManualRebalancingRun(partner, subscription, kind, weights)
+        CancelRebalancingRun(partner, run)
+}
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open question "Account approval automation — exact conditions under which the broker advances an account from approval_pending to approved versus action_required versus aml_review. Currently treated as broker-internal and modelled as opaque external stimuli."
+
+open question "Rebalancing trigger semantics — exact conditions under which a portfolio update or a drift-band breach produces a system-initiated RebalancingRun. Currently surfaced only through the run's initiator field."
+
+open question "Travel-rule threshold currency — config.travel_rule_threshold_amount is expressed in USD, but cash journals support multiple base currencies. Threshold may need to be per-currency."
+
+open question "OAuth B2B authorization flow — referenced in scope description but not present in the surveyed code; assumed to live in a separate authorization service."

--- a/.allium/market-data-client.allium
+++ b/.allium/market-data-client.allium
@@ -1,0 +1,492 @@
+-- allium: 3
+-- market-data-client.allium
+
+------------------------------------------------------------
+-- Enumerations
+------------------------------------------------------------
+
+enum AssetClass { stock | crypto | option | news }
+
+enum DataFeed {
+    iex | sip | `delayed_sip` | otc | boats | overnight
+    | opra | indicative | us
+}
+
+enum Adjustment { raw | split | dividend | all }
+
+enum BarTimeframeUnit { minute | hour | day | week | month }
+
+enum SortOrder { asc | desc }
+
+enum ScreenerRankBy { volume | trades }
+
+enum ScreenerMarketType { stocks | crypto }
+
+enum StreamingDataType {
+    trades | quotes | bars | updated_bars | daily_bars
+    | orderbooks | trading_statuses | trade_corrections | trade_cancels
+    | news
+}
+
+enum StreamStatus { idle | connecting | authenticated | streaming | stopped }
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value TimeFrame {
+    amount: Integer
+    unit: BarTimeframeUnit
+
+    valid_as_minute: unit = minute and amount >= 1 and amount <= 59
+    valid_as_hour: unit = hour and amount >= 1 and amount <= 23
+    valid_as_day_or_week: unit in {day, week} and amount = 1
+    valid_as_month: unit = month and amount in {1, 2, 3, 6, 12}
+    is_valid: valid_as_minute or valid_as_hour or valid_as_day_or_week or valid_as_month
+}
+
+value OrderbookLevel {
+    price: Decimal
+    size: Decimal
+}
+
+value OptionsGreeks {
+    delta: Decimal?
+    gamma: Decimal?
+    rho: Decimal?
+    theta: Decimal?
+    vega: Decimal?
+}
+
+------------------------------------------------------------
+-- External Entities
+------------------------------------------------------------
+
+external entity ApiClient {
+    has_credentials: Boolean
+}
+
+external entity Bar {
+    symbol: String
+    timestamp: Timestamp
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: Decimal
+    trade_count: Integer?
+    vwap: Decimal?
+    timeframe: TimeFrame
+}
+
+external entity Quote {
+    symbol: String
+    timestamp: Timestamp
+    ask_price: Decimal
+    ask_size: Decimal
+    bid_price: Decimal
+    bid_size: Decimal
+    conditions: List<String>?
+    tape: String?
+}
+
+external entity Trade {
+    symbol: String
+    timestamp: Timestamp
+    price: Decimal
+    size: Decimal
+    exchange: String?
+    conditions: List<String>?
+    tape: String?
+}
+
+external entity Snapshot {
+    symbol: String
+    latest_trade: Trade?
+    latest_quote: Quote?
+    minute_bar: Bar?
+    daily_bar: Bar?
+    previous_daily_bar: Bar?
+}
+
+external entity OptionsSnapshot {
+    symbol: String
+    latest_trade: Trade?
+    latest_quote: Quote?
+    minute_bar: Bar?
+    daily_bar: Bar?
+    previous_daily_bar: Bar?
+    greeks: OptionsGreeks?
+    implied_volatility: Decimal?
+}
+
+external entity Orderbook {
+    symbol: String
+    timestamp: Timestamp
+    bids: List<OrderbookLevel>
+    asks: List<OrderbookLevel>
+    reset: Boolean
+}
+
+external entity TradingStatus {
+    symbol: String
+    timestamp: Timestamp
+    status_code: String
+    status_message: String
+    halt_reason: String?
+}
+
+external entity TradeCorrection {
+    symbol: String
+    timestamp: Timestamp
+    original_price: Decimal
+    original_size: Decimal
+    corrected_price: Decimal
+    corrected_size: Decimal
+}
+
+external entity TradeCancel {
+    symbol: String
+    timestamp: Timestamp
+    price: Decimal
+    size: Decimal
+}
+
+external entity NewsArticle {
+    news_id: Integer
+    headline: String
+    author: String?
+    content: String?
+    summary: String?
+    symbols: List<String>
+    created_at: Timestamp
+    updated_at: Timestamp
+}
+
+external entity CorporateActionEvent {
+    symbol: String
+    action_type: String
+    process_date: Timestamp
+    record_date: Timestamp?
+    payable_date: Timestamp?
+    old_rate: Decimal?
+    new_rate: Decimal?
+}
+
+------------------------------------------------------------
+-- Entities
+------------------------------------------------------------
+
+entity DataStream {
+    asset_class: AssetClass
+    status: StreamStatus
+
+    transitions status {
+        idle -> connecting
+        connecting -> authenticated
+        connecting -> idle
+        authenticated -> streaming
+        streaming -> idle
+        idle -> stopped
+        connecting -> stopped
+        authenticated -> stopped
+        streaming -> stopped
+        terminal: stopped
+    }
+}
+
+entity DataSubscription {
+    stream: DataStream
+    symbol: String
+    data_type: StreamingDataType
+    is_wildcard: Boolean
+
+    invariant WildcardSymbol {
+        is_wildcard implies symbol = "*"
+    }
+}
+
+------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    bar_query_page_size: Integer = 10_000
+    news_query_page_size: Integer = 50
+    stream_ping_interval: Duration = 10.seconds
+    stream_ping_timeout: Duration = 180.seconds
+}
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+rule FetchBars {
+    when: FetchBars(symbols, timeframe, start?, end?, feed?, adjustment?, sort?, limit?, currency?)
+    requires: timeframe.is_valid
+    ensures: BarsReturned(symbols: symbols)
+}
+
+rule FetchQuotes {
+    when: FetchQuotes(symbols, start?, end?, feed?, sort?, limit?, currency?)
+    ensures: QuotesReturned(symbols: symbols)
+}
+
+rule FetchTrades {
+    when: FetchTrades(symbols, start?, end?, feed?, sort?, limit?, currency?)
+    ensures: TradesReturned(symbols: symbols)
+}
+
+rule FetchSnapshots {
+    when: FetchSnapshots(symbols, feed?, currency?)
+    ensures: SnapshotsReturned(symbols: symbols)
+}
+
+rule FetchOptionChain {
+    when: FetchOptionChain(underlying_symbol, feed?, expiration_gte?, expiration_lte?, strike_gte?, strike_lte?, contract_type?, root_symbol?, updated_since?)
+    ensures: OptionChainReturned(underlying_symbol: underlying_symbol)
+}
+
+rule FetchCryptoOrderbooks {
+    when: FetchCryptoOrderbooks(symbols)
+    ensures: OrderbooksReturned(symbols: symbols)
+}
+
+rule FetchNews {
+    when: FetchNews(symbols?, start?, end?, limit?, sort?, include_content?, exclude_contentless?, page_token?)
+    ensures: NewsReturned(symbols: symbols)
+}
+
+rule FetchMostActives {
+    when: FetchMostActives(by?, top?)
+    ensures: MostActivesReturned(rank_by: by ?? volume, top: top)
+}
+
+rule FetchMarketMovers {
+    when: FetchMarketMovers(market_type, top?)
+    ensures: MarketMoversReturned(market_type: market_type, top: top)
+}
+
+rule FetchCorporateActionsById {
+    when: FetchCorporateActions(ids?, symbols?, cusips?, types?, start?, end?)
+    requires: ids != null
+    ensures: CorporateActionsReturned(ids: ids)
+
+    @guidance
+        -- When IDs are provided, all other filter parameters (symbols, CUSIPs,
+        -- types, date range) are ignored.
+}
+
+rule FetchCorporateActionsByFilter {
+    when: FetchCorporateActions(ids?, symbols?, cusips?, types?, start?, end?)
+    requires: ids = null
+    ensures: CorporateActionsReturned(symbols: symbols, cusips: cusips, types: types, start: start, end: end)
+}
+
+rule StartStream {
+    when: StartStream(stream)
+    requires: stream.status = idle
+    ensures: stream.status = connecting
+}
+
+rule StreamAuthSucceeded {
+    when: StreamAuthSucceeded(stream)
+    requires: stream.status = connecting
+    ensures: stream.status = authenticated
+}
+
+rule StreamAuthFailed {
+    when: StreamAuthFailed(stream)
+    requires: stream.status = connecting
+    ensures: stream.status = idle
+}
+
+rule StartSubscribing {
+    when: Subscribe(stream, symbol, data_type, is_wildcard?)
+    requires: stream.status = authenticated
+    ensures:
+        stream.status = streaming
+        DataSubscription.created(stream: stream, symbol: symbol, data_type: data_type, is_wildcard: is_wildcard ?? false)
+}
+
+rule AddSubscription {
+    when: Subscribe(stream, symbol, data_type, is_wildcard?)
+    requires: stream.status = streaming
+    ensures:
+        DataSubscription.created(stream: stream, symbol: symbol, data_type: data_type, is_wildcard: is_wildcard ?? false)
+}
+
+rule RemoveSubscription {
+    when: Unsubscribe(stream, symbol, data_type)
+    requires: stream.status = streaming
+    let subscription = DataSubscription{stream, symbol, data_type}
+    requires: exists subscription
+    ensures: not exists subscription
+}
+
+rule StopStream {
+    when: StopStream(stream)
+    requires: stream.status in {idle, connecting, authenticated, streaming}
+    ensures: stream.status = stopped
+}
+
+rule StreamConnectionLost {
+    when: StreamConnectionLost(stream)
+    requires: stream.status in {authenticated, streaming}
+    ensures: stream.status = idle
+}
+
+rule OrderbookResetReceived {
+    when: StreamOrderbookReceived(stream, orderbook)
+    requires: stream.status = streaming
+    requires: orderbook.reset = true
+    ensures: OrderbookReset(stream: stream, symbol: orderbook.symbol)
+
+    @guidance
+        -- Consumers must discard all locally cached bids and asks for the symbol
+        -- and rebuild from the bids and asks in this message.
+}
+
+rule UpdatedBarReceived {
+    when: StreamUpdatedBarReceived(stream, bar)
+    requires: stream.status = streaming
+    ensures: UpdatedBarDelivered(stream: stream, bar: bar)
+
+    @guidance
+        -- Updated bars are in-progress aggregations for the current interval.
+        -- They are superseded by subsequent updates or the final bar at interval close.
+}
+
+------------------------------------------------------------
+-- Surfaces
+------------------------------------------------------------
+
+surface HistoricalStockData {
+    facing caller: ApiClient
+
+    provides:
+        FetchBars(symbols, timeframe, start?, end?, feed?, adjustment?, sort?, limit?, currency?)
+        FetchQuotes(symbols, start?, end?, feed?, sort?, limit?, currency?)
+        FetchTrades(symbols, start?, end?, feed?, sort?, limit?, currency?)
+        FetchSnapshots(symbols, feed?, currency?)
+
+    @guidance
+        -- Default feed is IEX (free). SIP, DELAYED_SIP, and OTC feeds require
+        -- a premium market data subscription.
+        -- Adjustment defaults to RAW when not specified. Applies to stocks only.
+        -- Results paginate automatically at config.bar_query_page_size data points per page.
+}
+
+surface HistoricalCryptoData {
+    facing caller: ApiClient
+
+    provides:
+        FetchBars(symbols, timeframe, start?, end?, sort?, limit?, currency?)
+        FetchQuotes(symbols, start?, end?, sort?, limit?, currency?)
+        FetchTrades(symbols, start?, end?, sort?, limit?, currency?)
+        FetchSnapshots(symbols, currency?)
+        FetchCryptoOrderbooks(symbols)
+
+    @guidance
+        -- Crypto data does not require credentials; unauthenticated requests
+        -- are subject to lower rate limits. No feed or adjustment parameters apply.
+}
+
+surface HistoricalOptionsData {
+    facing caller: ApiClient
+
+    provides:
+        FetchTrades(symbols, start?, end?, feed?, sort?, limit?)
+        FetchQuotes(symbols, start?, end?, feed?, sort?, limit?)
+        FetchSnapshots(symbols, feed?)
+        FetchOptionChain(underlying_symbol, feed?, expiration_gte?, expiration_lte?, strike_gte?, strike_lte?, contract_type?, root_symbol?, updated_since?)
+
+    @guidance
+        -- Default feed (INDICATIVE) does not require a subscription.
+        -- OPRA feed requires an options market data subscription.
+        -- OptionsSnapshot includes greeks and implied volatility alongside the standard snapshot fields.
+}
+
+surface MarketIntelligence {
+    facing caller: ApiClient
+
+    provides:
+        FetchNews(symbols?, start?, end?, limit?, sort?, include_content?, exclude_contentless?, page_token?)
+        FetchMostActives(by?, top?)
+        FetchMarketMovers(market_type, top?)
+        FetchCorporateActions(ids?, symbols?, cusips?, types?, start?, end?)
+
+    @guidance
+        -- News results use token-based pagination via page_token.
+        -- Screener results (most actives, market movers) are pre-computed rankings refreshed periodically.
+        -- Corporate action queries by ID are exclusive with filter-based queries.
+}
+
+surface LiveStockStream {
+    facing caller: ApiClient
+    context stream: DataStream where asset_class = stock
+
+    exposes:
+        stream.status
+
+    provides:
+        StartStream(stream) when stream.status = idle
+        Subscribe(stream, symbol, data_type) when stream.status in {authenticated, streaming}
+        Unsubscribe(stream, symbol, data_type) when stream.status = streaming
+        StopStream(stream)
+
+    @guidance
+        -- Supported data types: trades, quotes, bars, updated_bars, daily_bars, trading_statuses.
+        -- Trade corrections and cancels are delivered on the trades channel without separate subscription.
+        -- Wildcard symbol "*" subscribes to all symbols for the given data type.
+}
+
+surface LiveCryptoStream {
+    facing caller: ApiClient
+    context stream: DataStream where asset_class = crypto
+
+    exposes:
+        stream.status
+
+    provides:
+        StartStream(stream) when stream.status = idle
+        Subscribe(stream, symbol, data_type) when stream.status in {authenticated, streaming}
+        Unsubscribe(stream, symbol, data_type) when stream.status = streaming
+        StopStream(stream)
+
+    @guidance
+        -- Supported data types: trades, quotes, bars, updated_bars, daily_bars, orderbooks.
+        -- Orderbook subscriptions are unique to crypto streams.
+        -- An orderbook message with reset=true requires a full local orderbook rebuild for that symbol.
+}
+
+surface LiveOptionsStream {
+    facing caller: ApiClient
+    context stream: DataStream where asset_class = option
+
+    exposes:
+        stream.status
+
+    provides:
+        StartStream(stream) when stream.status = idle
+        Subscribe(stream, symbol, data_type) when stream.status in {authenticated, streaming}
+        Unsubscribe(stream, symbol, data_type) when stream.status = streaming
+        StopStream(stream)
+
+    @guidance
+        -- Supported data types: trades, quotes.
+}
+
+surface LiveNewsStream {
+    facing caller: ApiClient
+    context stream: DataStream where asset_class = news
+
+    exposes:
+        stream.status
+
+    provides:
+        StartStream(stream) when stream.status = idle
+        Subscribe(stream, symbol, news) when stream.status in {authenticated, streaming}
+        Unsubscribe(stream, symbol, news) when stream.status = streaming
+        StopStream(stream)
+}

--- a/.allium/trading-client.allium
+++ b/.allium/trading-client.allium
@@ -1,0 +1,708 @@
+-- allium: 3
+-- trading-client.allium
+
+-- Scope: Alpaca TradingClient — orders, positions, account, assets, watchlists,
+--        calendar/clock, options contracts, and real-time streaming.
+-- Excludes: examples/ demo notebooks
+
+------------------------------------------------------------
+-- Enumerations
+------------------------------------------------------------
+
+enum AssetClass { us_equity | us_option | crypto | crypto_perp }
+
+enum OrderStatus {
+    new | pending_new | accepted | pending_review | accepted_for_bidding
+    | partially_filled | filled
+    | done_for_day | held | stopped | suspended | calculated
+    | pending_replace | replaced
+    | pending_cancel | canceled
+    | expired | rejected
+}
+
+enum OrderType { market | limit | stop | stop_limit | trailing_stop }
+
+enum OrderSide { buy | sell }
+
+enum OrderClass { simple | bracket | oco | oto | mleg }
+
+enum TimeInForce { day | gtc | opg | cls | ioc | fok }
+
+enum PositionSide { long | short }
+
+enum PositionIntent { buy_to_open | buy_to_close | sell_to_open | sell_to_close }
+
+enum TradeEvent {
+    new | pending_new | accepted | fill | partial_fill
+    | canceled | expired | replaced | pending_cancel | pending_replace
+    | rejected | restated
+}
+
+enum ContractType { call | put }
+
+enum ExerciseStyle { american | european }
+
+enum AccountStatus {
+    onboarding | submission_failed | submitted | resubmitted
+    | approval_pending | reapproval_pending | kyc_submitted | aml_review
+    | approved | account_updated | edited | active | limited | paper_only
+    | action_required | disable_pending | disabled | account_closed
+    | rejected | signed_up
+}
+
+enum OptionsApprovalLevel { disabled | covered_only | long_options | spreads }
+
+enum DTBPCheck { both | entry | exit }
+
+enum TradeConfirmationEmail { all | none }
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value TakeProfitSpec {
+    limit_price: Decimal
+}
+
+value StopLossSpec {
+    stop_price: Decimal
+    limit_price: Decimal?
+}
+
+------------------------------------------------------------
+-- Entities and Variants
+------------------------------------------------------------
+
+entity Asset {
+    symbol: String
+    name: String
+    asset_class: AssetClass
+    exchange: String
+    tradable: Boolean
+    marginable: Boolean
+    shortable: Boolean
+    easy_to_borrow: Boolean
+    fractionable: Boolean
+    min_order_size: Decimal?
+    min_trade_increment: Decimal?
+    price_increment: Decimal?
+}
+
+entity OptionContract {
+    symbol: String
+    name: String
+    root_symbol: String
+    underlying_symbol: String
+    underlying_asset: Asset
+    tradable: Boolean
+    expiration_date: Timestamp
+    contract_type: ContractType
+    exercise_style: ExerciseStyle
+    strike_price: Decimal
+    size: Decimal
+    open_interest: Decimal?
+    close_price: Decimal?
+}
+
+entity Order {
+    symbol: String?
+    asset_class: AssetClass?
+    qty: Decimal?
+    notional: Decimal?
+    filled_qty: Decimal
+    filled_avg_price: Decimal?
+    order_class: OrderClass
+    order_type: OrderType
+    side: OrderSide?
+    position_intent: PositionIntent?
+    time_in_force: TimeInForce
+    limit_price: Decimal?
+    stop_price: Decimal?
+    trail_price: Decimal?
+    trail_percent: Decimal?
+    hwm: Decimal?
+    extended_hours: Boolean
+    client_order_id: String
+    status: OrderStatus
+    submitted_at: Timestamp?
+    filled_at: Timestamp when status = filled
+    canceled_at: Timestamp when status = canceled
+    expired_at: Timestamp when status = expired
+    replaced_at: Timestamp when status = replaced
+    failed_at: Timestamp when status = rejected
+    expires_at: Timestamp?
+    take_profit: TakeProfitSpec?
+    stop_loss: StopLossSpec?
+    legs: List<Order>
+    replaces: Order?
+    replaced_by: Order?
+
+    transitions status {
+        new -> pending_new
+        new -> pending_review
+        pending_new -> accepted
+        pending_new -> pending_cancel
+        pending_review -> accepted_for_bidding
+        accepted -> partially_filled
+        accepted -> filled
+        accepted -> done_for_day
+        accepted -> held
+        accepted -> stopped
+        accepted -> suspended
+        accepted -> calculated
+        accepted -> pending_replace
+        accepted -> pending_cancel
+        partially_filled -> filled
+        partially_filled -> done_for_day
+        partially_filled -> pending_replace
+        partially_filled -> pending_cancel
+        pending_replace -> accepted
+        pending_replace -> replaced
+        pending_cancel -> canceled
+        terminal: filled, canceled, expired, rejected, replaced, done_for_day,
+                  stopped, suspended, calculated, held, accepted_for_bidding
+    }
+
+    invariant QuantityOrNotional {
+        (qty != null) implies (notional = null)
+    }
+
+    invariant TrailPriceOrPercent {
+        order_type = trailing_stop implies
+            (trail_price != null) or (trail_percent != null)
+    }
+
+    invariant MlegHasLegs {
+        order_class = mleg implies legs.count >= 2
+    }
+}
+
+entity Position {
+    symbol: String
+    asset_class: AssetClass
+    qty: Decimal
+    qty_available: Decimal
+    side: PositionSide
+    avg_entry_price: Decimal
+    market_value: Decimal
+    unrealized_pl: Decimal
+}
+
+entity TradeAccount {
+    status: AccountStatus
+    buying_power: Decimal
+    daytrading_buying_power: Decimal
+    cash: Decimal
+    equity: Decimal
+    daytrade_count: Integer
+    pattern_day_trader: Boolean
+    options_approved_level: OptionsApprovalLevel?
+    options_trading_level: OptionsApprovalLevel?
+
+    transitions status {
+        signed_up -> submission_failed
+        signed_up -> submitted
+        submission_failed -> submitted
+        submitted -> resubmitted
+        submitted -> approval_pending
+        submitted -> kyc_submitted
+        resubmitted -> approval_pending
+        kyc_submitted -> aml_review
+        aml_review -> approval_pending
+        approval_pending -> reapproval_pending
+        approval_pending -> approved
+        reapproval_pending -> approved
+        approved -> account_updated
+        account_updated -> active
+        approved -> active
+        active -> action_required
+        active -> limited
+        active -> edited
+        active -> disable_pending
+        action_required -> active
+        limited -> active
+        edited -> active
+        disable_pending -> disabled
+        disabled -> disable_pending
+        disable_pending -> active
+        terminal: account_closed, rejected, onboarding, paper_only
+    }
+}
+
+entity AccountConfiguration {
+    dtbp_check: DTBPCheck
+    fractional_trading: Boolean
+    max_margin_multiplier: Integer
+    no_shorting: Boolean
+    pdt_check: DTBPCheck
+    suspend_trade: Boolean
+    trade_confirm_email: TradeConfirmationEmail
+    max_options_trading_level: OptionsApprovalLevel?
+}
+
+entity Watchlist {
+    name: String
+    updated_at: Timestamp
+    assets: List<String>
+}
+
+entity MarketCalendarDay {
+    date: Timestamp
+    open: Timestamp
+    close: Timestamp
+}
+
+entity TradeUpdate {
+    event: TradeEvent
+    order: Order
+    timestamp: Timestamp
+    position_qty: Decimal?
+    price: Decimal?
+    qty: Decimal?
+}
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+-- Order Management
+
+rule SubmitOrder {
+    when: SubmitOrder(order_data)
+
+    requires: order_data.order_class = mleg implies order_data.qty != null
+    requires: order_data.order_class != mleg implies order_data.symbol != null
+    requires: order_data.qty = null or order_data.notional = null
+    requires: order_data.order_type = trailing_stop implies
+        (order_data.trail_price != null) or (order_data.trail_percent != null)
+    requires: order_data.order_type = limit or order_data.order_class = oco implies
+        order_data.limit_price != null
+    requires: order_data.order_type = stop or order_data.order_type = stop_limit implies
+        order_data.stop_price != null
+    requires: order_data.order_class = mleg implies order_data.legs.count >= 2
+
+    ensures: Order.created(
+        symbol: order_data.symbol,
+        asset_class: order_data.asset_class,
+        qty: order_data.qty,
+        notional: order_data.notional,
+        filled_qty: 0,
+        order_class: order_data.order_class,
+        order_type: order_data.order_type,
+        side: order_data.side,
+        position_intent: order_data.position_intent,
+        time_in_force: order_data.time_in_force,
+        limit_price: order_data.limit_price,
+        stop_price: order_data.stop_price,
+        trail_price: order_data.trail_price,
+        trail_percent: order_data.trail_percent,
+        extended_hours: order_data.extended_hours,
+        take_profit: order_data.take_profit,
+        stop_loss: order_data.stop_loss,
+        legs: order_data.legs,
+        status: new,
+        submitted_at: now
+    )
+}
+
+rule ReplaceOrder {
+    when: ReplaceOrder(order, replace_data)
+
+    requires: order.status in { new, pending_new, accepted, partially_filled }
+
+    ensures:
+        let new_order = Order.created(
+            symbol: order.symbol,
+            asset_class: order.asset_class,
+            qty: replace_data.qty ?? order.qty,
+            time_in_force: replace_data.time_in_force ?? order.time_in_force,
+            limit_price: replace_data.limit_price ?? order.limit_price,
+            stop_price: replace_data.stop_price ?? order.stop_price,
+            trail_price: replace_data.trail_price ?? order.trail_price,
+            trail_percent: replace_data.trail_percent ?? order.trail_percent,
+            filled_qty: 0,
+            order_class: order.order_class,
+            order_type: order.order_type,
+            side: order.side,
+            extended_hours: order.extended_hours,
+            replaces: order,
+            status: new,
+            submitted_at: now
+        )
+        order.status = pending_replace
+        order.replaced_by = new_order
+}
+
+rule CancelOrder {
+    when: CancelOrder(order)
+
+    requires: order.status in { new, pending_new, accepted, partially_filled, held }
+
+    ensures: order.status = pending_cancel
+}
+
+rule CancelAllOrders {
+    when: CancelAllOrders()
+
+    ensures:
+        for order in Orders where status in { new, pending_new, accepted, partially_filled, held }:
+            order.status = pending_cancel
+}
+
+-- Order lifecycle — driven by exchange
+
+rule OrderFilled {
+    when: OrderFilled(order, fill_qty, fill_price)
+
+    requires: order.status in { accepted, partially_filled }
+
+    ensures: order.status = filled
+    ensures: order.filled_qty = fill_qty
+    ensures: order.filled_avg_price = fill_price
+    ensures: order.filled_at = now
+}
+
+rule OrderPartiallyFilled {
+    when: OrderPartiallyFilled(order, fill_qty, fill_price)
+
+    requires: order.status in { accepted, partially_filled }
+
+    ensures: order.status = partially_filled
+    ensures: order.filled_qty = fill_qty
+    ensures: order.filled_avg_price = fill_price
+}
+
+rule OrderRejected {
+    when: OrderRejected(order)
+
+    requires: order.status in { new, pending_new, accepted, pending_review }
+
+    ensures: order.status = rejected
+    ensures: order.failed_at = now
+}
+
+rule OrderExpired {
+    when: OrderExpired(order)
+
+    requires: order.status in { new, pending_new, accepted, partially_filled }
+
+    ensures: order.status = expired
+    ensures: order.expired_at = now
+}
+
+rule OrderCanceled {
+    when: OrderCanceled(order)
+
+    requires: order.status = pending_cancel
+
+    ensures: order.status = canceled
+    ensures: order.canceled_at = now
+}
+
+rule OrderReplaced {
+    when: OrderReplaced(order, replacement)
+
+    requires: order.status = pending_replace
+
+    ensures: order.status = replaced
+    ensures: order.replaced_at = now
+    ensures: order.replaced_by = replacement
+}
+
+-- Bracket / OCO / OTO lifecycle
+
+rule BracketLegTriggered {
+    when: OrderFilled(parent_order, fill_qty, fill_price)
+
+    requires: parent_order.order_class = bracket
+    requires: parent_order.take_profit != null or parent_order.stop_loss != null
+
+    ensures:
+        for leg in parent_order.legs:
+            leg.status = new
+}
+
+rule OcoLegCanceled {
+    when: OrderFilled(oco_leg, fill_qty, fill_price)
+
+    requires: oco_leg.order_class = oco
+
+    ensures:
+        for sibling in Orders where replaces = oco_leg.replaces and status != filled:
+            sibling.status = pending_cancel
+}
+
+rule OtoSecondarySubmitted {
+    when: OrderFilled(primary, fill_qty, fill_price)
+
+    requires: primary.order_class = oto
+    requires: primary.legs.count > 0
+
+    ensures:
+        for leg in primary.legs:
+            leg.status = new
+}
+
+-- Position Management
+
+rule ClosePosition {
+    when: ClosePosition(position, close_options)
+
+    requires: position.qty_available > 0
+    requires: close_options.qty != null or close_options.percentage != null
+    requires: close_options.qty = null or close_options.percentage = null
+
+    ensures: Order.created(
+        symbol: position.symbol,
+        asset_class: position.asset_class,
+        side: if position.side = long: sell else: buy,
+        order_type: market,
+        order_class: simple,
+        filled_qty: 0,
+        extended_hours: false,
+        status: new,
+        submitted_at: now
+    )
+}
+
+rule CloseAllPositions {
+    when: CloseAllPositions(cancel_orders)
+
+    ensures:
+        if cancel_orders:
+            for order in Orders where status in { new, pending_new, accepted, partially_filled }:
+                order.status = pending_cancel
+    ensures:
+        for position in Positions:
+            Order.created(
+                symbol: position.symbol,
+                asset_class: position.asset_class,
+                side: if position.side = long: sell else: buy,
+                order_type: market,
+                order_class: simple,
+                filled_qty: 0,
+                extended_hours: false,
+                status: new,
+                submitted_at: now
+            )
+}
+
+rule ExerciseOptionsPosition {
+    when: ExerciseOptionsPosition(position)
+
+    requires: position.asset_class = us_option
+    requires: position.qty_available > 0
+
+    ensures: OptionsExercised(position: position)
+}
+
+-- Watchlist Management
+
+rule CreateWatchlist {
+    when: CreateWatchlist(name, symbols)
+
+    ensures: Watchlist.created(
+        name: name,
+        assets: symbols,
+        updated_at: now
+    )
+}
+
+rule UpdateWatchlist {
+    when: UpdateWatchlist(watchlist, name?, symbols?)
+
+    ensures: watchlist.name = name ?? watchlist.name
+    ensures: watchlist.assets = symbols ?? watchlist.assets
+    ensures: watchlist.updated_at = now
+}
+
+rule AddAssetToWatchlist {
+    when: AddAssetToWatchlist(watchlist, symbol)
+
+    requires: symbol not in watchlist.assets
+
+    ensures: watchlist.assets.add(symbol)
+    ensures: watchlist.updated_at = now
+}
+
+rule RemoveAssetFromWatchlist {
+    when: RemoveAssetFromWatchlist(watchlist, symbol)
+
+    requires: symbol in watchlist.assets
+
+    ensures: watchlist.assets.remove(symbol)
+    ensures: watchlist.updated_at = now
+}
+
+rule DeleteWatchlist {
+    when: DeleteWatchlist(watchlist)
+
+    ensures: not exists watchlist
+}
+
+-- Account Configuration
+
+rule UpdateAccountConfiguration {
+    when: UpdateAccountConfiguration(config_update)
+
+    ensures: AccountConfiguration.created(
+        dtbp_check: config_update.dtbp_check,
+        fractional_trading: config_update.fractional_trading,
+        max_margin_multiplier: config_update.max_margin_multiplier,
+        no_shorting: config_update.no_shorting,
+        pdt_check: config_update.pdt_check,
+        suspend_trade: config_update.suspend_trade,
+        trade_confirm_email: config_update.trade_confirm_email,
+        max_options_trading_level: config_update.max_options_trading_level
+    )
+}
+
+-- Real-time streaming
+
+rule TradeUpdateReceived {
+    when: trade_update: TradeUpdate.created
+
+    ensures: OrderUpdateApplied(order: trade_update.order, event: trade_update.event)
+}
+
+------------------------------------------------------------
+-- Invariants
+------------------------------------------------------------
+
+invariant PatternDayTraderBuyingPower {
+    for account in TradeAccounts:
+        account.pattern_day_trader implies
+            account.daytrading_buying_power <= account.buying_power * 4
+}
+
+invariant OptionsLevelWithinApproved {
+    for account in TradeAccounts:
+        account.options_trading_level != null and account.options_approved_level != null implies
+            account.options_trading_level = account.options_approved_level
+}
+
+invariant AvailableQtyBound {
+    for position in Positions:
+        position.qty_available <= position.qty
+}
+
+------------------------------------------------------------
+-- Surfaces
+------------------------------------------------------------
+
+surface OrderManagement {
+    exposes:
+        for order in Orders:
+            order.symbol
+            order.status
+            order.order_type
+            order.side
+            order.qty
+            order.filled_qty
+            order.limit_price
+            order.stop_price
+            order.legs
+
+    provides:
+        SubmitOrder(order_data)
+        ReplaceOrder(order, replace_data) when order.status in { new, pending_new, accepted, partially_filled }
+        CancelOrder(order) when order.status in { new, pending_new, accepted, partially_filled, held }
+        CancelAllOrders()
+}
+
+surface PositionManagement {
+    exposes:
+        for position in Positions:
+            position.symbol
+            position.qty
+            position.qty_available
+            position.side
+            position.market_value
+            position.unrealized_pl
+            position.avg_entry_price
+
+    provides:
+        ClosePosition(position, close_options)
+        CloseAllPositions(cancel_orders)
+        ExerciseOptionsPosition(position) when position.asset_class = us_option
+}
+
+surface AccountView {
+    exposes:
+        for account in TradeAccounts:
+            account.status
+            account.buying_power
+            account.equity
+            account.cash
+            account.pattern_day_trader
+            account.daytrade_count
+            account.options_approved_level
+
+    provides:
+        UpdateAccountConfiguration(config_update)
+}
+
+surface WatchlistList {
+    exposes:
+        for watchlist in Watchlists:
+            watchlist.name
+            watchlist.updated_at
+
+    provides:
+        CreateWatchlist(name, symbols)
+}
+
+surface WatchlistManagement {
+    context watchlist: Watchlist
+
+    exposes:
+        watchlist.name
+        watchlist.assets
+        watchlist.updated_at
+
+    provides:
+        UpdateWatchlist(watchlist, name?, symbols?)
+        AddAssetToWatchlist(watchlist, symbol)
+        RemoveAssetFromWatchlist(watchlist, symbol) when symbol in watchlist.assets
+        DeleteWatchlist(watchlist)
+}
+
+surface MarketData {
+    exposes:
+        for asset in Assets:
+            asset.symbol
+            asset.tradable
+            asset.fractionable
+            asset.asset_class
+        for day in MarketCalendarDays:
+            day.date
+            day.open
+            day.close
+        for contract in OptionContracts:
+            contract.symbol
+            contract.underlying_symbol
+            contract.contract_type
+            contract.expiration_date
+            contract.strike_price
+}
+
+surface ExchangeFeed {
+    provides:
+        OrderFilled(order, fill_qty, fill_price)
+        OrderPartiallyFilled(order, fill_qty, fill_price)
+        OrderRejected(order)
+        OrderExpired(order)
+        OrderCanceled(order)
+        OrderReplaced(order, replacement)
+}
+
+surface TradeStream {
+    exposes:
+        for update in TradeUpdates:
+            update.event
+            update.order
+            update.timestamp
+            update.price
+            update.qty
+            update.position_qty
+}

--- a/.github/workflows/allium-check.yml
+++ b/.github/workflows/allium-check.yml
@@ -1,0 +1,81 @@
+name: Allium Check
+
+# Runs `allium check` on every `.allium` file in the repo.
+#
+# Local install:
+#     cargo install --locked --version 3.0.4 allium-cli
+#
+# Toolchain note: allium-cli is a Rust binary and is not bootstrapped through
+# the Makefile's `bin/<name>-<version>` convention (where one exists). The
+# version is single-sourced via the ALLIUM_VERSION env var below.
+
+"on":
+  push:
+    branches: [master]
+    paths:
+      - "**/*.allium"
+      - ".github/workflows/allium-check.yml"
+  pull_request:
+    paths:
+      - "**/*.allium"
+      - ".github/workflows/allium-check.yml"
+
+permissions:
+  contents: read
+
+env:
+  ALLIUM_VERSION: "3.0.4"
+  # Opt in to Node 24 runtime for actions; Node 20 will be removed 2026-09-16.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache allium-cli binary
+        id: cache-allium
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/allium
+          key: allium-cli-${{ env.ALLIUM_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install Rust toolchain
+        if: steps.cache-allium.outputs.cache-hit != 'true'
+        # Pinned SHA for `stable` branch — dtolnay/rust-toolchain uses
+        # branches (not tags) for channel pinning, so we pin the commit
+        # instead. Bump when refreshing the toolchain.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install allium-cli
+        if: steps.cache-allium.outputs.cache-hit != 'true'
+        run: cargo install --locked --version ${{ env.ALLIUM_VERSION }} allium-cli
+
+      - name: Run allium check
+        # `-e` is GHA's default, but `allium check` exits non-zero on any
+        # warning — we only want to fail CI on actual errors. Disable
+        # errexit and gate on the parsed summary line.
+        shell: bash
+        run: |
+          set +e
+          set -uo pipefail
+          FILES=$(find . -type f -name "*.allium" -not -path "./.git/*" | sort)
+          if [ -z "$FILES" ]; then
+            echo "No .allium files found; nothing to check."
+            exit 0
+          fi
+          echo "Checking:"
+          echo "$FILES" | sed 's/^/  /'
+          allium check $FILES 2>&1 | tee allium.log
+          ERRORS=$(grep -oE '[0-9]+ error\(s\)' allium.log | tail -1 | awk '{print $1}')
+          if [ -z "$ERRORS" ]; then
+            echo "::error::could not parse allium check summary"
+            exit 1
+          fi
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "::error::allium check reported $ERRORS error(s)"
+            exit 1
+          fi
+          echo "OK — 0 errors."

--- a/.github/workflows/allium-drift.yml
+++ b/.github/workflows/allium-drift.yml
@@ -1,0 +1,38 @@
+name: Allium Drift Check
+
+# Thin caller — the drift check logic lives in alpaca-harness.
+#
+# Runs automatically on every PR update. Posts a drift report as a PR comment.
+# Currently in advisory mode (required_passing: false) — drift findings will not
+# block PRs. Flip to true once specs are trusted.
+#
+# Required secret on this repo (set one — the reusable workflow auto-detects):
+#   ANTHROPIC_API_KEY — claude provider (preferred when both set)
+#   CURSOR_API_KEY    — cursor provider
+#
+# Ref pin policy: alpacahq/alpaca-harness is a first-party internal repo and
+# this caller deliberately tracks its `master` so improvements (e.g. parser
+# fixes, model bumps) reach all callers without per-repo PRs. The repo is
+# org-internal, so all branch writes are gated by the same review process
+# as this repo. If we later need pinned releases, switch to a tag and bump
+# via dependabot.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  allium-drift:
+    uses: alpacahq/alpaca-harness/.github/workflows/ai-allium-drift.yml@master
+    with:
+      pr_num: ${{ github.event.pull_request.number }}
+      head_ref: ${{ github.event.pull_request.head.ref }}
+      target_repo: alpacahq/alpaca-py
+      required_passing: false
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}


### PR DESCRIPTION
## Behavioral Specifications

Machine-distilled from source code using [allium-spec-distillation](https://github.com/alpacahq/allium-spec-distillation).

### `trading-client`

```
Scope: Alpaca TradingClient — orders, positions, account, assets, watchlists,
calendar/clock, options contracts, and real-time streaming.
Excludes: examples/ demo notebooks
```

### `market-data-client`

```
Enumerations
```

**Review notes:**
- [minor] Enums SortOrder, DataFeed, Adjustment, ScreenerRankBy, and ScreenerMarketType are declared but rule parameters that should bind to them (sort?, feed?, adjustment?, by?, market_type) are untyped — the link between parameter and enum is implicit only
- [minor] Config entries stream_ping_interval and stream_ping_timeout are declared but no rules model the ping/keepalive lifecycle or what happens when a ping times out

---
🤖 Generated with [allium-spec-distillation](https://github.com/alpacahq/allium-spec-distillation)