### PR TITLE
feat(trading): add crypto transfer and tokenization schemas

### DIFF
--- a/alpaca/broker/models/funding.py
+++ b/alpaca/broker/models/funding.py
@@ -89,7 +89,7 @@ class Transfer(ModelWithID):
         amount (str): The amount the recipient will receive after any applicable fees are deducted.
         type (TransferType): The type of transfer.
         status (TransferStatus): The status of the transfer.
-        direction (TransferDirection): The direction of the transfer.
+        direction (alpaca.broker.enums.TransferDirection): The direction of the transfer.
         reason (Optional[str]): Reasoning associated with the current status.
         requested_amount (Optional[str]): Amount entered upon creation of a transfer entity.
         fee (Optional[str]): Dollar amount of any applicable fees.

--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -417,3 +417,70 @@ class PositionIntent(str, Enum):
     BUY_TO_CLOSE = "buy_to_close"
     SELL_TO_OPEN = "sell_to_open"
     SELL_TO_CLOSE = "sell_to_close"
+
+
+class CreateCryptoTransferRequestChain(str, Enum):
+    """Blockchain network for a crypto withdrawal transfer."""
+
+    SOL = "SOL"
+    ETH = "ETH"
+    BTC = "BTC"
+    XRP = "XRP"
+    ARB = "ARB"
+
+
+class TransferDirection(str, Enum):
+    """Direction of a crypto transfer."""
+
+    INCOMING = "INCOMING"
+    OUTGOING = "OUTGOING"
+
+
+class CryptoTransferStatus(str, Enum):
+    """Processing status of a crypto transfer."""
+
+    PROCESSING = "PROCESSING"
+    FAILED = "FAILED"
+    COMPLETE = "COMPLETE"
+
+
+class WhitelistedAddressStatus(str, Enum):
+    """Approval status of a whitelisted crypto address."""
+
+    APPROVED = "APPROVED"
+    PENDING = "PENDING"
+
+
+class TokenizationIssuer(str, Enum):
+    """Issuer of a tokenized asset."""
+
+    XSTOCKS = "xstocks"
+    ST0X = "st0x"
+
+
+class TokenizationNetwork(str, Enum):
+    """Blockchain network for a tokenized asset."""
+
+    SOLANA = "solana"
+    ARBITRUM = "arbitrum"
+    ETHEREUM = "ethereum"
+    BINANCE = "binance"
+    BASE = "base"
+    TON = "ton"
+    TRON = "tron"
+    MANTLE = "mantle"
+
+
+class TokenizationRequestType(str, Enum):
+    """Direction of a tokenization request."""
+
+    MINT = "mint"
+    REDEEM = "redeem"
+
+
+class TokenizationRequestStatus(str, Enum):
+    """Processing status of a tokenization request."""
+
+    PENDING = "pending"
+    REJECTED = "rejected"
+    COMPLETED = "completed"

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -25,6 +25,13 @@ from alpaca.trading.enums import (
     CorporateActionSubType,
     TradeConfirmationEmail,
     TradeEvent,
+    CryptoTransferStatus,
+    TokenizationIssuer,
+    TokenizationNetwork,
+    TokenizationRequestStatus,
+    TokenizationRequestType,
+    TransferDirection,
+    WhitelistedAddressStatus,
 )
 from pydantic import Field, model_validator
 
@@ -700,3 +707,81 @@ class OptionContractsResponse(BaseModel):
 
     option_contracts: Optional[List[OptionContract]] = None
     next_page_token: Optional[str] = None
