### PR TITLE
feat: add CashInterest model to account requests and Account model

### DIFF
--- a/alpaca/broker/models/accounts.py
+++ b/alpaca/broker/models/accounts.py
@@ -41,6 +41,33 @@ class KycResults(BaseModel):
     summary: Optional[str] = None
 
 
+class CashInterestProgram(BaseModel):
+    """
+    The configuration and status of an account within a cash interest program.
+    ref. https://docs.alpaca.markets/reference/createaccount
+
+    Attributes:
+        apr_tier_name (Optional[str]): The unique name of the APR tier for a specific program
+        status (Optional[str]): The status of the account within a cash interest program. One of
+         ACTIVE, INACTIVE, or PENDING_CHANGE. Should not be specified on enrollment or tier changes.
+    """
+
+    apr_tier_name: Optional[str] = None
+    status: Optional[str] = None
+
+
+class CashInterest(BaseModel):
+    """
+    The configuration of the account's cash interest program per currency.
+    ref. https://docs.alpaca.markets/reference/createaccount
+
+    Attributes:
+        USD (Optional[CashInterestProgram]): The configuration of the account's USD cash interest program
+    """
+
+    USD: Optional[CashInterestProgram] = None
+
+
 class Contact(BaseModel):
     """User contact details within Account Model
 
@@ -250,6 +277,7 @@ class Account(ModelWithID):
         agreements (Optional[List[Agreement]]): The agreements the account holder has signed
         documents (Optional[List[AccountDocument]]): The documents the account holder has submitted
         trusted_contact (Optional[TrustedContact]): The account holder's trusted contact details
+        cash_interest (Optional[CashInterest]): The configuration and status of the account's cash interest program
     """
 
     account_number: str
@@ -267,6 +295,7 @@ class Account(ModelWithID):
     agreements: Optional[List[Agreement]] = None
     documents: Optional[List[AccountDocument]] = None
     trusted_contact: Optional[TrustedContact] = None
+    cash_interest: Optional[CashInterest] = None
 
     def __init__(self, **response):
         super().__init__(
@@ -316,6 +345,11 @@ class Account(ModelWithID):
             trusted_contact=(
                 TypeAdapter(TrustedContact).validate_python(response["trusted_contact"])
                 if "trusted_contact" in response
+                else None
+            ),
+            cash_interest=(
+                TypeAdapter(CashInterest).validate_python(response["cash_interest"])
+                if "cash_interest" in response and response["cash_interest"] is not None
                 else None
             ),
         )

