### PR TITLE
feat(trading): align replace order request

### DIFF
--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -330,37 +330,69 @@ def _validate_advanced_order_class_requirements(values: dict) -> None:
 
 
 class ReplaceOrderRequest(NonEmptyRequest):
-    """Contains data for submitting a request to replace an order.
+    """
+    Request to replace (patch) an existing open order.
+
+    Note: ``qty`` and ``notional`` are mutually exclusive. ``notional`` is only valid for
+    IPO indications of interest (``asset_class: "ipo"``); non-IPO notional orders cannot
+    be replaced at all.
 
     Attributes:
-        qty (Optional[int]): Number of shares to trade
-        time_in_force (Optional[TimeInForce]): The new expiration logic of the order.
-        limit_price (Optional[float]): Required if type of order being replaced is limit or stop_limit
-        stop_price (Optional[float]): Required if type of order being replaced is stop or stop_limit
-        trail (Optional[float]): The new value of the trail_price or trail_percent value (works only for type=“trailing_stop”)
-        client_order_id (Optional[str]): A unique identifier for the order.
+        qty (Optional[str]): Number of shares to trade.
+        notional (Optional[str]): New dollar amount for IPO orders only.
+        time_in_force (Optional[TimeInForce]): New time-in-force for the order.
+        limit_price (Optional[str]): Required if the original order type is ``limit`` or
+            ``stop_limit``. For multi-leg orders, positive = debit, negative = credit.
+        stop_price (Optional[str]): Required if the original order type is ``stop`` or
+            ``stop_limit``.
+        trail (Optional[str]): New ``trail_price`` or ``trail_percent`` value
+            (trailing-stop orders only).
+        client_order_id (Optional[str]): Unique identifier for the replacement order.
+        advanced_instructions (Optional[AdvancedInstructions]): Elite Smart Router
+            instructions for the replacement order.
     """
 
-    qty: Optional[int] = None
+    qty: Optional[str] = None
+    notional: Optional[str] = None
     time_in_force: Optional[TimeInForce] = None
-    limit_price: Optional[float] = None
-    stop_price: Optional[float] = None
-    trail: Optional[float] = None
+    limit_price: Optional[str] = None
+    stop_price: Optional[str] = None
+    trail: Optional[str] = None
     client_order_id: Optional[str] = None
+    advanced_instructions: Optional[AdvancedInstructions] = None
 
     @model_validator(mode="before")
     def root_validator(cls, values: dict) -> dict:
+        values = dict(values)
+
+        for field in ("qty", "notional", "limit_price", "stop_price", "trail"):
+            value = values.get(field)
+            if value is not None and not isinstance(value, str):
+                values[field] = str(value)
+
         qty = values.get("qty", None)
-        limit_price = values.get("limit_price", None)
+        notional = values.get("notional", None)
         stop_price = values.get("stop_price", None)
         trail = values.get("trail", None)
 
-        if (qty is not None) and (qty <= 0):
-            raise ValueError("qty must be greater than 0")
-        if (stop_price is not None) and (stop_price <= 0):
-            raise ValueError("stop_price must be greater than 0")
-        if (trail is not None) and (trail <= 0):
-            raise ValueError("trail must be greater than 0")
+        if qty is not None and notional is not None:
+            raise ValueError("Both qty and notional can not be set.")
+
+        def validate_greater_than_zero(value: str, name: str) -> None:
+            try:
+                numeric_value = float(value)
+            except (TypeError, ValueError):
+                raise ValueError(f"{name} must be greater than 0")
+
+            if numeric_value <= 0:
+                raise ValueError(f"{name} must be greater than 0")
+
+        if qty is not None:
+            validate_greater_than_zero(qty, "qty")
+        if stop_price is not None:
+            validate_greater_than_zero(stop_price, "stop_price")
+        if trail is not None:
+            validate_greater_than_zero(trail, "trail")
 
         return values
 
@@ -799,41 +831,6 @@ class CreateCryptoTransferRequest(NonEmptyRequest):
             CreateCryptoTransferRequestChain, Literal["SOL", "ETH", "BTC", "XRP", "ARB"]
         ]
     ] = None
-
-
-class PatchOrderRequest(NonEmptyRequest):
-    """
-    Request to patch (replace) an existing open order.
-
-    Note: ``qty`` and ``notional`` are mutually exclusive. ``notional`` is only valid for
-    IPO indications of interest (``asset_class: "ipo"``); non-IPO notional orders cannot
-    be replaced at all — cancel and resubmit instead.
-
-    Attributes:
-        qty (Optional[str]): Number of shares to trade (full shares only). Fractional qty
-            and non-IPO notional orders cannot be changed via patch.
-        notional (Optional[str]): New dollar amount for IPO orders only.
-        time_in_force (Optional[TimeInForce]): New time-in-force for the order.
-        limit_price (Optional[str]): Required if the original order type is ``limit`` or
-            ``stop_limit``. For multi-leg orders, positive = debit, negative = credit.
-        stop_price (Optional[str]): Required if the original order type is ``stop`` or
-            ``stop_limit``.
-        trail (Optional[str]): New ``trail_price`` or ``trail_percent`` value
-            (trailing-stop orders only).
-        client_order_id (Optional[str]): Unique identifier for the replacement order
-            (max 128 characters).
-        advanced_instructions (Optional[AdvancedInstructions]): Elite Smart Router
-            instructions for the replacement order.
-    """
-
-    qty: Optional[str] = None
-    notional: Optional[str] = None
-    time_in_force: Optional[TimeInForce] = None
-    limit_price: Optional[str] = None
-    stop_price: Optional[str] = None
-    trail: Optional[str] = None
-    client_order_id: Optional[str] = None
-    advanced_instructions: Optional[AdvancedInstructions] = None
 
 
 class TokenizationMintRequest(NonEmptyRequest):

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -1,4 +1,6 @@
+import inspect
 import warnings
+from typing import Optional
 from uuid import UUID
 import pytest
 
@@ -286,6 +288,113 @@ def test_replace_order(reqmock, trading_client: TradingClient):
     order = trading_client.replace_order_by_id(order_id, replace_order_request)
 
     assert type(order) is Order
+
+
+def test_replace_order_accepts_patch_request_string_fields(
+    reqmock, trading_client: TradingClient
+):
+    order_id = "61e69015-8549-4bfd-b9c3-01e75843f47d"
+
+    reqmock.patch(
+        f"{BaseURL.TRADING_PAPER.value}/v2/orders/{order_id}",
+        text="""
+        {
+            "id": "61e69015-8549-4bfd-b9c3-01e75843f47d",
+            "client_order_id": "eb9e2aaa-f71a-4f51-b5b4-52a6c565dad4",
+            "created_at": "2021-03-16T18:38:01.942282Z",
+            "updated_at": "2021-03-16T18:38:01.942282Z",
+            "submitted_at": "2021-03-16T18:38:01.937734Z",
+            "filled_at": null,
+            "expired_at": null,
+            "canceled_at": null,
+            "failed_at": null,
+            "replaced_at": null,
+            "replaced_by": null,
+            "replaces": null,
+            "asset_id": "904837e3-3b76-47ec-b432-046db621571b",
+            "symbol": "AAPL",
+            "asset_class": "us_equity",
+            "notional": "0",
+            "qty": "4",
+            "filled_qty": "0",
+            "filled_avg_price": null,
+            "order_class": "simple",
+            "order_type": "limit",
+            "type": "limit",
+            "side": "buy",
+            "time_in_force": "gtc",
+            "limit_price": "155",
+            "stop_price": null,
+            "status": "accepted",
+            "extended_hours": false,
+            "legs": null,
+            "trail_percent": null,
+            "trail_price": null,
+            "hwm": null,
+            "position_intent": "buy_to_open",
+            "commission": 1.25
+        }
+        """,
+    )
+
+    order = trading_client.replace_order_by_id(
+        order_id,
+        ReplaceOrderRequest(qty="4", limit_price="155", time_in_force="gtc"),
+    )
+
+    assert type(order) is Order
+    assert reqmock.request_history[0].json() == {
+        "qty": "4",
+        "time_in_force": "gtc",
+        "limit_price": "155",
+    }
+
+
+def test_replace_order_by_id_uses_replace_order_request_annotation() -> None:
+    signature = inspect.signature(TradingClient.replace_order_by_id)
+
+    assert (
+        signature.parameters["order_data"].annotation == Optional[ReplaceOrderRequest]
+    )
+
+
+def test_replace_order_request_accepts_spec_string_fields() -> None:
+    request = ReplaceOrderRequest(qty="4", limit_price="155", time_in_force="gtc")
+
+    assert request.to_request_fields() == {
+        "qty": "4",
+        "time_in_force": "gtc",
+        "limit_price": "155",
+    }
+
+
+def test_replace_order_request_matches_patch_order_oas_fields() -> None:
+    assert set(ReplaceOrderRequest.model_fields) == {
+        "qty",
+        "notional",
+        "time_in_force",
+        "limit_price",
+        "stop_price",
+        "trail",
+        "client_order_id",
+        "advanced_instructions",
+    }
+
+
+def test_replace_order_request_converts_numeric_inputs_to_oas_strings() -> None:
+    request = ReplaceOrderRequest(qty=4, limit_price=155, stop_price=150.5, trail=1)
+
+    assert request.to_request_fields() == {
+        "qty": "4",
+        "limit_price": "155",
+        "stop_price": "150.5",
+        "trail": "1",
+    }
+
+
+def test_replace_order_request_rejects_qty_and_notional_together() -> None:
+    with pytest.raises(ValueError):
+        ReplaceOrderRequest(qty="4", notional="750")
 
 
 def test_replace_order_validate_replace_request() -> None:


### PR DESCRIPTION
Fold patch-order OAS fields into ReplaceOrderRequest and remove the duplicate PatchOrderRequest schema.

Convert numeric patch inputs to API string fields and validate qty/notional exclusivity.