+
+
+class CryptoTransfer(BaseModel):
+    """A crypto asset transfer into or out of an account."""
+
+    id: Optional[UUID] = None
+    tx_hash: Optional[str] = None
+    direction: Optional[TransferDirection] = None
+    status: Optional[CryptoTransferStatus] = None
+    amount: Optional[str] = None
+    usd_value: Optional[str] = None
+    network_fee: Optional[str] = None
+    fees: Optional[str] = None
+    chain: Optional[str] = None
+    asset: Optional[str] = None
+    from_address: Optional[str] = None
+    to_address: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+class CryptoWallet(BaseModel):
+    """A crypto wallet associated with an account."""
+
+    chain: Optional[str] = None
+    address: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+class WhitelistedAddress(BaseModel):
+    """A whitelisted crypto wallet address for withdrawals."""
+
+    id: Optional[str] = None
+    chain: Optional[str] = None
+    asset: Optional[str] = None
+    address: Optional[str] = None
+    status: Optional[WhitelistedAddressStatus] = None
+    created_at: Optional[datetime] = None
+
+
+class WalletFeeEstimate(BaseModel):
+    """Estimated gas fee for a proposed crypto transfer."""
+
+    fee: Optional[str] = None
+    network_fee: Optional[str] = None
+
+
+class TokenizationMintResponse(BaseModel):
+    """Response returned after submitting a tokenization mint request."""
+
+    tokenization_request_id: str
+    status: TokenizationRequestStatus
+    underlying_symbol: str
+    token_symbol: str
+    qty: str
+    created_at: datetime
+    issuer: TokenizationIssuer
+    network: TokenizationNetwork
+
+
+class TokenizationRequest(BaseModel):
+    """A tokenization request record returned by the API."""
+
+    tokenization_request_id: str
+    created_at: datetime
+    type: TokenizationRequestType
+    status: TokenizationRequestStatus
+    underlying_symbol: str
+    token_symbol: str
+    qty: str
+    issuer: TokenizationIssuer
+    network: TokenizationNetwork
+    wallet_address: str
+    issuer_request_id: Optional[str] = None
+    account: Optional[str] = None
+    issuer_account: Optional[str] = None
+    updated_at: Optional[datetime] = None
+    tx_hash: Optional[str] = None
+    fees: Optional[str] = None

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime, timedelta
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import pandas as pd
 from pydantic import model_validator
@@ -14,12 +14,15 @@ from alpaca.trading.enums import (
     ContractType,
     CorporateActionDateType,
     CorporateActionType,
+    CreateCryptoTransferRequestChain,
     ExerciseStyle,
     OrderClass,
     OrderSide,
     OrderType,
     PositionIntent,
     QueryOrderStatus,
+    TokenizationIssuer,
+    TokenizationNetwork,
     TimeInForce,
 )
 
@@ -716,3 +719,36 @@ class GetOptionContractsRequest(NonEmptyRequest):
 
     limit: Optional[int] = None
     page_token: Optional[str] = None
+
+
+class CreateCryptoTransferRequest(NonEmptyRequest):
+    """Request to initiate a crypto withdrawal transfer."""
+
+    amount: str
+    address: str
+    asset: str
+    # TODO: simplify to CreateCryptoTransferRequestChain on the next breaking release.
+    chain: Optional[
+        Union[
+            CreateCryptoTransferRequestChain, Literal["SOL", "ETH", "BTC", "XRP", "ARB"]
+        ]
+    ] = None
+
+
+class GetWalletFeeEstimateRequest(NonEmptyRequest):
+    """Parameters for estimating the gas fee for a crypto transfer."""
+
+    asset: Optional[str] = None
+    from_address: Optional[str] = None
+    to_address: Optional[str] = None
+    amount: Optional[str] = None
+
+
+class TokenizationMintRequest(NonEmptyRequest):
+    """Request to convert an underlying asset into a tokenized asset."""
+
+    underlying_symbol: str
+    qty: str
+    issuer: TokenizationIssuer
+    network: TokenizationNetwork
+    wallet_address: str

--- a/docs/api_reference/trading/enums.rst
+++ b/docs/api_reference/trading/enums.rst
@@ -120,3 +120,51 @@ PositionIntent
 ----------------------
 
 .. autoenum:: alpaca.trading.enums.PositionIntent
+
+
+CreateCryptoTransferRequestChain
+--------------------------------
+
+.. autoenum:: alpaca.trading.enums.CreateCryptoTransferRequestChain
+
+
+TransferDirection
+-----------------
+
+.. autoenum:: alpaca.trading.enums.TransferDirection
+
+
+CryptoTransferStatus
+--------------------
+
+.. autoenum:: alpaca.trading.enums.CryptoTransferStatus
+
+
+WhitelistedAddressStatus
+------------------------
+
+.. autoenum:: alpaca.trading.enums.WhitelistedAddressStatus
+
+
+TokenizationIssuer
+------------------
+
+.. autoenum:: alpaca.trading.enums.TokenizationIssuer
+
+
+TokenizationNetwork
+-------------------
+
+.. autoenum:: alpaca.trading.enums.TokenizationNetwork
+
+
+TokenizationRequestType
+-----------------------
+
+.. autoenum:: alpaca.trading.enums.TokenizationRequestType
+
+
+TokenizationRequestStatus
+-------------------------
+
+.. autoenum:: alpaca.trading.enums.TokenizationRequestStatus

