### PR TITLE
Tolerate Alpaca's deprecated PDT/DTBP account fields

### DIFF
--- a/alpaca/broker/models/accounts.py
+++ b/alpaca/broker/models/accounts.py
@@ -335,8 +335,10 @@ class TradeAccount(BaseTradeAccount):
         last_cash (Optional[str]): Value of all cash as of previous trading day at 16:00:00 ET
         last_initial_margin (Optional[str]): Value of initial_margin as of previous trading day at 16:00:00 ET
         last_regt_buying_power (Optional[str]): Value of regt_buying_power as of previous trading day at 16:00:00 ET
-        last_daytrading_buying_power (Optional[str]): Value of daytrading_buying_power as of previous trading day at 16:00:00 ET
-        last_daytrade_count (Optional[int]): Value of daytrade_count as of previous trading day at 16:00:00 ET
+        last_daytrading_buying_power (Optional[str]): Value of daytrading_buying_power as of previous trading day at 16:00:00 ET.
+          Deprecated; removed from Alpaca responses on 2026-07-06 (FINRA intraday-margin migration) and defaults to None.
+        last_daytrade_count (Optional[int]): Value of daytrade_count as of previous trading day at 16:00:00 ET.
+          Deprecated; removed from Alpaca responses on 2026-07-06 (FINRA intraday-margin migration) and defaults to None.
         last_buying_power (Optional[str]): Value of buying_power as of previous trading day at 16:00:00 ET
         clearing_broker (Optional[ClearingBroker]): The Clearing broker for this account
     """
@@ -349,7 +351,7 @@ class TradeAccount(BaseTradeAccount):
     last_cash: Optional[str]
     last_initial_margin: Optional[str]
     last_regt_buying_power: Optional[str]
-    last_daytrading_buying_power: Optional[str]
-    last_daytrade_count: Optional[int]
+    last_daytrading_buying_power: Optional[str] = None
+    last_daytrade_count: Optional[int] = None
     last_buying_power: Optional[str]
     clearing_broker: Optional[ClearingBroker]

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -489,7 +489,8 @@ class TradeAccount(ModelWithID):
           buying_power = max(equity-initial_margin(0) * 2). If multiplier = 1 then buying_power = cash.
         regt_buying_power (Optional[str]): User’s buying power under Regulation T
           (excess equity - (equity - margin value) - * margin multiplier)
-        daytrading_buying_power (Optional[str]): The buying power for day trades for the account
+        daytrading_buying_power (Optional[str]): The buying power for day trades for the account.
+          Deprecated; removed from Alpaca responses on 2026-07-06 (FINRA intraday-margin migration) and defaults to None.
         non_marginable_buying_power (Optional[str]): The non marginable buying power for the account
         cash (Optional[str]): Cash balance in the account
         accrued_fees (Optional[str]): Fees accrued in this account
@@ -498,6 +499,7 @@ class TradeAccount(ModelWithID):
         portfolio_value (str): Total value of cash + holding positions.
           (This field is deprecated. It is equivalent to the equity field.)
         pattern_day_trader (Optional[bool]): Whether the account is flagged as pattern day trader or not.
+          Deprecated; removed from Alpaca responses on 2026-07-06 (FINRA intraday-margin migration) and defaults to None.
         trading_blocked (Optional[bool]): If true, the account is not allowed to place orders.
         transfers_blocked (Optional[bool]): If true, the account is not allowed to request money transfers.
         account_blocked (Optional[bool]): If true, the account activity by user is prohibited.
@@ -515,7 +517,8 @@ class TradeAccount(ModelWithID):
         last_maintenance_margin (Optional[str]): Maintenance margin requirement on the previous trading day
         sma (Optional[str]): Value of Special Memorandum Account (will be used at a later date to provide additional buying_power)
         daytrade_count (Optional[int]): The current number of daytrades that have been made in the last 5 trading days
-          (inclusive of today)
+          (inclusive of today).
+          Deprecated; removed from Alpaca responses on 2026-07-06 (FINRA intraday-margin migration) and defaults to None.
         options_buying_power (Optional[str]): Your buying power for options trading
         options_approved_level (Optional[int]): The options trading level that was approved for this account.
           0=disabled, 1=Covered Call/Cash-Secured Put, 2=Long Call/Put, 3=Spreads/Straddles.
@@ -563,22 +566,24 @@ class AccountConfiguration(BaseModel):
     Represents configuration options for a TradeAccount.
 
     Attributes:
-        dtbp_check (DTBPCheck): Day Trade Buying Power Check. Controls Day Trading Margin Call (DTMC) checks.
+        dtbp_check (Optional[DTBPCheck]): Day Trade Buying Power Check. Controls Day Trading Margin Call (DTMC) checks.
+          Deprecated; removed from Alpaca responses on 2026-07-06 (FINRA intraday-margin migration) and defaults to None.
         fractional_trading (bool): If true, account is able to participate in fractional trading
         max_margin_multiplier (str): A number between 1-4 that represents your max margin multiplier
         no_shorting (bool): If true then Account becomes long-only mode.
-        pdt_check (PDTCheck): Controls Pattern Day Trader (PDT) checks.
+        pdt_check (Optional[PDTCheck]): Controls Pattern Day Trader (PDT) checks.
+          Deprecated; removed from Alpaca responses on 2026-07-06 (FINRA intraday-margin migration) and defaults to None.
         suspend_trade (bool): If true Account becomes unable to submit new orders
         trade_confirm_email (TradeConfirmationEmail): Controls whether Trade confirmation emails are sent.
         ptp_no_exception_entry (bool): If set to true then Alpaca will accept orders for PTP symbols with no exception. Default is false.
         max_options_trading_level (Optional[int]): The desired maximum options trading level. 0=disabled, 1=Covered Call/Cash-Secured Put, 2=Long Call/Put, 3=Spreads/Straddles.
     """
 
