### PR TITLE
feat(trading): add clock and calendar schemas

### DIFF
--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -333,6 +333,55 @@ class TradeEvent(str, Enum):
     RESTATED = "restated"
 
 
+class Market(str, Enum):
+    """
+    Market identifier (MIC, BIC, or acronym) used in clock and calendar APIs.
+    """
+
+    BMO = "BMO"
+    BNYM = "BNYM"
+    BOATS = "BOATS"
+    CEUX = "CEUX"
+    CHIX = "CHIX"
+    HKEX = "HKEX"
+    IEX = "IEX"
+    IEXG = "IEXG"
+    ISE = "ISE"
+    LSE = "LSE"
+    MTA = "MTA"
+    MTAA = "MTAA"
+    NASDAQ = "NASDAQ"
+    NYSE = "NYSE"
+    OCEA = "OCEA"
+    OPRA = "OPRA"
+    OTC = "OTC"
+    OTCM = "OTCM"
+    SIFMA = "SIFMA"
+    TADAWUL = "TADAWUL"
+    XAMS = "XAMS"
+    XBRU = "XBRU"
+    XDUB = "XDUB"
+    XETR = "XETR"
+    XETRA = "XETRA"
+    XHKG = "XHKG"
+    XLIS = "XLIS"
+    XLON = "XLON"
+    XNAS = "XNAS"
+    XNYS = "XNYS"
+    XPAR = "XPAR"
+    XSAU = "XSAU"
+
+
+class Phase(str, Enum):
+    """Trading session phase reported by the clock API."""
+
+    CLOSED = "closed"
+    PRE = "pre"
+    CORE = "core"
+    LUNCH = "lunch"
+    POST = "post"
+
+
 class QueryOrderStatus(str, Enum):
     OPEN = "open"
     CLOSED = "closed"

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -25,6 +25,7 @@ from alpaca.trading.enums import (
     CorporateActionSubType,
     TradeConfirmationEmail,
     TradeEvent,
+    Phase,
 )
 from pydantic import Field, model_validator
 
@@ -386,6 +387,141 @@ class Calendar(BaseModel):
             data["close"] = datetime.strptime(start_datetime_str, "%Y-%m-%d %H:%M")
 
         super().__init__(**data)
