### PR TITLE
fix: Limit GitHub Actions token permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   lints-ci:
     #The lint jobs don't need to run on other OS's or python versions

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -4,6 +4,9 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
 
   tests-ci:


### PR DESCRIPTION
Add explicit workflow-level permissions to CI and PyPI publish workflows, granting only contents: read. This resolves CodeQL code-scanning alerts for missing `GITHUB_TOKEN` permission boundaries and follows least-privilege defaults for jobs that only need repository checkout/read access.