--- a/alpaca/broker/requests.py
+++ b/alpaca/broker/requests.py
@@ -32,6 +32,7 @@ from alpaca.broker.enums import (
 from alpaca.broker.models.accounts import (
     AccountDocument,
     Agreement,
+    CashInterest,
     Contact,
     Disclosures,
     Identity,
@@ -130,6 +131,8 @@ class CreateAccountRequest(NonEmptyRequest):
         agreements (List[Agreement]): The agreements the account holder has signed
         documents (List[Union[AccountDocument, UploadW8BenDocumentRequest]]): The documents the account holder has submitted
         trusted_contact (TrustedContact): The account holder's trusted contact details
+        cash_interest (Optional[CashInterest]): The configuration of the account's cash interest program.
+         If not provided and there is a default APR tier defined, that tier will be used.
     """
 
     account_type: Optional[Union[AccountType, str]] = None
@@ -142,6 +145,7 @@ class CreateAccountRequest(NonEmptyRequest):
     trusted_contact: Optional[TrustedContact] = None
     currency: Optional[SupportedCurrencies] = None  # None = USD
     enabled_assets: Optional[List[AssetClass]] = None  # None = Default to server
+    cash_interest: Optional[CashInterest] = None
 
     @model_validator(mode="before")
     def validate_parameters_only_optional_in_response(cls, values: dict) -> dict:
@@ -159,6 +163,25 @@ class CreateAccountRequest(NonEmptyRequest):
             if dict(values[model]).get(field, None) is None:
                 raise ValueError(f"{field} is required to create a new account.")
         return values
+
+    @field_validator("cash_interest")
+    def cash_interest_specifies_only_apr_tier_name(
+        cls, v: Optional[CashInterest]
+    ) -> Optional[CashInterest]:
+        """
+        Validate that a cash_interest enrollment only specifies the desired apr_tier_name.
+        The status should not be specified on enrollment.
+        """
+        if v is not None and v.USD is not None:
+            if v.USD.status is not None:
+                raise ValueError(
+                    "status should not be specified when enrolling in a cash interest program."
+                )
+            if v.USD.apr_tier_name is None:
+                raise ValueError(
+                    "apr_tier_name is required to enroll in a cash interest program."
+                )
+        return v
 
 
 class UpdatableContact(Contact):
@@ -290,12 +313,37 @@ class UpdateAccountRequest(NonEmptyRequest):
         identity (Optional[UpdatableIdentity]): Identity details to update to
         disclosures (Optional[UpdatableDisclosures]): Disclosure details to update to
         trusted_contact (Optional[UpdatableTrustedContact]): TrustedContact details to update to
+        cash_interest (Optional[CashInterest]): Cash interest program configuration to update to.
+         To enroll or change tiers, specify the apr_tier_name. To unenroll, set the status to INACTIVE.
     """
 
     contact: Optional[UpdatableContact] = None
     identity: Optional[UpdatableIdentity] = None
     disclosures: Optional[UpdatableDisclosures] = None
     trusted_contact: Optional[UpdatableTrustedContact] = None
+    cash_interest: Optional[CashInterest] = None
+
+    @field_validator("cash_interest")
+    def cash_interest_specifies_a_single_change(
+        cls, v: Optional[CashInterest]
+    ) -> Optional[CashInterest]:
+        """
+        Validate that a cash_interest update either specifies the apr_tier_name to
+        enroll or change tiers, or the status to unenroll, but not both. The status
+        should not be specified on enrollment or tier changes.
+        """
+        if v is not None and v.USD is not None:
+            if v.USD.apr_tier_name is not None and v.USD.status is not None:
+                raise ValueError(
+                    "status should not be specified when enrolling in a cash interest"
+                    " program or changing APR tiers."
+                )
+            if v.USD.apr_tier_name is None and v.USD.status is None:
+                raise ValueError(
+                    "cash_interest must specify either an apr_tier_name to enroll or"
+                    " change APR tiers, or a status to unenroll."
+                )
+        return v
 
 
 class ListAccountsRequest(NonEmptyRequest):

--- a/tests/broker/broker_client/test_accounts_routes.py
+++ b/tests/broker/broker_client/test_accounts_routes.py
@@ -8,7 +8,14 @@ import pytest
 
 from alpaca.broker.client import BrokerClient
 from alpaca.broker.enums import AccountEntities, AccountSubType, AccountType
-from alpaca.broker.models import Account, Contact, Identity, TradeAccount
+from alpaca.broker.models import (
+    Account,
+    CashInterest,
+    CashInterestProgram,
+    Contact,
+    Identity,
+    TradeAccount,
+)
 from alpaca.broker.requests import (
     CreateAccountRequest,
     ListAccountsRequest,
@@ -131,6 +138,58 @@ def test_create_account(reqmock, client: BrokerClient):
     assert returned_account.kyc_results is None
     assert returned_account.account_type == AccountType.TRADING
     assert returned_account.account_sub_type is None
+    assert returned_account.cash_interest is None
+
+
+def test_create_account_with_cash_interest(reqmock, client: BrokerClient):
+    created_id = "0d969814-40d6-4b2b-99ac-2e37427f1ad2"
+
+    reqmock.post(
+        "https://broker-api.sandbox.alpaca.markets/v1/accounts",
+        text="""
+        {
+          "id": "0d969814-40d6-4b2b-99ac-2e37427f1ad2",
+          "account_number": "682389557",
+          "status": "SUBMITTED",
+          "crypto_status": "INACTIVE",
+          "currency": "USD",
+          "last_equity": "0",
+          "created_at": "2022-04-12T17:24:31.30283Z",
+          "account_type": "trading",
+          "trading_configurations": null,
+          "cash_interest": {
+            "USD": {
+              "apr_tier_name": "gold",
+              "status": "PENDING_CHANGE"
+            }
+          }
+        }
+        """,
+    )
+
+    create_data = CreateAccountRequest(
+        agreements=factory.create_dummy_agreements(),
+        contact=factory.create_dummy_contact(),
+        disclosures=factory.create_dummy_disclosures(),
+        documents=factory.create_dummy_account_documents(),
+        identity=factory.create_dummy_identity(),
+        trusted_contact=factory.create_dummy_trusted_contact(),
+        cash_interest=CashInterest(
+            USD=CashInterestProgram(apr_tier_name="gold"),
+        ),
+    )
+
+    returned_account = client.create_account(create_data)
+
+    assert reqmock.called_once
+    request_body = reqmock.request_history[0].json()
+    # status should not be specified on enrollment, only the desired apr_tier_name
+    assert request_body["cash_interest"] == {"USD": {"apr_tier_name": "gold"}}
+    assert type(returned_account) == Account
+    assert returned_account.id == UUID(created_id)
+    assert returned_account.cash_interest == CashInterest(
+        USD=CashInterestProgram(apr_tier_name="gold", status="PENDING_CHANGE"),
+    )
 
 
 def test_create_ira_account(reqmock, client: BrokerClient):
@@ -643,6 +702,87 @@ def test_update_account_validates_non_empty_request(reqmock, client: BrokerClien
         client.update_account(account_id, update_data)
 
     assert str(e.value) == "update_data must contain at least 1 field to change"
+
+
+def test_update_account_cash_interest_unenroll(reqmock, client: BrokerClient):
+    account_id = "0d969814-40d6-4b2b-99ac-2e37427f1ad2"
+
+    reqmock.patch(
+        f"https://broker-api.sandbox.alpaca.markets/v1/accounts/{account_id}",
+        text="""
+        {
+          "id": "0d969814-40d6-4b2b-99ac-2e37427f1ad2",
+          "account_number": "682389557",
+          "status": "ACTIVE",
+          "currency": "USD",
+          "last_equity": "0",
+          "created_at": "2022-04-12T17:24:31.30283Z",
+          "account_type": "trading",
+          "trading_configurations": null,
+          "cash_interest": {
+            "USD": {
+              "apr_tier_name": "gold",
+              "status": "PENDING_CHANGE"
+            }
+          }
+        }
+        """,
+    )
+
+    update_data = UpdateAccountRequest(
+        cash_interest=CashInterest(
+            USD=CashInterestProgram(status="INACTIVE"),
+        ),
+    )
+
+    account = client.update_account(account_id, update_data)
+
+    assert reqmock.called_once
+    request_body = reqmock.request_history[0].json()
+    assert request_body["cash_interest"] == {"USD": {"status": "INACTIVE"}}
+    assert account.cash_interest == CashInterest(
+        USD=CashInterestProgram(apr_tier_name="gold", status="PENDING_CHANGE"),
+    )
+
+
+def test_create_account_validates_cash_interest(reqmock, client: BrokerClient):
+    # status should not be specified on enrollment
+    with pytest.raises(ValueError):
+        CreateAccountRequest(
+            agreements=factory.create_dummy_agreements(),
+            contact=factory.create_dummy_contact(),
+            disclosures=factory.create_dummy_disclosures(),
+            identity=factory.create_dummy_identity(),
+            cash_interest=CashInterest(
+                USD=CashInterestProgram(apr_tier_name="gold", status="ACTIVE"),
+            ),
+        )
+
+    # an empty program is not a valid enrollment
+    with pytest.raises(ValueError):
+        CreateAccountRequest(
+            agreements=factory.create_dummy_agreements(),
+            contact=factory.create_dummy_contact(),
+            disclosures=factory.create_dummy_disclosures(),
+            identity=factory.create_dummy_identity(),
+            cash_interest=CashInterest(USD=CashInterestProgram()),
+        )
+
+
+def test_update_account_validates_cash_interest(reqmock, client: BrokerClient):
+    # status should not be specified when enrolling or changing APR tiers
+    with pytest.raises(ValueError):
+        UpdateAccountRequest(
+            cash_interest=CashInterest(
+                USD=CashInterestProgram(apr_tier_name="gold", status="INACTIVE"),
+            ),
+        )
+
+    # an empty program is neither an enrollment, tier change, nor unenrollment
+    with pytest.raises(ValueError):
+        UpdateAccountRequest(
+            cash_interest=CashInterest(USD=CashInterestProgram()),
+        )
 
 
 def test_delete_account(reqmock, client: BrokerClient):


### PR DESCRIPTION
## Summary

Fixes #657.

The Broker API supports a `cash_interest` object on account creation ([Create an Account](https://docs.alpaca.markets/reference/createaccount)), account updates, and in account responses, but the SDK has no model for it. Constructing these requests currently requires bypassing the request models and passing raw query params.

## Changes

- Add `CashInterestProgram` (`apr_tier_name`, `status`) and `CashInterest` (`USD`) models to `alpaca/broker/models/accounts.py`
- Wire `cash_interest` into `CreateAccountRequest`, `UpdateAccountRequest`, and the `Account` response model
- Request validation per the API docs: `status` is rejected on enrollment/tier changes (the docs state it should not be specified), and an empty program is rejected; `status` remains `Optional[str]` rather than an enum, matching the API spec
- Tests: enrollment request body pins that only `apr_tier_name` is sent, unenrollment pins the `{"USD": {"status": "INACTIVE"}}` PATCH body, plus validation cases and response parsing

## Testing

```
pytest tests/ -> 247 passed
black --check -> clean
```