+
+
+class CalendarDay(BaseModel):
+    """
+    A single trading calendar day with session times.
+
+    Attributes:
+        date (date): The calendar date.
+        core_start (datetime): Start of the core market session.
+        core_end (datetime): End of the core market session.
+        pre_start (Optional[datetime]): Start of the pre-market session.
+        pre_end (Optional[datetime]): End of the pre-market session.
+        lunch_start (Optional[datetime]): Start of the lunch session.
+        lunch_end (Optional[datetime]): End of the lunch session.
+        post_start (Optional[datetime]): Start of the after-hours session.
+        post_end (Optional[datetime]): End of the after-hours session.
+        settlement_date (Optional[date]): Settlement date for trades on this day.
+    """
+
+    date: date
+    core_start: datetime
+    core_end: datetime
+    pre_start: Optional[datetime] = None
+    pre_end: Optional[datetime] = None
+    lunch_start: Optional[datetime] = None
+    lunch_end: Optional[datetime] = None
+    post_start: Optional[datetime] = None
+    post_end: Optional[datetime] = None
+    settlement_date: Optional[date] = None
+
+
+class LegacyCalendarDay(BaseModel):
+    """
+    A single trading calendar day in the legacy calendar format.
+
+    Attributes:
+        date (date): The calendar date (YYYY-MM-DD).
+        open (str): Market open time in ``HH:MM`` format.
+        close (str): Market close time in ``HH:MM`` format.
+        session_open (str): Session open time in ``HHMM`` format.
+        session_close (str): Session close time in ``HHMM`` format.
+        settlement_date (date): Settlement date for trades on this day.
+    """
+
+    date: date
+    open: str
+    close: str
+    session_open: str
+    session_close: str
+    settlement_date: date
+
+
+class LegacyClock(BaseModel):
+    """
+    Market clock in the legacy format.
+
+    See also ``Clock`` which is the existing SDK alias for this schema.
+
+    Attributes:
+        timestamp (datetime): Current timestamp.
+        is_open (bool): Whether the market is currently open.
+        next_open (datetime): Next market open timestamp.
+        next_close (datetime): Next market close timestamp.
+    """
+
+    timestamp: datetime
+    is_open: bool
+    next_open: datetime
+    next_close: datetime
+
+
+class PublicMarket(BaseModel):
+    """
+    Market metadata as returned in clock responses.
+
+    Attributes:
+        acronym (str): The market's acronym (e.g. ``NYSE``).
+        name (str): Full name of the market.
+        timezone (str): IANA timezone identifier (e.g. ``America/New_York``).
+        mic (Optional[str]): Market Identifier Code (ISO 10383, 4 characters).
+        bic (Optional[str]): Business Identifier Code / SWIFT code (11 characters).
+    """
+
+    acronym: str
+    name: str
+    timezone: str
+    mic: Optional[str] = None
+    bic: Optional[str] = None
+
+
+class MarketClock(BaseModel):
+    """
+    Clock for a specific market, including current phase information.
+
+    Attributes:
+        market (PublicMarket): The market this clock applies to.
+        timestamp (datetime): The current time on the clock.
+        is_market_day (bool): Whether today is a trading day for this market.
+        next_market_open (datetime): Next time this market opens.
+        next_market_close (datetime): Next time this market closes.
+        phase (Phase): The current trading session phase.
+        phase_until (datetime): When the current phase ends.
+    """
+
+    market: PublicMarket
+    timestamp: datetime
+    is_market_day: bool
+    next_market_open: datetime
+    next_market_close: datetime
+    phase: Phase
+    phase_until: datetime
+
+
+class ClockResp(BaseModel):
+    """
+    Response containing clocks for one or more markets.
+
+    Attributes:
+        clocks (List[MarketClock]): One clock entry per requested market.
+    """
+
+    clocks: List[MarketClock]
+
+
+class PublicCalendarResp(BaseModel):
+    """
+    Calendar response for a specific market.
+
+    Attributes:
+        market (PublicMarket): The market this calendar applies to.
+        calendar (List[CalendarDay]): Ordered list of trading calendar days.
+    """
+
+    market: PublicMarket
+    calendar: List[CalendarDay]
 
 
 class BaseActivity(BaseModel):

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -82,7 +82,15 @@ class GetPortfolioHistoryRequest(NonEmptyRequest):
 
 class GetCalendarRequest(NonEmptyRequest):
     """
-    Represents the optional filtering you can do when requesting a Calendar object
+    Represents the optional filtering you can do when requesting a Calendar object.
+
+    Attributes:
+        start (Optional[date]): The first calendar date to include.
+        end (Optional[date]): The last calendar date to include.
+        date_type (Optional[Literal["TRADING", "SETTLEMENT"]]): Whether start and
+            end select trading dates or trade settlement dates. Defaults to
+            ``"TRADING"``; ``"SETTLEMENT"`` returns days for trades settling in
+            the requested date range.
     """
 
     start: Optional[date] = None

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime, timedelta
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import pandas as pd
 from pydantic import model_validator
@@ -87,6 +87,7 @@ class GetCalendarRequest(NonEmptyRequest):
 
     start: Optional[date] = None
     end: Optional[date] = None
+    date_type: Optional[Literal["TRADING", "SETTLEMENT"]] = "TRADING"
 
 
 class CreateWatchlistRequest(NonEmptyRequest):

--- a/docs/api_reference/trading/enums.rst
+++ b/docs/api_reference/trading/enums.rst
@@ -64,6 +64,18 @@ AccountStatus
 
 
 
+Market
+------
+
+.. autoenum:: alpaca.trading.enums.Market
+
+
+Phase
+-----
+
+.. autoenum:: alpaca.trading.enums.Phase
+
+
 ActivityType
 ------------
 

--- a/docs/api_reference/trading/models.rst
+++ b/docs/api_reference/trading/models.rst
@@ -50,6 +50,48 @@ Calendar
 .. autoclass:: alpaca.trading.models.Calendar
 
 
+LegacyClock
+-----------
+
+.. autoclass:: alpaca.trading.models.LegacyClock
+
+
+PublicMarket
+------------
+
+.. autoclass:: alpaca.trading.models.PublicMarket
+
+
+MarketClock
+-----------
+
+.. autoclass:: alpaca.trading.models.MarketClock
+
+
+ClockResp
+---------
+
+.. autoclass:: alpaca.trading.models.ClockResp
+
+
+CalendarDay
+-----------
+
+.. autoclass:: alpaca.trading.models.CalendarDay
+
+
+LegacyCalendarDay
+-----------------
+
+.. autoclass:: alpaca.trading.models.LegacyCalendarDay
+
+
+PublicCalendarResp
+------------------
+
+.. autoclass:: alpaca.trading.models.PublicCalendarResp
+
+
 NonTradeActivity
 ----------------
 

