### PR TITLE
feat(trading): add v3 clock and calendar

### DIFF
--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -13,14 +13,16 @@ from alpaca.common.utils import (
     validate_symbol_or_contract_id,
     validate_uuid_id_param,
 )
+from alpaca.trading.enums import Market
 from alpaca.trading.models import (
     AccountConfiguration,
     Asset,
-    Calendar,
     CanceledOrderResponse,
     Clock,
+    ClockResp,
     ClosePositionResponse,
     CorporateActionAnnouncement,
+    LegacyCalendarDay,
     Locate,
     LocateQuotesResponse,
     LocatesResponse,
@@ -29,11 +31,12 @@ from alpaca.trading.models import (
     Order,
     PortfolioHistory,
     Position,
+    PublicCalendarResp,
     TradeAccount,
     USCorporate,
     USCorporatesResp,
-    USTreasury,
     USTreasuriesResp,
+    USTreasury,
     WalletFeeEstimate,
     Watchlist,
 )
@@ -52,6 +55,8 @@ from alpaca.trading.requests import (
     GetPortfolioHistoryRequest,
     GetUSCorporatesRequest,
     GetUSTreasuriesRequest,
+    GetV3CalendarRequest,
+    GetV3ClockRequest,
     GetWalletFeeEstimateRequest,
     OrderRequest,
     ReplaceOrderRequest,
@@ -435,6 +440,16 @@ class TradingClient(RESTClient):
 
     def get_clock(self) -> Union[Clock, RawData]:
         """
+        Gets the legacy v2 market clock.
+
+        Returns:
+            Clock: The market Clock data
+        """
+
+        return self.get_v2_clock()
+
+    def get_v2_clock(self) -> Union[Clock, RawData]:
+        """
         Gets the current market timestamp, whether or not the market is currently open, as well as the times
         of the next market open and close.
 
@@ -452,7 +467,23 @@ class TradingClient(RESTClient):
     def get_calendar(
         self,
         filters: Optional[GetCalendarRequest] = None,
-    ) -> Union[List[Calendar], RawData]:
+    ) -> Union[List[LegacyCalendarDay], RawData]:
+        """
+        Gets the legacy v2 market calendar.
+
+        Args:
+            filters: Any optional filters to limit the returned market days
+
+        Returns:
+            List[LegacyCalendarDay]: A list of legacy calendar day objects representing the market days.
+        """
+
+        return self.get_v2_calendar(filters)
+
+    def get_v2_calendar(
+        self,
+        filters: Optional[GetCalendarRequest] = None,
+    ) -> Union[List[LegacyCalendarDay], RawData]:
         """
         The calendar API serves the full list of market days from 1970 to 2029. It can also be queried by specifying a
         start and/or end time to narrow down the results.
@@ -464,7 +495,7 @@ class TradingClient(RESTClient):
             filters: Any optional filters to limit the returned market days
 
         Returns:
-            List[Calendar]: A list of Calendar objects representing the market days.
+            List[LegacyCalendarDay]: A list of legacy calendar day objects representing the market days.
         """
 
         result = self.get("/calendar", filters.to_request_fields() if filters else {})
@@ -472,7 +503,60 @@ class TradingClient(RESTClient):
         if self._use_raw_data:
             return result
 
-        return TypeAdapter(List[Calendar]).validate_python(result)
+        return TypeAdapter(List[LegacyCalendarDay]).validate_python(result)
+
+    def get_v3_calendar(
+        self,
+        market: Union[Market, str],
+        filters: Optional[GetV3CalendarRequest] = None,
+    ) -> Union[PublicCalendarResp, RawData]:
+        """
+        Gets the calendar for a specific market.
+
+        Args:
+            market: The market identifier to retrieve calendar days for.
+            filters: Any optional filters to limit the returned market days.
+
+        Returns:
+            PublicCalendarResp: The market metadata and trading calendar days.
+        """
+
+        market_value = market.value if isinstance(market, Market) else market
+        response = self.get(
+            f"/calendar/{market_value}",
+            filters.to_request_fields() if filters else {},
+            api_version="v3",
+        )
+
+        if self._use_raw_data:
+            return response
+
+        return PublicCalendarResp(**response)
+
+    def get_v3_clock(
+        self,
+        filters: Optional[GetV3ClockRequest] = None,
+    ) -> Union[ClockResp, RawData]:
+        """
+        Gets clock information for one or more markets.
+
+        Args:
+            filters: Any optional filters to limit the returned market clocks.
+
+        Returns:
+            ClockResp: A response containing clock information for one or more markets.
+        """
+
+        response = self.get(
+            "/clock",
+            filters.to_request_fields() if filters else {},
+            api_version="v3",
+        )
+
+        if self._use_raw_data:
+            return response
+
+        return ClockResp(**response)
 
     # ############################## ACCOUNT ################################# #
 

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -21,6 +21,7 @@ from alpaca.trading.enums import (
     CreateCryptoTransferRequestChain,
     ExerciseStyle,
     LocateStatus,
+    Market,
     OrderClass,
     OrderSide,
     OrderType,
@@ -98,6 +99,37 @@ class GetCalendarRequest(NonEmptyRequest):
     start: Optional[date] = None
     end: Optional[date] = None
     date_type: Optional[Literal["TRADING", "SETTLEMENT"]] = "TRADING"
+
+
+class GetV3CalendarRequest(NonEmptyRequest):
+    """
+    Represents the optional filtering you can do when requesting a v3 market calendar.
+    """
+
+    start: Optional[date] = None
+    end: Optional[date] = None
+    timezone: Optional[Literal["UTC"]] = None
+
+
+class GetV3ClockRequest(NonEmptyRequest):
+    """
+    Represents the optional filtering you can do when requesting v3 market clocks.
+    """
+
+    markets: Optional[Union[str, List[Union[Market, str]]]] = None
+    time: Optional[datetime] = None
+
+    def to_request_fields(self) -> dict:
+        fields = super().to_request_fields()
+        markets = fields.get("markets")
+
+        if isinstance(markets, list):
+            fields["markets"] = ",".join(
+                market.value if isinstance(market, Market) else market
+                for market in markets
+            )
+
+        return fields
 
 
 class CreateWatchlistRequest(NonEmptyRequest):

--- a/tests/trading/trading_client/test_clock_calendar_routes.py
+++ b/tests/trading/trading_client/test_clock_calendar_routes.py
@@ -1,0 +1,194 @@
+from datetime import date, datetime, timezone
+from typing import List
+
+import pytest
+
+from alpaca.common.enums import BaseURL
+from alpaca.trading.client import TradingClient
+from alpaca.trading.enums import Market, Phase
+from alpaca.trading.models import (
+    Clock,
+    ClockResp,
+    LegacyCalendarDay,
+    PublicCalendarResp,
+)
+from alpaca.trading.requests import GetV3CalendarRequest, GetV3ClockRequest
+
+
+@pytest.mark.parametrize("method_name", ["get_clock", "get_v2_clock"])
+def test_get_v2_clock(reqmock, trading_client: TradingClient, method_name):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/clock",
+        text="""
+        {
+          "timestamp": "2022-05-16T16:32:24.14373588-04:00",
+          "is_open": false,
+          "next_open": "2022-05-17T09:30:00-04:00",
+          "next_close": "2022-05-17T16:00:00-04:00"
+        }
+        """,
+    )
+
+    result = getattr(trading_client, method_name)()
+
+    assert reqmock.called_once
+    assert isinstance(result, Clock)
+
+
+@pytest.mark.parametrize("method_name", ["get_calendar", "get_v2_calendar"])
+def test_get_v2_calendar_preserves_legacy_session_fields(
+    reqmock, trading_client: TradingClient, method_name
+):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/calendar",
+        text="""
+        [
+          {
+            "date": "2025-01-02",
+            "open": "09:30",
+            "close": "16:00",
+            "session_open": "0400",
+            "session_close": "2000",
+            "settlement_date": "2025-01-03"
+          }
+        ]
+        """,
+    )
+
+    result = getattr(trading_client, method_name)()
+
+    assert reqmock.called_once
+    assert isinstance(result, List)
+    assert len(result) == 1
+    assert isinstance(result[0], LegacyCalendarDay)
+    assert result[0].date == date(2025, 1, 2)
+    assert result[0].open == "09:30"
+    assert result[0].close == "16:00"
+    assert result[0].session_open == "0400"
+    assert result[0].session_close == "2000"
+    assert result[0].settlement_date == date(2025, 1, 3)
+
+
+def test_get_v3_calendar(reqmock, trading_client: TradingClient):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v3/calendar/NYSE",
+        text="""
+        {
+          "market": {
+            "acronym": "NYSE",
+            "name": "New York Stock Exchange",
+            "timezone": "America/New_York",
+            "mic": "XNYS"
+          },
+          "calendar": [
+            {
+              "date": "2025-01-02",
+              "core_start": "2025-01-02T09:30:00-05:00",
+              "core_end": "2025-01-02T16:00:00-05:00",
+              "pre_start": "2025-01-02T04:00:00-05:00",
+              "pre_end": "2025-01-02T09:30:00-05:00",
+              "post_start": "2025-01-02T16:00:00-05:00",
+              "post_end": "2025-01-02T20:00:00-05:00",
+              "settlement_date": "2025-01-03"
+            }
+          ]
+        }
+        """,
+    )
+
+    result = trading_client.get_v3_calendar(
+        Market.NYSE,
+        GetV3CalendarRequest(
+            start=date(2025, 1, 2),
+            end=date(2025, 1, 3),
+            timezone="UTC",
+        ),
+    )
+
+    assert reqmock.called_once
+    assert reqmock.request_history[0].qs == {
+        "start": ["2025-01-02"],
+        "end": ["2025-01-03"],
+        "timezone": ["utc"],
+    }
+    assert isinstance(result, PublicCalendarResp)
+    assert result.market.acronym == "NYSE"
+    assert len(result.calendar) == 1
+    assert result.calendar[0].date == date(2025, 1, 2)
+    assert result.calendar[0].settlement_date == date(2025, 1, 3)
+
+
+def test_get_v3_calendar_raw(reqmock, trading_client_raw: TradingClient):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v3/calendar/NYSE",
+        json={
+            "market": {
+                "acronym": "NYSE",
+                "name": "New York Stock Exchange",
+                "timezone": "America/New_York",
+                "mic": "XNYS",
+            },
+            "calendar": [],
+        },
+    )
+
+    result = trading_client_raw.get_v3_calendar("NYSE")
+
+    assert reqmock.called_once
+    assert result["market"]["acronym"] == "NYSE"
+    assert result["calendar"] == []
+
+
+def test_get_v3_clock(reqmock, trading_client: TradingClient):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v3/clock",
+        text="""
+        {
+          "clocks": [
+            {
+              "market": {
+                "acronym": "NYSE",
+                "name": "New York Stock Exchange",
+                "timezone": "America/New_York",
+                "mic": "XNYS"
+              },
+              "timestamp": "2025-01-02T14:30:00Z",
+              "is_market_day": true,
+              "next_market_open": "2025-01-02T09:30:00-05:00",
+              "next_market_close": "2025-01-02T16:00:00-05:00",
+              "phase": "core",
+              "phase_until": "2025-01-02T16:00:00-05:00"
+            }
+          ]
+        }
+        """,
+    )
+
+    result = trading_client.get_v3_clock(
+        GetV3ClockRequest(
+            markets=[Market.NYSE, "LSE"],
+            time=datetime(2025, 1, 2, 14, 30, tzinfo=timezone.utc),
+        )
+    )
+
+    assert reqmock.called_once
+    assert reqmock.request_history[0].qs == {
+        "markets": ["nyse,lse"],
+        "time": ["2025-01-02t14:30:00+00:00"],
+    }
+    assert isinstance(result, ClockResp)
+    assert len(result.clocks) == 1
+    assert result.clocks[0].market.acronym == "NYSE"
+    assert result.clocks[0].phase == Phase.CORE
+
+
+def test_get_v3_clock_raw(reqmock, trading_client_raw: TradingClient):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v3/clock",
+        json={"clocks": []},
+    )
+
+    result = trading_client_raw.get_v3_clock()
+
+    assert reqmock.called_once
+    assert result == {"clocks": []}


### PR DESCRIPTION
Add TradingClient.get_v3_calendar and TradingClient.get_v3_clock.

Also, created aliases for TradingClient.get_calendar -> TradingClient.get_v2_calendar and TradingClient.get_clock -> TradingClient.get_v2_clock