### PR TITLE
feat(trading): add corporate announcement fields

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -653,6 +653,7 @@ class CorporateActionAnnouncement(ModelWithID):
     Attributes:
         id (UUID): The unique identifier for this single announcement.
         corporate_action_id (str): ID that remains consistent across all announcements for the same corporate action.
+        corporate_actions_id (Optional[str]): API response alias for the corporate action ID.
         ca_type (CorporateActionType): The type of corporate action that was announced.
         ca_sub_type (CorporateActionSubType): The specific subtype of corporate action that was announced.
         initiating_symbol (str): Symbol of the company initiating the announcement.
@@ -665,12 +666,14 @@ class CorporateActionAnnouncement(ModelWithID):
             corporate action entitlement.
         payable_date (Optional[date]): The date the announcement will take effect. On this date, account stock and cash
             balances are expected to be processed accordingly.
+        expiration_date (Optional[date]): Expiration date for the corporate action announcement.
         cash (float): The amount of cash to be paid per share held by an account on the record date.
         old_rate (float): The denominator to determine any quantity change ratios in positions.
         new_rate (float): The numerator to determine any quantity change ratios in positions.
     """
 
     corporate_action_id: str
+    corporate_actions_id: Optional[str] = None
     ca_type: CorporateActionType
     ca_sub_type: CorporateActionSubType
     initiating_symbol: str
@@ -679,6 +682,7 @@ class CorporateActionAnnouncement(ModelWithID):
     target_original_cusip: Optional[str] = None
     declaration_date: Optional[date] = None
     ex_date: Optional[date] = None
+    expiration_date: Optional[date] = None
     record_date: Optional[date] = None
     payable_date: Optional[date] = None
     cash: float

--- a/tests/trading/trading_client/test_corporate_announcements.py
+++ b/tests/trading/trading_client/test_corporate_announcements.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import List
 
 import pytest
@@ -78,3 +79,66 @@ def test_get_announcements(reqmock, trading_client: TradingClient):
     assert isinstance(response, List)
     assert len(response) > 0
     assert isinstance(response[0], CorporateActionAnnouncement)
+    assert response[0].expiration_date == date(2021, 1, 12)
+
+
+def test_get_announcements_preserves_corporate_actions_id_and_expiration_date(
+    reqmock, trading_client: TradingClient
+):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/corporate_actions/announcements",
+        json=[
+            {
+                "id": "be3c368a-4c7c-4384-808e-f02c9f5a8afe",
+                "corporate_action_id": "F58684224_XY37",
+                "corporate_actions_id": "F58684224_XY37",
+                "ca_type": "dividend",
+                "ca_sub_type": "cash",
+                "initiating_symbol": "MLLAX",
+                "initiating_original_cusip": "55275E101",
+                "expiration_date": "2021-01-12",
+                "cash": "0.018",
+                "old_rate": "1",
+                "new_rate": "1",
+            }
+        ],
+    )
+
+    with pytest.deprecated_call():
+        response = trading_client.get_corporate_announcements(
+            GetCorporateAnnouncementsRequest(
+                ca_types=[CorporateActionType.DIVIDEND.value],
+                since="2021-01-01",
+                until="2021-02-01",
+            )
+        )
+
+    assert response[0].corporate_actions_id == "F58684224_XY37"
+    assert response[0].expiration_date == date(2021, 1, 12)
+
+
+def test_get_announcement_by_id_preserves_corporate_actions_id_and_expiration_date(
+    reqmock, trading_client: TradingClient
+):
+    announcement_id = "be3c368a-4c7c-4384-808e-f02c9f5a8afe"
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/corporate_actions/announcements/{announcement_id}",
+        json={
+            "id": announcement_id,
+            "corporate_action_id": "F58684224_XY37",
+            "corporate_actions_id": "F58684224_XY37",
+            "ca_type": "dividend",
+            "ca_sub_type": "cash",
+            "initiating_symbol": "MLLAX",
+            "initiating_original_cusip": "55275E101",
+            "expiration_date": "2021-01-12",
+            "cash": "0.018",
+            "old_rate": "1",
+            "new_rate": "1",
+        },
+    )
+
+    response = trading_client.get_corporate_announcement_by_id(announcement_id)
+
+    assert response.corporate_actions_id == "F58684224_XY37"
+    assert response.expiration_date == date(2021, 1, 12)


### PR DESCRIPTION
Preserve corporate_actions_id and expiration_date on CorporateActionAnnouncement responses.

Expand announcement route tests for list and by-id parsing.