-    dtbp_check: DTBPCheck
+    dtbp_check: Optional[DTBPCheck] = None
     fractional_trading: bool
     max_margin_multiplier: str
     no_shorting: bool
-    pdt_check: PDTCheck
+    pdt_check: Optional[PDTCheck] = None
     suspend_trade: bool
     trade_confirm_email: TradeConfirmationEmail
     ptp_no_exception_entry: bool

--- a/tests/broker/broker_client/test_accounts_routes.py
+++ b/tests/broker/broker_client/test_accounts_routes.py
@@ -950,6 +950,72 @@ def test_get_trade_account_by_id(reqmock, client: BrokerClient):
     assert account.id == UUID(account_id)
 
 
+def test_get_trade_account_by_id_without_deprecated_pdt_fields(
+    reqmock, client: BrokerClient
+):
+    """PDT/DTBP account fields are removed from Alpaca responses on 2026-07-06
+    (FINRA intraday-margin migration). The model must still validate when they
+    are absent, defaulting them to None instead of raising a ValidationError."""
+    account_id = "5fc0795e-1f16-40cc-aa90-ede67c39d7a9"
+
+    reqmock.get(
+        BaseURL.BROKER_SANDBOX.value + f"/v1/trading/accounts/{account_id}/account",
+        text="""
+        {
+          "id": "5fc0795e-1f16-40cc-aa90-ede67c39d7a9",
+          "account_number": "684486106",
+          "status": "ACTIVE",
+          "crypto_status": "ACTIVE",
+          "currency": "USD",
+          "buying_power": "0",
+          "regt_buying_power": "0",
+          "non_marginable_buying_power": "0",
+          "cash": "0",
+          "cash_withdrawable": "0",
+          "cash_transferable": "0",
+          "accrued_fees": "0",
+          "pending_transfer_out": "0",
+          "pending_transfer_in": "0",
+          "portfolio_value": "0",
+          "trading_blocked": false,
+          "transfers_blocked": false,
+          "account_blocked": false,
+          "created_at": "2022-04-14T15:51:14.523349Z",
+          "trade_suspended_by_user": false,
+          "multiplier": "1",
+          "shorting_enabled": false,
+          "equity": "0",
+          "last_equity": "0",
+          "long_market_value": "0",
+          "short_market_value": "0",
+          "initial_margin": "0",
+          "maintenance_margin": "0",
+          "last_maintenance_margin": "0",
+          "sma": "0",
+          "previous_close": "2022-04-13T20:00:00-04:00",
+          "last_long_market_value": "0",
+          "last_short_market_value": "0",
+          "last_cash": "0",
+          "last_initial_margin": "0",
+          "last_regt_buying_power": "0",
+          "last_buying_power": "0",
+          "clearing_broker": "VELOX"
+        }
+              """,
+    )
+
+    account = client.get_trade_account_by_id(account_id)
+
+    assert reqmock.called_once
+    assert type(account) == TradeAccount
+    assert account.id == UUID(account_id)
+    assert account.daytrading_buying_power is None
+    assert account.pattern_day_trader is None
+    assert account.daytrade_count is None
+    assert account.last_daytrading_buying_power is None
+    assert account.last_daytrade_count is None
+
+
 def test_get_trade_account_by_id_validates_account_id(reqmock, client: BrokerClient):
     with pytest.raises(ValueError) as e:
         client.get_trade_account_by_id("not a uuid")

