### PR TITLE
feat(trading): add wallet fee estimate route

### DIFF
--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -847,6 +847,30 @@ class TradingClient(RESTClient):
 
         return TypeAdapter(USCorporatesResp).validate_python(response)
 
+    # ####################### CRYPTO WALLETS ################################## #
+
+    def get_wallet_fee_estimate(
+        self, request: Optional[GetWalletFeeEstimateRequest] = None
+    ) -> Union[WalletFeeEstimate, RawData]:
+        """
+        Returns the estimated gas fee for a proposed crypto transfer.
+
+        Args:
+            request (Optional[GetWalletFeeEstimateRequest]): Optional query
+                parameters (asset, from_address, to_address, amount).
+
+        Returns:
+            Union[WalletFeeEstimate, RawData]: The estimated fee.
+        """
+        params = request.to_request_fields() if request is not None else {}
+
+        response = self.get("/wallets/fees/estimate", params)
+
+        if self._use_raw_data:
+            return response
+
+        return WalletFeeEstimate(**response)
+
     # ############################## LOCATES ################################# #
 
     def get_locates(

--- a/tests/trading/trading_client/test_wallet_routes.py
+++ b/tests/trading/trading_client/test_wallet_routes.py
@@ -1,0 +1,87 @@
+"""
+Tests for the Trading API's wallet routes:
+  GET /v2/wallets/fees/estimate
+"""
+
+from alpaca.common.enums import BaseURL
+from alpaca.trading.client import TradingClient
+from alpaca.trading.models import WalletFeeEstimate
+from alpaca.trading.requests import GetWalletFeeEstimateRequest
+
+
+def test_get_wallet_fee_estimate_no_params(reqmock, trading_client: TradingClient):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/wallets/fees/estimate",
+        text='{"fee": "0.0021", "network_fee": "0.0019"}',
+    )
+
+    result = trading_client.get_wallet_fee_estimate()
+
+    assert reqmock.called_once
+    assert isinstance(result, WalletFeeEstimate)
+    assert result.fee == "0.0021"
+    assert result.network_fee == "0.0019"
+
+
+def test_get_wallet_fee_estimate_fee_fields_are_optional(
+    reqmock, trading_client: TradingClient
+):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/wallets/fees/estimate",
+        text='{"network_fee": "0.0019"}',
+    )
+
+    result = trading_client.get_wallet_fee_estimate()
+
+    assert reqmock.called_once
+    assert isinstance(result, WalletFeeEstimate)
+    assert result.fee is None
+    assert result.network_fee == "0.0019"
+
+
+def test_get_wallet_fee_estimate_with_params(reqmock, trading_client: TradingClient):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/wallets/fees/estimate"
+        f"?asset=USDC&from_address=0xABC&to_address=0xDEF&amount=100",
+        text='{"fee": "0.0035"}',
+    )
+
+    result = trading_client.get_wallet_fee_estimate(
+        GetWalletFeeEstimateRequest(
+            asset="USDC",
+            from_address="0xABC",
+            to_address="0xDEF",
+            amount="100",
+        )
+    )
+
+    assert reqmock.called_once
+    assert isinstance(result, WalletFeeEstimate)
+    assert result.fee == "0.0035"
+
+
+def test_get_wallet_fee_estimate_partial_params(reqmock, trading_client: TradingClient):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/wallets/fees/estimate?asset=ETH",
+        text='{"fee": "0.0018"}',
+    )
+
+    result = trading_client.get_wallet_fee_estimate(
+        GetWalletFeeEstimateRequest(asset="ETH")
+    )
+
+    assert reqmock.called_once
+    assert isinstance(result, WalletFeeEstimate)
+    assert result.fee == "0.0018"
+
+
+def test_get_wallet_fee_estimate_raw(reqmock, trading_client_raw: TradingClient):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/wallets/fees/estimate",
+        text='{"fee": "0.0021"}',
+    )
+
+    result = trading_client_raw.get_wallet_fee_estimate()
+
+    assert isinstance(result, dict)
+    assert result["fee"] == "0.0021"


### PR DESCRIPTION
Add TradingClient.get_wallet_fee_estimate for estimating crypto transfer fees.

The new route tests cover empty parameters, partial parameters, optional fee fields, parsed response models, and raw response mode.