### PR TITLE
fix: add __contains__ to BaseDataSet so `symbol in dataset` works

### DIFF
--- a/alpaca/data/models/base.py
+++ b/alpaca/data/models/base.py
@@ -65,6 +65,17 @@ class BaseDataSet(BaseModel):
 
         return self.data[symbol]
 
+    def __contains__(self, symbol: str) -> bool:
+        """Checks if data exists for a given symbol
+
+        Args:
+            symbol (str): The ticker identifier to check for
+
+        Returns:
+            bool: Whether data exists for the given symbol
+        """
+        return symbol in self.data
+
     def dict(self, **kwargs) -> dict:
         """
         Gives dictionary representation of data.

--- a/tests/data/test_historical_stock_data.py
+++ b/tests/data/test_historical_stock_data.py
@@ -76,6 +76,47 @@ def test_get_bars(reqmock, stock_client: StockHistoricalDataClient):
     assert reqmock.called_once
 
 
+def test_barset_contains(reqmock, stock_client: StockHistoricalDataClient):
+    # Test that `symbol in barset` reflects whether data exists for the symbol
+
+    symbol = "AAPL"
+    timeframe = TimeFrame.Day
+    start = datetime(2022, 2, 1)
+    limit = 2
+    _start_in_url = urllib.parse.quote_plus(
+        start.replace(tzinfo=timezone.utc).isoformat()
+    )
+    reqmock.get(
+        f"https://data.alpaca.markets/v2/stocks/bars?symbols=AAPL&start={_start_in_url}&timeframe={timeframe}&limit={limit}",
+        text="""
+{
+    "bars": {
+        "AAPL": [
+            {
+                "t": "2022-02-01T05:00:00Z",
+                "o": 174,
+                "h": 174.84,
+                "l": 172.31,
+                "c": 174.61,
+                "v": 85998033,
+                "n": 732412,
+                "vw": 173.703516
+            }
+        ]
+    },
+    "next_page_token": null
+}
+        """,
+    )
+    request = StockBarsRequest(
+        symbol_or_symbols=symbol, timeframe=timeframe, start=start, limit=limit
+    )
+    barset = stock_client.get_stock_bars(request_params=request)
+
+    assert symbol in barset
+    assert "TSLA" not in barset
+
+
 def test_get_bars_desc(reqmock, stock_client: StockHistoricalDataClient):
     symbol = "TSLA"
     timeframe = TimeFrame.Day


### PR DESCRIPTION
## Summary

Fixes #641.

`BaseDataSet` (parent of `BarSet`, `QuoteSet`, `TradeSet`, etc.) defines `__getitem__` but not `__contains__`, so `"SPY" in bars` fell back to pydantic's default field iteration and always returned `False`, even when `bars["SPY"]` returned data.

## Changes

- Add `__contains__` to `BaseDataSet`, delegating membership to `self.data` (consistent with `__getitem__`)
- Add `test_barset_contains` covering both the positive case (symbol with data) and negative case (symbol not in the response)

## Testing

```
pytest tests/ -> 244 passed
black --check -> clean
```

The new test fails on master (`assert symbol in barset` returns False) and passes with this change.