### PR TITLE
feat(trading): add account response fields

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -529,9 +529,11 @@ class TradeAccount(ModelWithID):
         status (AccountStatus): The current status of the account
         crypto_status (Optional[AccountStatus]): The status of the account in regards to trading crypto. Only present if
           crypto trading is enabled for your brokerage account.
+        crypto_tier (Optional[int]): The account's crypto trading tier.
         currency (Optional[str]): Currently will always be the value "USD".
         buying_power (Optional[str]): Current available cash buying power. If multiplier = 2 then
           buying_power = max(equity-initial_margin(0) * 2). If multiplier = 1 then buying_power = cash.
+        effective_buying_power (Optional[str]): Effective buying power available to the account.
         regt_buying_power (Optional[str]): User’s buying power under Regulation T
           (excess equity - (equity - margin value) * margin multiplier)
         daytrading_buying_power (Optional[str]): The buying power for day trades for the account
@@ -555,6 +557,7 @@ class TradeAccount(ModelWithID):
         last_equity (Optional[str]): Equity as of previous trading day at 16:00:00 ET
         long_market_value (Optional[str]): Real-time MtM value of all long positions held in the account
         short_market_value (Optional[str]): Real-time MtM value of all short positions held in the account
+        position_market_value (Optional[str]): Real-time MtM value of all positions held in the account
         initial_margin (Optional[str]): Reg T initial margin requirement
         maintenance_margin (Optional[str]): Maintenance margin requirement
         balance_asof (Optional[str]): The date of the snapshot for `last_*` fields
@@ -575,8 +578,10 @@ class TradeAccount(ModelWithID):
     account_number: Optional[str] = None
     status: AccountStatus
     crypto_status: Optional[AccountStatus] = None
+    crypto_tier: Optional[int] = None
     currency: Optional[str] = None
     buying_power: Optional[str] = None
+    effective_buying_power: Optional[str] = None
     regt_buying_power: Optional[str] = None
     daytrading_buying_power: Optional[str] = None
     non_marginable_buying_power: Optional[str] = None
@@ -597,6 +602,7 @@ class TradeAccount(ModelWithID):
     last_equity: Optional[str] = None
     long_market_value: Optional[str] = None
     short_market_value: Optional[str] = None
+    position_market_value: Optional[str] = None
     initial_margin: Optional[str] = None
     maintenance_margin: Optional[str] = None
     balance_asof: Optional[str] = None

--- a/tests/trading/trading_client/test_account_routes.py
+++ b/tests/trading/trading_client/test_account_routes.py
@@ -16,9 +16,11 @@ def test_get_account(reqmock: Mocker, trading_client: TradingClient):
           "buying_power": "262113.632",
           "cash": "-23140.2",
           "created_at": "2019-06-12T22:47:07.99658Z",
+          "crypto_tier": 1,
           "currency": "USD",
           "daytrade_count": 0,
           "daytrading_buying_power": "262113.632",
+          "effective_buying_power": "262113.632",
           "equity": "103820.56",
           "id": "e6fe16f3-64a4-4921-8928-cadf02f92f98",
           "initial_margin": "63480.38",
@@ -40,7 +42,8 @@ def test_get_account(reqmock: Mocker, trading_client: TradingClient):
           "transfers_blocked": false,
           "options_buying_power": "262113.632",
           "options_approved_level": "1",
-          "options_trading_level": "1"
+          "options_trading_level": "1",
+          "position_market_value": "126960.76"
         }
       """,
     )
@@ -52,6 +55,9 @@ def test_get_account(reqmock: Mocker, trading_client: TradingClient):
     assert account.options_buying_power == "262113.632"
     assert account.options_approved_level == 1
     assert account.options_trading_level == 1
+    assert account.crypto_tier == 1
+    assert account.effective_buying_power == "262113.632"
+    assert account.position_market_value == "126960.76"
 
 
 def test_get_account_configurations(reqmock: Mocker, trading_client: TradingClient):


### PR DESCRIPTION
Add TradeAccount fields for crypto_tier, effective_buying_power, and position_market_value.

Expand account route tests to assert the new response fields parse correctly.