### PR TITLE
feat(trading): add locates API schemas

### DIFF
--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -195,6 +195,43 @@ class AssetStatus(str, Enum):
     INACTIVE = "inactive"
 
 
+class LocateStatus(str, Enum):
+    """
+    Represents the lifecycle status of a locate request.
+    """
+
+    ACTIVE = "active"
+    EXPIRED = "expired"
+    REJECTED = "rejected"
+
+
+class LocateErrorCode(str, Enum):
+    """
+    Represents machine-readable error codes returned by the Locates API.
+    """
+
+    INVALID_INPUT = "invalid_input"
+    INVALID_REQUEST_BODY = "invalid_request_body"
+    INVALID_LIMIT_PRICE = "invalid_limit_price"
+    INVALID_SYMBOLS = "invalid_symbols"
+    SYMBOL_NOT_FOUND = "symbol_not_found"
+    SECURITY_NOT_FOUND = "security_not_found"
+    INSUFFICIENT_BUYING_POWER = "insufficient_buying_power"
+    EASY_TO_BORROW = "easy_to_borrow"
+    THRESHOLD_SECURITY = "threshold_security"
+
+
+class LocateQuoteErrorCode(str, Enum):
+    """
+    Represents machine-readable quote-level error codes returned by the Locates API.
+    """
+
+    SYMBOL_NOT_FOUND = "symbol_not_found"
+    EASY_TO_BORROW = "easy_to_borrow"
+    THRESHOLD_SECURITY = "threshold_security"
+    CORPORATE_ACTION = "corporate_action"
+
+
 class AssetExchange(str, Enum):
     """
     Represents the current exchanges Alpaca supports.

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -9,6 +9,9 @@ from alpaca.trading.enums import (
     ContractType,
     DTBPCheck,
     ExerciseStyle,
+    LocateErrorCode,
+    LocateQuoteErrorCode,
+    LocateStatus,
     OrderStatus,
     OrderType,
     OrderClass,
@@ -700,3 +703,121 @@ class OptionContractsResponse(BaseModel):
 
     option_contracts: Optional[List[OptionContract]] = None
     next_page_token: Optional[str] = None
+
+
+class Locate(ModelWithID):
+    """
+    A locate request and its current lifecycle status.
+
+    Attributes:
+        id (UUID): Locate ID.
+        symbol (str): Stock symbol.
+        requested_qty (int): Number of shares requested.
+        all_or_none (bool): Whether the request required the full quantity.
+        status (LocateStatus): Locate status.
+        created_at (datetime): Time when the locate was created.
+        expires_at (Optional[datetime]): Time when the active locate expires.
+        limit_price (Optional[str]): Maximum acceptable fee per share from the request.
+        located_price (Optional[str]): Locate fee per share in USD.
+        located_qty (Optional[int]): Number of shares located.
+        total_fee (Optional[str]): Total locate fee in USD.
+        rejection_reason (Optional[str]): Machine-readable rejection reason.
+    """
+
+    symbol: str
+    requested_qty: int
+    all_or_none: bool
+    status: LocateStatus
+    created_at: datetime
+    expires_at: Optional[datetime] = None
+    limit_price: Optional[str] = None
+    located_price: Optional[str] = None
+    located_qty: Optional[int] = None
+    total_fee: Optional[str] = None
+    rejection_reason: Optional[str] = None
+
+
+class ErrorResponse(BaseModel):
+    """
+    API error response.
+
+    Attributes:
+        message (Optional[str]): Human-readable error message.
+    """
+
+    message: Optional[str] = None
+
+
+class LocateError(BaseModel):
+    """
+    Locates API error response.
+
+    Attributes:
+        message (str): Error message.
+        code (Optional[LocateErrorCode]): Machine-readable locate error code.
+    """
+
+    message: str
+    code: Optional[LocateErrorCode] = None
+
+
+class ListLocatesResponse(BaseModel):
+    """
+    Response returned when listing locate requests.
+
+    Attributes:
+        locates (List[Locate]): Locates matching the filter criteria.
+        next_page_token (Optional[str]): Pagination token for the next page.
+    """
+
+    locates: List[Locate]
+    next_page_token: Optional[str]
+
+
+class LocateQuote(BaseModel):
+    """
+    Current locate pricing and availability for a symbol.
+
+    Attributes:
+        symbol (str): Stock symbol.
+        available_qty (int): Available locate quantity.
+        quoted_at (datetime): Time when the quote was issued.
+        price (Optional[str]): Locate fee per share.
+    """
+
+    symbol: str
+    available_qty: int
+    quoted_at: datetime
+    price: Optional[str] = None
+
+
+class LocateQuoteError(BaseModel):
+    """
+    Error returned for a symbol that could not be quoted.
+
+    Attributes:
+        symbol (str): Requested stock symbol that could not be quoted.
+        code (LocateQuoteErrorCode): Error code.
+        message (str): Error message.
+    """
+
+    symbol: str
+    code: LocateQuoteErrorCode
+    message: str
+
+
+class ListLocateQuotesResponse(BaseModel):
+    """
+    Response returned when fetching locate quotes.
+
+    Attributes:
+        quotes (List[LocateQuote]): Locate quotes returned for requested symbols.
+        errors (Optional[List[LocateQuoteError]]): Symbols that could not be quoted.
+    """
+
+    quotes: List[LocateQuote]
+    errors: Optional[List[LocateQuoteError]] = None
+
+
+LocatesResponse = ListLocatesResponse
+LocateQuotesResponse = ListLocateQuotesResponse

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -15,6 +15,7 @@ from alpaca.trading.enums import (
     CorporateActionDateType,
     CorporateActionType,
     ExerciseStyle,
+    LocateStatus,
     OrderClass,
     OrderSide,
     OrderType,
@@ -716,3 +717,53 @@ class GetOptionContractsRequest(NonEmptyRequest):
 
     limit: Optional[int] = None
     page_token: Optional[str] = None
+
+
+class GetLocatesRequest(NonEmptyRequest):
+    """
+    Parameters for fetching locate requests.
+
+    Attributes:
+        page_token (Optional[str]): Pagination token to continue from.
+        limit (Optional[int]): Maximum number of results to return.
+        status (Optional[LocateStatus]): Filter by locate status.
+        symbol (Optional[str]): Filter by stock symbol.
+        start (Optional[date]): Filter locates with trading date on or after this date.
+        end (Optional[date]): Filter locates with trading date before this date.
+    """
+
+    page_token: Optional[str] = None
+    limit: Optional[int] = None
+    status: Optional[LocateStatus] = None
+    symbol: Optional[str] = None
+    start: Optional[date] = None
+    end: Optional[date] = None
+
+
+class CreateLocateRequest(NonEmptyRequest):
+    """
+    Request to locate shares for a short sale.
+
+    Attributes:
+        symbol (str): Stock symbol.
+        qty (int): Number of shares to locate.
+        all_or_none (Optional[bool]): Reject unless the full requested quantity is available.
+        limit_price (Optional[str]): Maximum acceptable locate fee per share in USD.
+    """
+
+    symbol: str
+    qty: int
+    all_or_none: Optional[bool] = False
+    limit_price: Optional[str] = None
+
+
+class GetLocateQuotesRequest(NonEmptyRequest):
+    """
+    Parameters for fetching locate availability and pricing.
+
+    Attributes:
+        symbols (Union[str, List[str]]): Comma-separated stock symbols or a list
+            of stock symbols to quote.
+    """
+
+    symbols: Union[str, List[str]]

--- a/docs/api_reference/trading/enums.rst
+++ b/docs/api_reference/trading/enums.rst
@@ -45,6 +45,24 @@ AssetStatus
 .. autoenum:: alpaca.trading.enums.AssetStatus
 
 
+LocateStatus
+------------
+
+.. autoenum:: alpaca.trading.enums.LocateStatus
+
+
+LocateErrorCode
+---------------
+
+.. autoenum:: alpaca.trading.enums.LocateErrorCode
+
+
+LocateQuoteErrorCode
+--------------------
+
+.. autoenum:: alpaca.trading.enums.LocateQuoteErrorCode
+
+
 AssetExchange
 -------------
 

--- a/docs/api_reference/trading/models.rst
+++ b/docs/api_reference/trading/models.rst
@@ -96,3 +96,63 @@ OptionContractsResponse
 -----------------------
 
 .. autoclass:: alpaca.trading.models.OptionContractsResponse
+
+
+Locate
+------
+
+.. autoclass:: alpaca.trading.models.Locate
+
+
+ErrorResponse
+-------------
+
+.. autoclass:: alpaca.trading.models.ErrorResponse
+
+
+LocateError
+-----------
+
+.. autoclass:: alpaca.trading.models.LocateError
+
+
+ListLocatesResponse
+-------------------
+
+.. autoclass:: alpaca.trading.models.ListLocatesResponse
+
+
+LocateQuote
+-----------
+
+.. autoclass:: alpaca.trading.models.LocateQuote
+
+
+LocateQuoteError
+----------------
+
+.. autoclass:: alpaca.trading.models.LocateQuoteError
+
+
+ListLocateQuotesResponse
+------------------------
+
+.. autoclass:: alpaca.trading.models.ListLocateQuotesResponse
+
+
+LocatesResponse
+---------------
+
+Alias for :class:`alpaca.trading.models.ListLocatesResponse`.
+
+.. autoclass:: alpaca.trading.models.LocatesResponse
+   :noindex:
+
+
+LocateQuotesResponse
+--------------------
+
+Alias for :class:`alpaca.trading.models.ListLocateQuotesResponse`.
+
+.. autoclass:: alpaca.trading.models.LocateQuotesResponse
+   :noindex:

--- a/docs/api_reference/trading/requests.rst
+++ b/docs/api_reference/trading/requests.rst
@@ -126,3 +126,21 @@ GetCorporateAnnouncementsRequest
 --------------------------------
 
 .. autoclass:: alpaca.trading.requests.GetCorporateAnnouncementsRequest
+
+
+GetLocatesRequest
+-----------------
+
+.. autoclass:: alpaca.trading.requests.GetLocatesRequest
+
+
+CreateLocateRequest
+-------------------
+
+.. autoclass:: alpaca.trading.requests.CreateLocateRequest
+
+
+GetLocateQuotesRequest
+----------------------
+
+.. autoclass:: alpaca.trading.requests.GetLocateQuotesRequest

--- a/tests/trading/test_locates_schema.py
+++ b/tests/trading/test_locates_schema.py
@@ -1,0 +1,123 @@
+from datetime import date, datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from alpaca.trading.enums import (
+    LocateErrorCode,
+    LocateQuoteErrorCode,
+    LocateStatus,
+)
+from alpaca.trading.models import (
+    ErrorResponse,
+    ListLocateQuotesResponse,
+    ListLocatesResponse,
+    Locate,
+    LocateError,
+    LocateQuote,
+    LocateQuoteError,
+    LocateQuotesResponse,
+    LocatesResponse,
+)
+from alpaca.trading.requests import (
+    CreateLocateRequest,
+    GetLocateQuotesRequest,
+    GetLocatesRequest,
+)
+
+
+def test_locate_enums_match_api_values() -> None:
+    assert [status.value for status in LocateStatus] == [
+        "active",
+        "expired",
+        "rejected",
+    ]
+    assert [code.value for code in LocateErrorCode] == [
+        "invalid_input",
+        "invalid_request_body",
+        "invalid_limit_price",
+        "invalid_symbols",
+        "symbol_not_found",
+        "security_not_found",
+        "insufficient_buying_power",
+        "easy_to_borrow",
+        "threshold_security",
+    ]
+    assert [code.value for code in LocateQuoteErrorCode] == [
+        "symbol_not_found",
+        "easy_to_borrow",
+        "threshold_security",
+        "corporate_action",
+    ]
+
+
+def test_locate_models_parse_api_payloads() -> None:
+    now = datetime.now(timezone.utc)
+    locate = Locate(
+        id=uuid4(),
+        symbol="AAPL",
+        requested_qty=100,
+        all_or_none=True,
+        status="active",
+        created_at=now,
+        located_qty=100,
+    )
+    quote = LocateQuote(symbol="AAPL", available_qty=250, quoted_at=now, price="0.01")
+    quote_error = LocateQuoteError(
+        symbol="UNKNOWN",
+        code="symbol_not_found",
+        message="symbol not found",
+    )
+
+    assert locate.status is LocateStatus.ACTIVE
+    assert ListLocatesResponse(locates=[locate], next_page_token=None).locates == [
+        locate
+    ]
+    assert ListLocateQuotesResponse(quotes=[quote], errors=[quote_error]).errors == [
+        quote_error
+    ]
+
+
+def test_locate_error_models_parse_error_codes() -> None:
+    assert ErrorResponse().message is None
+    assert (
+        LocateError(message="bad request", code="invalid_input").code
+        is LocateErrorCode.INVALID_INPUT
+    )
+
+
+def test_locate_response_aliases_are_backwards_compatible() -> None:
+    assert LocatesResponse is ListLocatesResponse
+    assert LocateQuotesResponse is ListLocateQuotesResponse
+
+
+def test_list_locates_response_requires_nullable_page_token() -> None:
+    with pytest.raises(ValidationError):
+        ListLocatesResponse(locates=[])
+
+    assert ListLocatesResponse(locates=[], next_page_token=None).next_page_token is None
+
+
+def test_locate_requests_serialize_api_fields() -> None:
+    assert GetLocatesRequest(
+        page_token="next",
+        limit=25,
+        status=LocateStatus.ACTIVE,
+        symbol="AAPL",
+        start=date(2026, 1, 1),
+        end=date(2026, 1, 31),
+    ).to_request_fields() == {
+        "page_token": "next",
+        "limit": 25,
+        "status": "active",
+        "symbol": "AAPL",
+        "start": "2026-01-01",
+        "end": "2026-01-31",
+    }
+    assert CreateLocateRequest(
+        symbol="AAPL", qty=100, all_or_none=None
+    ).to_request_fields() == {"symbol": "AAPL", "qty": 100}
+    assert GetLocateQuotesRequest(symbols=["AAPL", "MSFT"]).to_request_fields() == {
+        "symbols": ["AAPL", "MSFT"]
+    }


### PR DESCRIPTION
## What

Adds Trading API request and response schemas for stock locates and locate quotes.

## Why

This extracts the locates contract layer from #698 so it can be reviewed independently from the client route implementation in #700.

## Changes

- Adds locate lifecycle and error-code enums.
- Adds locate, quote, error, and paginated response models.
- Adds list, create, and quote request models.
- Preserves compatibility aliases for response names.
- Documents every public locate schema and adds focused validation coverage.

## Testing

- Full suite: 249 passed on Python 3.11.
- Black: all 96 Python files unchanged.
- Sphinx: warnings-fatal HTML build passed.

## Desired feedback

Please verify locate status/error wire values, pagination nullability, and monetary string fields.

## Reviewer guide

1. Review enums and request filters.
2. Review response nullability and compatibility aliases.
3. Confirm representative parsing in the focused tests.
4. Documentation directives are mechanical and safe to skim.

## Checklist

- [x] 428 changed lines, below the split cap
- [x] Full tests pass
- [x] Formatting and documentation builds pass
- [x] No account or client-route changes included

## References

- Extracted from #698
- Schema prerequisite for #700

Made with [Cursor](https://cursor.com)