### PR TITLE
fix: add fractional order validation in submit_order (closes #252)

### DIFF
--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -96,6 +96,18 @@ class TradingClient(RESTClient):
         Returns:
             alpaca.trading.models.Order: The resulting submitted order.
         """
+        # Validate fractional orders: fractional qty requires market order type and day time_in_force
+        if order_data.qty is not None and order_data.qty != int(order_data.qty):
+            from alpaca.trading.enums import OrderType, TimeInForce
+            if hasattr(order_data, 'type') and order_data.type != OrderType.MARKET:
+                raise ValueError(
+                    "Fractional orders must be market orders. "
+                    "Please use OrderType.MARKET for fractional quantities."
+                )
+            if hasattr(order_data, 'time_in_force') and order_data.time_in_force != TimeInForce.DAY:
+                raise ValueError(
+                    "Fractional orders must have time_in_force set to TimeInForce.DAY."
+                )
         data = order_data.to_request_fields()
         response = self.post("/orders", data)
 


### PR DESCRIPTION
## What
Fractional orders (orders with non-integer `qty`) can only be submitted as market orders with `time_in_force='day'`. Previously, no validation was done on the client side, leading to API errors only after submission.

## Fix
Added validation in the `submit_order` method to check if the order quantity is fractional. If so, it verifies that:
1. The order type is `OrderType.MARKET`
2. The `time_in_force` is `TimeInForce.DAY`

A `ValueError` is raised with a descriptive message if these conditions are not met, providing early feedback to the user before making the API call.

Closes #252