--- a/tests/trading/trading_client/test_account_routes.py
+++ b/tests/trading/trading_client/test_account_routes.py
@@ -78,6 +78,34 @@ def test_get_account_configurations(reqmock: Mocker, trading_client: TradingClie
     assert account_configurations.max_options_trading_level == 1
 
 
+def test_get_account_configurations_without_deprecated_pdt_fields(
+    reqmock: Mocker, trading_client: TradingClient
+):
+    """dtbp_check / pdt_check are removed from Alpaca responses on 2026-07-06
+    (FINRA intraday-margin migration). The config model must still validate when
+    they are absent, defaulting them to None instead of raising a ValidationError."""
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/account/configurations",
+        text="""
+        {
+          "no_shorting": false,
+          "suspend_trade": false,
+          "fractional_trading": true,
+          "max_margin_multiplier": "4",
+          "trade_confirm_email": "all",
+          "ptp_no_exception_entry": false,
+          "max_options_trading_level": 1
+        }
+      """,
+    )
+
+    account_configurations = trading_client.get_account_configurations()
+    assert reqmock.called_once
+    assert isinstance(account_configurations, AccountConfiguration)
+    assert account_configurations.dtbp_check is None
+    assert account_configurations.pdt_check is None
+
+
 def test_set_account_configurations(reqmock: Mocker, trading_client: TradingClient):
     new_account_configurations = AccountConfiguration(
         **{


### PR DESCRIPTION
## Context
Alpaca is removing the pattern-day-trading/day-trading-buying-power fields from account and account-configuration responses on 2026-07-06 per FINRA's new intraday-margin framework (https://docs.alpaca.markets/us/changelog/2026-06-03-pdt-651df23). They have already started deprecating in sandbox starting today 2026-06-22. There are several fields currently on the deprecation path, but most are already configured as optional values that default to `None`, which prevents a pydantic validation error.

## Issue
I received the following error multiple times earlier today when using the sandbox API.
```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for TradeAccount
last_daytrading_buying_power
  Field required [type=missing, input_value={'id': '3f367124-b1df-4a3...ding_reg_taf_fees': '0'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
last_daytrade_count
  Field required [type=missing, input_value={'id': '3f367124-b1df-4a3...ding_reg_taf_fees': '0'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
```

## Fix
- Make sure all fields on the deprecation path are marked as optional and default to `None`. This is important because alpaca will no longer vend the field at all and therefore the `last_daytrading_buying_power`, `last_daytrade_count`, `dtbp_check`, and `pdt_check` keys will no longer exist. 
- Updated docstrings to indicate deprecation

## Testing
- Add some regression tests to test the lack of fields in mocked responses.

## Alternative solutions
There is a new feature introduced in pydantic (> 2.7) wherein we could warn the user of deprecated fields like so 
```
last_daytrade_count: Optional[int] = Field(
    default=None,
    deprecated="Removed from Alpaca responses on 2026-07-06 (FINRA intraday-margin migration).",
)
```
and would print a `DeprecationWarning` like this
```
DeprecationWarning: Removed from Alpaca responses on 2826-07-06 (FINRA intraday-margin migration).
```

However, alpaca-py's pydantic configuration currently puts the version floor at `^2.0.3` [Code](https://github.com/alpacahq/alpaca-py/blob/e4268eb61c564b0b665fa32f69024a9970e6f12b/pyproject.toml#L21), which does not support the `deprecated` kwarg. I'd like some input into whether it would be feasible to bump the pydantic floor version to support this, but adding the `deprecated` kwarg will not break pydantic versions < 2.7.


## Next Steps
To prevent code bloat I recommend removing these fields entirely once the deprecation is fully complete (2026-07-06).