--- a/docs/api_reference/trading/models.rst
+++ b/docs/api_reference/trading/models.rst
@@ -96,3 +96,39 @@ OptionContractsResponse
 -----------------------
 
 .. autoclass:: alpaca.trading.models.OptionContractsResponse
+
+
+CryptoTransfer
+--------------
+
+.. autoclass:: alpaca.trading.models.CryptoTransfer
+
+
+CryptoWallet
+------------
+
+.. autoclass:: alpaca.trading.models.CryptoWallet
+
+
+WhitelistedAddress
+------------------
+
+.. autoclass:: alpaca.trading.models.WhitelistedAddress
+
+
+WalletFeeEstimate
+-----------------
+
+.. autoclass:: alpaca.trading.models.WalletFeeEstimate
+
+
+TokenizationMintResponse
+------------------------
+
+.. autoclass:: alpaca.trading.models.TokenizationMintResponse
+
+
+TokenizationRequest
+-------------------
+
+.. autoclass:: alpaca.trading.models.TokenizationRequest

--- a/docs/api_reference/trading/requests.rst
+++ b/docs/api_reference/trading/requests.rst
@@ -126,3 +126,21 @@ GetCorporateAnnouncementsRequest
 --------------------------------
 
 .. autoclass:: alpaca.trading.requests.GetCorporateAnnouncementsRequest
+
+
+CreateCryptoTransferRequest
+---------------------------
+
+.. autoclass:: alpaca.trading.requests.CreateCryptoTransferRequest
+
+
+GetWalletFeeEstimateRequest
+---------------------------
+
+.. autoclass:: alpaca.trading.requests.GetWalletFeeEstimateRequest
+
+
+TokenizationMintRequest
+-----------------------
+
+.. autoclass:: alpaca.trading.requests.TokenizationMintRequest