--- a/tests/broker/broker_client/test_misc_routes.py
+++ b/tests/broker/broker_client/test_misc_routes.py
@@ -40,7 +40,11 @@ def test_get_calendar(reqmock, client: BrokerClient):
     )
 
     assert reqmock.called_once
-    assert reqmock.request_history[0].qs == {"start": [start], "end": [end]}
+    assert reqmock.request_history[0].qs == {
+        "start": [start],
+        "end": [end],
+        "date_type": ["trading"],
+    }
 
     assert isinstance(result, List)
     assert len(result) == 2

--- a/tests/trading/test_clock_calendar_models.py
+++ b/tests/trading/test_clock_calendar_models.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime
+
 from alpaca.trading.enums import Market, Phase
 from alpaca.trading.models import (
     CalendarDay,
@@ -136,8 +138,43 @@ def test_calendar_day_optional_sessions_default_to_none() -> None:
     assert day.post_end is None
 
 
+def test_calendar_day_coerces_all_session_and_settlement_fields() -> None:
+    day = CalendarDay(
+        date="2026-07-14",
+        core_start="2026-07-14T09:30:00-04:00",
+        core_end="2026-07-14T16:00:00-04:00",
+        pre_start="2026-07-14T04:00:00-04:00",
+        pre_end="2026-07-14T09:30:00-04:00",
+        lunch_start="2026-07-14T12:00:00-04:00",
+        lunch_end="2026-07-14T13:00:00-04:00",
+        post_start="2026-07-14T16:00:00-04:00",
+        post_end="2026-07-14T20:00:00-04:00",
+        settlement_date="2026-07-15",
+    )
+
+    assert isinstance(day.date, date)
+    assert isinstance(day.settlement_date, date)
+    for field in (
+        "core_start",
+        "core_end",
+        "pre_start",
+        "pre_end",
+        "lunch_start",
+        "lunch_end",
+        "post_start",
+        "post_end",
+    ):
+        assert isinstance(getattr(day, field), datetime)
+
+
 def test_get_calendar_request_defaults_to_trading_dates() -> None:
     request = GetCalendarRequest()
 
     assert request.date_type == "TRADING"
     assert request.to_request_fields() == {"date_type": "TRADING"}
+
+
+def test_get_calendar_request_serializes_settlement_date_type() -> None:
+    request = GetCalendarRequest(date_type="SETTLEMENT")
+
+    assert request.to_request_fields() == {"date_type": "SETTLEMENT"}

--- a/tests/trading/test_clock_calendar_models.py
+++ b/tests/trading/test_clock_calendar_models.py
@@ -1,0 +1,143 @@
+from alpaca.trading.enums import Market, Phase
+from alpaca.trading.models import (
+    CalendarDay,
+    ClockResp,
+    LegacyCalendarDay,
+    LegacyClock,
+    MarketClock,
+    PublicCalendarResp,
+    PublicMarket,
+)
+from alpaca.trading.requests import GetCalendarRequest
+
+
+def test_clock_calendar_enums_match_api_values() -> None:
+    assert [market.value for market in Market] == [
+        "BMO",
+        "BNYM",
+        "BOATS",
+        "CEUX",
+        "CHIX",
+        "HKEX",
+        "IEX",
+        "IEXG",
+        "ISE",
+        "LSE",
+        "MTA",
+        "MTAA",
+        "NASDAQ",
+        "NYSE",
+        "OCEA",
+        "OPRA",
+        "OTC",
+        "OTCM",
+        "SIFMA",
+        "TADAWUL",
+        "XAMS",
+        "XBRU",
+        "XDUB",
+        "XETR",
+        "XETRA",
+        "XHKG",
+        "XLIS",
+        "XLON",
+        "XNAS",
+        "XNYS",
+        "XPAR",
+        "XSAU",
+    ]
+    assert [phase.value for phase in Phase] == [
+        "closed",
+        "pre",
+        "core",
+        "lunch",
+        "post",
+    ]
+
+
+def test_calendar_schemas_parse_legacy_and_public_responses() -> None:
+    legacy = LegacyCalendarDay(
+        date="2026-07-14",
+        open="09:30",
+        close="16:00",
+        session_open="0700",
+        session_close="1900",
+        settlement_date="2026-07-15",
+    )
+    public = PublicCalendarResp(
+        market={
+            "acronym": "NYSE",
+            "name": "New York Stock Exchange",
+            "timezone": "America/New_York",
+            "mic": "XNYS",
+        },
+        calendar=[
+            {
+                "date": "2026-07-14",
+                "core_start": "2026-07-14T09:30:00-04:00",
+                "core_end": "2026-07-14T16:00:00-04:00",
+            }
+        ],
+    )
+
+    assert legacy.date.isoformat() == "2026-07-14"
+    assert legacy.settlement_date.isoformat() == "2026-07-15"
+    assert public.market.mic == "XNYS"
+    assert public.market.bic is None
+    assert public.calendar[0].settlement_date is None
+
+
+def test_clock_schemas_parse_legacy_and_public_responses() -> None:
+    timestamp = "2026-07-14T12:00:00-04:00"
+    next_open = "2026-07-15T09:30:00-04:00"
+    next_close = "2026-07-14T16:00:00-04:00"
+    legacy = LegacyClock(
+        timestamp=timestamp,
+        is_open=True,
+        next_open=next_open,
+        next_close=next_close,
+    )
+    response = ClockResp(
+        clocks=[
+            {
+                "market": {
+                    "acronym": "NYSE",
+                    "name": "New York Stock Exchange",
+                    "timezone": "America/New_York",
+                },
+                "timestamp": timestamp,
+                "is_market_day": True,
+                "next_market_open": next_open,
+                "next_market_close": next_close,
+                "phase": "core",
+                "phase_until": next_close,
+            }
+        ]
+    )
+
+    assert legacy.is_open is True
+    assert isinstance(response.clocks[0], MarketClock)
+    assert isinstance(response.clocks[0].market, PublicMarket)
+    assert response.clocks[0].phase == Phase.CORE
+
+
+def test_calendar_day_optional_sessions_default_to_none() -> None:
+    day = CalendarDay(
+        date="2026-07-14",
+        core_start="2026-07-14T09:30:00-04:00",
+        core_end="2026-07-14T16:00:00-04:00",
+    )
+
+    assert day.pre_start is None
+    assert day.pre_end is None
+    assert day.lunch_start is None
+    assert day.lunch_end is None
+    assert day.post_start is None
+    assert day.post_end is None
+
+
+def test_get_calendar_request_defaults_to_trading_dates() -> None:
+    request = GetCalendarRequest()
+
+    assert request.date_type == "TRADING"
+    assert request.to_request_fields() == {"date_type": "TRADING"}


### PR DESCRIPTION
## What

Adds current Trading API clock and calendar enums, response models, and request behavior.

## Why

This extracts the clock/calendar schema prerequisite from #698 so it can be reviewed independently of the route implementation in #702.

## Changes

- Adds market and trading-phase enums.
- Adds legacy and current clock/calendar response models.
- Defaults calendar requests to `date_type=TRADING` while supporting explicit settlement calendars.
- Updates the broker request contract and adds focused parsing/coercion coverage.
- Documents all new public enum and model types in the Trading API reference.

## Behavior change

Calendar requests now include `date_type=TRADING` by default. Callers can explicitly request `SETTLEMENT`.

## Testing

- Full suite: 250 passed on Python 3.11.
- Black: all 96 Python files unchanged.
- Sphinx: warnings-fatal 67-page HTML build passed.

## Desired feedback

Please verify the session-field optionality and confirm that sending the trading date type by default is correct for both Trading and Broker calendar endpoints.

## Reviewer guide

1. Review model shapes in `alpaca/trading/models.py`.
2. Review default serialization and documentation in `alpaca/trading/requests.py`.
3. Confirm the broker request expectation and model coercion tests.
4. API-reference additions are mechanical and safe to skim.

## Checklist

- [x] 438 changed lines, below the split cap
- [x] Full tests pass
- [x] Formatting and documentation build pass
- [x] No route/client or watchlist changes included

## References

- Extracted from #698
- Schema prerequisite for #702

Made with [Cursor](https://cursor.com)