--- a/tests/trading/test_crypto_tokenization_schemas.py
+++ b/tests/trading/test_crypto_tokenization_schemas.py
@@ -1,0 +1,176 @@
+from datetime import datetime
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from alpaca.trading.enums import (
+    CreateCryptoTransferRequestChain,
+    CryptoTransferStatus,
+    TokenizationIssuer,
+    TokenizationNetwork,
+    TokenizationRequestStatus,
+    TokenizationRequestType,
+    TransferDirection,
+    WhitelistedAddressStatus,
+)
+from alpaca.trading.models import (
+    CryptoTransfer,
+    CryptoWallet,
+    TokenizationMintResponse,
+    TokenizationRequest,
+    WalletFeeEstimate,
+    WhitelistedAddress,
+)
+from alpaca.trading.requests import (
+    CreateCryptoTransferRequest,
+    GetWalletFeeEstimateRequest,
+    TokenizationMintRequest,
+)
+
+
+def test_crypto_transfer_enums_match_api_values():
+    assert [member.value for member in CreateCryptoTransferRequestChain] == [
+        "SOL",
+        "ETH",
+        "BTC",
+        "XRP",
+        "ARB",
+    ]
+    assert [member.value for member in TransferDirection] == [
+        "INCOMING",
+        "OUTGOING",
+    ]
+    assert [member.value for member in CryptoTransferStatus] == [
+        "PROCESSING",
+        "FAILED",
+        "COMPLETE",
+    ]
+    assert [member.value for member in WhitelistedAddressStatus] == [
+        "APPROVED",
+        "PENDING",
+    ]
+
+
+def test_tokenization_enums_match_api_values():
+    assert [member.value for member in TokenizationIssuer] == ["xstocks", "st0x"]
+    assert [member.value for member in TokenizationNetwork] == [
+        "solana",
+        "arbitrum",
+        "ethereum",
+        "binance",
+        "base",
+        "ton",
+        "tron",
+        "mantle",
+    ]
+    assert [member.value for member in TokenizationRequestType] == [
+        "mint",
+        "redeem",
+    ]
+    assert [member.value for member in TokenizationRequestStatus] == [
+        "pending",
+        "rejected",
+        "completed",
+    ]
+
+
+def test_create_crypto_transfer_request_validates_chain_and_serializes_fields():
+    request = CreateCryptoTransferRequest(
+        amount="1.25",
+        address="wallet-address",
+        asset="ETH",
+        chain="ETH",
+    )
+
+    assert request.chain == CreateCryptoTransferRequestChain.ETH
+    assert request.to_request_fields() == {
+        "amount": "1.25",
+        "address": "wallet-address",
+        "asset": "ETH",
+        "chain": "ETH",
+    }
+
+    with pytest.raises(ValidationError):
+        CreateCryptoTransferRequest(
+            amount="1.25",
+            address="wallet-address",
+            asset="ETH",
+            chain="DOGE",
+        )
+
+
+def test_crypto_transfer_models_parse_api_payloads():
+    transfer = CryptoTransfer(
+        id="4bb62d0f-9ce7-4f51-8e1f-b9b285a1f047",
+        tx_hash="0xabc",
+        direction="OUTGOING",
+        status="COMPLETE",
+        amount="1.25",
+        asset="ETH",
+        created_at="2026-07-14T08:30:00Z",
+    )
+    wallet = CryptoWallet(chain="ETH", address="0x123")
+    whitelisted = WhitelistedAddress(
+        id="address-id",
+        chain="ETH",
+        asset="ETH",
+        address="0x123",
+        status="PENDING",
+    )
+    fee = WalletFeeEstimate(fee="0.10", network_fee="0.08")
+
+    assert transfer.id == UUID("4bb62d0f-9ce7-4f51-8e1f-b9b285a1f047")
+    assert transfer.direction == TransferDirection.OUTGOING
+    assert transfer.status == CryptoTransferStatus.COMPLETE
+    assert transfer.created_at == datetime.fromisoformat("2026-07-14T08:30:00+00:00")
+    assert wallet.created_at is None
+    assert whitelisted.status == WhitelistedAddressStatus.PENDING
+    assert fee.model_dump() == {"fee": "0.10", "network_fee": "0.08"}
+
+
+def test_wallet_fee_estimate_request_omits_unset_fields():
+    request = GetWalletFeeEstimateRequest(asset="USDC", amount="100")
+
+    assert request.to_request_fields() == {"asset": "USDC", "amount": "100"}
+
+
+def test_tokenization_request_and_response_parse_api_payloads():
+    mint_request = TokenizationMintRequest(
+        underlying_symbol="AAPL",
+        qty="2.5",
+        issuer="xstocks",
+        network="solana",
+        wallet_address="wallet-address",
+    )
+    response = TokenizationMintResponse(
+        tokenization_request_id="request-id",
+        status="pending",
+        underlying_symbol="AAPL",
+        token_symbol="AAPLX",
+        qty="2.5",
+        created_at="2026-07-14T08:30:00Z",
+        issuer="xstocks",
+        network="solana",
+    )
+    record = TokenizationRequest(
+        tokenization_request_id="request-id",
+        created_at="2026-07-14T08:30:00Z",
+        type="mint",
+        status="completed",
+        underlying_symbol="AAPL",
+        token_symbol="AAPLX",
+        qty="2.5",
+        issuer="xstocks",
+        network="solana",
+        wallet_address="wallet-address",
+        tx_hash="0xabc",
+    )
+
+    assert mint_request.issuer == TokenizationIssuer.XSTOCKS
+    assert mint_request.network == TokenizationNetwork.SOLANA
+    assert response.status == TokenizationRequestStatus.PENDING
+    assert record.type == TokenizationRequestType.MINT
+    assert record.status == TokenizationRequestStatus.COMPLETED
+    assert record.issuer_request_id is None
+    assert record.tx_hash == "0xabc"


### PR DESCRIPTION
## What

Adds Trading API schemas for crypto transfers, wallets, whitelisted addresses, fee estimates, and tokenization requests.

## Why

This extracts the crypto/tokenization contract layer from #698 so it can be reviewed separately from route implementations such as #701.

## Changes

- Adds transfer, whitelist, and tokenization enums.
- Adds crypto wallet, transfer, fee-estimate, whitelist, and tokenization response models.
- Adds crypto-transfer, wallet-fee, and tokenization-mint request models.
- Documents every new public type in the generated API reference.
- Adds focused parsing, validation, and serialization coverage.

Financial quantities and fees remain strings to avoid precision loss.

## Testing

- Full suite: 249 passed on Python 3.11.
- Black: all 96 Python files unchanged.
- Sphinx: warnings-fatal HTML build passed.

## Desired feedback

Please verify enum wire values, optional field semantics, and string typing for blockchain quantities and fees.

## Reviewer guide

1. Review enums and request fields first.
2. Review response-model nullability.
3. Confirm validation examples in the focused test module.
4. API-reference changes are mechanical and safe to skim.

## Checklist

- [x] 470 changed lines, below the split cap
- [x] Full tests pass
- [x] Formatting and documentation builds pass
- [x] No route/client changes included

## References

- Extracted from #698
- Schema prerequisite for #701

Made with [Cursor](https://cursor.com)