### PR TITLE
feat(trading): add Activity V2 base models

### DIFF
--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -905,13 +905,13 @@ class ActivityEventV2CommonFields(BaseModel):
 
     at: datetime
     event_id: str
-    activity_type: ActivityType
+    activity_type: str
     executed_at: datetime
     status: str
     settle_date: date
     currency: str
     ref_id: UUID
-    activity_subtype: Optional[ActivitySubType] = None
+    activity_subtype: Optional[str] = None
     price: Optional[str] = None
     qty: Optional[str] = None
     net_amount: Optional[str] = None

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -26,6 +26,7 @@ from alpaca.trading.enums import (
     CorporateActionSubType,
     TradeConfirmationEmail,
     TradeEvent,
+    ExecutionType,
 )
 from pydantic import Field, model_validator
 
@@ -741,3 +742,185 @@ class OptionContractsResponse(BaseModel):
 
     option_contracts: Optional[List[OptionContract]] = None
     next_page_token: Optional[str] = None
+
+
+class CommonNTAActivityV2(BaseModel):
+    """Common fields for all non-trade Activity V2 events."""
+
+    system_date: date
+    group_id: Optional[UUID] = None
+
+
+class CommonCaActivityV2(CommonNTAActivityV2):
+    """Common fields for corporate action Activity V2 events."""
+
+    position_date: date
+    ca_id: Optional[UUID] = None
+    reorg_id: Optional[str] = None
+
+
+class CommonCDIVActivityV2(BaseModel):
+    """Common fields for cash dividend Activity V2 events."""
+
+    symbol: str
+    cusip: str
+    rate: str
+    foreign: bool
+    special: bool
+    due_bill_on_date: Optional[date] = None
+    due_bill_off_date: Optional[date] = None
+    ex_date: Optional[date] = None
+    record_date: Optional[date] = None
+    payable_date: Optional[date] = None
+
+
+class CommonSDIVActivityV2(BaseModel):
+    """Common fields for stock dividend Activity V2 events."""
+
+    symbol: str
+    cusip: str
+    rate: str
+    ex_date: Optional[date] = None
+    record_date: Optional[date] = None
+    payable_date: Optional[date] = None
+
+
+class CommonSplitActivityV2(BaseModel):
+    """Common fields for stock split Activity V2 events."""
+
+    old_cusip: str
+    new_cusip: str
+    old_rate: str
+    new_rate: str
+    payable_date: Optional[date] = None
+
+
+class CommonSplitStockActivityV2(CommonCaActivityV2, CommonSplitActivityV2):
+    """Common fields for stock splits that affect share counts."""
+
+    old_qty: str
+    new_qty: str
+
+
+class CommonSpinoffActivityV2(BaseModel):
+    """Common fields for spinoff Activity V2 events."""
+
+    source_cusip: str
+    source_symbol: str
+    source_rate: str
+    source_price: str
+    new_cusip: str
+    new_symbol: str
+    new_rate: str
+    new_price: str
+    due_bill_redemption_date: Optional[date] = None
+    ex_date: Optional[date] = None
+    record_date: Optional[date] = None
+    payable_date: Optional[date] = None
+
+
+class CommonMAActivityV2(BaseModel):
+    """Common fields for merger and acquisition Activity V2 events."""
+
+    acquiree_cusip: str
+    acquiree_symbol: str
+    effective_date: date
+    payable_date: date
+    acquiree_rate: Optional[str] = None
+    acquirer_cusip: Optional[str] = None
+    acquirer_symbol: Optional[str] = None
+    acquirer_rate: Optional[str] = None
+
+
+class CommonNCActivityV2(BaseModel):
+    """Common fields for name change Activity V2 events."""
+
+    old_cusip: str
+    old_symbol: str
+    new_cusip: str
+    new_symbol: str
+
+
+class CommonVOFSubtypeActivityV2(BaseModel):
+    """Common fields for voluntary offering Activity V2 events."""
+
+    source_cusip: str
+    source_symbol: str
+    new_cusip: Optional[str] = None
+    new_symbol: Optional[str] = None
+
+
+class CommonOptionsActivityV2(CommonNTAActivityV2):
+    """Common fields for options Activity V2 events."""
+
+    group_id: UUID  # type: ignore[assignment]
+
+
+class CommonOPCAActivityV2(CommonCaActivityV2):
+    """Common fields for options corporate action Activity V2 events."""
+
+    old_contract_symbol: str
+    new_contract_symbol: str
+    qty: Optional[str] = None
+    old_qty: Optional[str] = None
+    new_qty: Optional[str] = None
+
+
+class CommonAcatActivityV2(BaseModel):
+    """Common fields for ACATS transfer Activity V2 events."""
+
+    external_id: str
+    request_id: UUID
+    hold_date: Optional[date] = None
+
+
+class CommonJournalActivityV2(CommonNTAActivityV2):
+    """Common fields for journal Activity V2 events."""
+
+    journal_id: Optional[UUID] = None
+
+
+class ActivityV2DetailTRD(BaseModel):
+    """Activity details for a fill or partial-fill trade event."""
+
+    order_id: UUID
+    side: Union[OrderSide, str]
+    symbol: str
+    asset_id: UUID
+    leaves_qty: str
+    cum_qty: str
+    order_status: str
+    execution_type: Union[ExecutionType, str]
+    client_order_id: Optional[str] = None
+    cusip: Optional[str] = None
+    commission: Optional[str] = None
+
+
+class ActivityV2DetailNTA(CommonNTAActivityV2):
+    """Minimum common details for a non-trade activity event."""
+
+
+class ActivityEventV2CommonFields(BaseModel):
+    """Common fields shared by Activity V2 streaming events."""
+
+    at: datetime
+    event_id: str
+    activity_type: ActivityType
+    executed_at: datetime
+    status: str
+    settle_date: date
+    currency: str
+    ref_id: UUID
+    activity_subtype: Optional[ActivitySubType] = None
+    price: Optional[str] = None
+    qty: Optional[str] = None
+    net_amount: Optional[str] = None
+    swap_rate: Optional[str] = None
+    swap_fee_bps: Optional[str] = None
+    previous_id: Optional[UUID] = None
+
+
+class ActivityEventV2(ActivityEventV2CommonFields):
+    """Account activity delivered over the Event Streaming API V2."""
+
+    details: Union[ActivityV2DetailTRD, ActivityV2DetailNTA]

--- a/docs/api_reference/trading/models.rst
+++ b/docs/api_reference/trading/models.rst
@@ -96,3 +96,43 @@ OptionContractsResponse
 -----------------------
 
 .. autoclass:: alpaca.trading.models.OptionContractsResponse
+
+
+Activity V2 Models
+------------------
+
+.. autoclass:: alpaca.trading.models.CommonNTAActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonCaActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonCDIVActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonSDIVActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonSplitActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonSplitStockActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonSpinoffActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonMAActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonNCActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonVOFSubtypeActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonOptionsActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonOPCAActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonAcatActivityV2
+
+.. autoclass:: alpaca.trading.models.CommonJournalActivityV2
+
+.. autoclass:: alpaca.trading.models.ActivityV2DetailTRD
+
+.. autoclass:: alpaca.trading.models.ActivityV2DetailNTA
+
+.. autoclass:: alpaca.trading.models.ActivityEventV2CommonFields
+
+.. autoclass:: alpaca.trading.models.ActivityEventV2

--- a/tests/trading/test_activities.py
+++ b/tests/trading/test_activities.py
@@ -9,6 +9,10 @@ from alpaca.trading.enums import (
     TradeActivityType,
 )
 from alpaca.trading.models import (
+    ActivityEventV2,
+    ActivityV2DetailNTA,
+    ActivityV2DetailTRD,
+    CommonSplitStockActivityV2,
     NonTradeActivities,
     NonTradeActivity,
     TradingActivities,
@@ -139,6 +143,77 @@ def test_activity_response_models_parse_current_schema():
     assert trading_activity.activity_type is ActivityType.FILL
     assert trading_activity.type is TradeActivityType.PARTIAL_FILL
     assert isinstance(trading_activity.order_id, UUID)
+
+
+def test_activity_v2_common_base_parses_inherited_fields():
+    group_id = UUID("4ce24134-3d0c-4f61-aef5-1807a3391380")
+
+    activity = CommonSplitStockActivityV2(
+        system_date="2026-07-14",
+        group_id=str(group_id),
+        position_date="2026-07-11",
+        old_cusip="old-cusip",
+        new_cusip="new-cusip",
+        old_rate="1",
+        new_rate="2",
+        payable_date="2026-07-15",
+        old_qty="5",
+        new_qty="10",
+    )
+
+    assert activity.system_date == date(2026, 7, 14)
+    assert activity.group_id == group_id
+    assert activity.position_date == date(2026, 7, 11)
+    assert activity.payable_date == date(2026, 7, 15)
+    assert activity.new_qty == "10"
+
+
+def test_activity_v2_event_envelope_parses_trade_details():
+    event = ActivityEventV2(
+        at="2026-07-14T10:00:01Z",
+        event_id="01J2Y7YQJFM6V3J5A8YF0P0M0A",
+        activity_type="FILL",
+        activity_subtype="CDIV",
+        executed_at="2026-07-14T10:00:00Z",
+        status="executed",
+        settle_date="2026-07-16",
+        currency="USD",
+        ref_id="4ce24134-3d0c-4f61-aef5-1807a3391380",
+        details={
+            "order_id": "8f027b04-755e-4e33-88c8-66c5aa1e8109",
+            "side": "buy",
+            "symbol": "AAPL",
+            "asset_id": "3b7f98a8-941a-4c59-9b12-1c728c1131ac",
+            "leaves_qty": "0",
+            "cum_qty": "2",
+            "order_status": "filled",
+            "execution_type": "fill",
+        },
+    )
+
+    assert isinstance(event.at, datetime)
+    assert event.activity_type is ActivityType.FILL
+    assert event.activity_subtype is ActivitySubType.CDIV
+    assert isinstance(event.details, ActivityV2DetailTRD)
+    assert event.details.execution_type == ExecutionType.FILL
+
+
+def test_activity_v2_event_envelope_parses_non_trade_details():
+    event = ActivityEventV2(
+        at="2026-07-14T10:00:01Z",
+        event_id="01J2Y7YQJFM6V3J5A8YF0P0M0B",
+        activity_type="DIV",
+        executed_at="2026-07-14T10:00:00Z",
+        status="executed",
+        settle_date="2026-07-16",
+        currency="USD",
+        ref_id="4ce24134-3d0c-4f61-aef5-1807a3391380",
+        net_amount="12.34",
+        details={"system_date": "2026-07-14"},
+    )
+
+    assert isinstance(event.details, ActivityV2DetailNTA)
+    assert event.details.system_date == date(2026, 7, 14)
 
 
 def test_get_activities_request_serializes_filters():

--- a/tests/trading/test_activities.py
+++ b/tests/trading/test_activities.py
@@ -192,8 +192,8 @@ def test_activity_v2_event_envelope_parses_trade_details():
     )
 
     assert isinstance(event.at, datetime)
-    assert event.activity_type is ActivityType.FILL
-    assert event.activity_subtype is ActivitySubType.CDIV
+    assert event.activity_type == "FILL"
+    assert event.activity_subtype == "CDIV"
     assert isinstance(event.details, ActivityV2DetailTRD)
     assert event.details.execution_type == ExecutionType.FILL
 
@@ -214,6 +214,24 @@ def test_activity_v2_event_envelope_parses_non_trade_details():
 
     assert isinstance(event.details, ActivityV2DetailNTA)
     assert event.details.system_date == date(2026, 7, 14)
+
+
+def test_activity_v2_event_envelope_accepts_unknown_activity_values():
+    event = ActivityEventV2(
+        at="2026-07-14T10:00:01Z",
+        event_id="01J2Y7YQJFM6V3J5A8YF0P0M0C",
+        activity_type="CUSTOM_ACTIVITY",
+        activity_subtype="CUSTOM_SUBTYPE",
+        executed_at="2026-07-14T10:00:00Z",
+        status="executed",
+        settle_date="2026-07-16",
+        currency="USD",
+        ref_id="4ce24134-3d0c-4f61-aef5-1807a3391380",
+        details={"system_date": "2026-07-14"},
+    )
+
+    assert event.activity_type == "CUSTOM_ACTIVITY"
+    assert event.activity_subtype == "CUSTOM_SUBTYPE"
 
 
 def test_get_activities_request_serializes_filters():


### PR DESCRIPTION
## What

Adds the shared Activity V2 model hierarchy and event-envelope types.

## Why

This stacked extraction from #698 establishes the reusable Activity V2 contract separately from its many concrete corporate-action event models.

## Changes

- Adds common Activity V2 non-trade, corporate-action, split, option, ACAT, and journal bases.
- Adds trade and non-trade detail models.
- Adds the Activity V2 event envelope with forward-compatible activity type and subtype strings.
- Documents all new public base types and adds focused parsing coverage.

## Testing

- Full suite: 256 passed on Python 3.11.
- Black: all 96 Python files unchanged.
- Sphinx: warnings-fatal HTML build passed.

## Desired feedback

Please focus on inheritance boundaries, field optionality, and forward compatibility of the event envelope.

## Reviewer guide

1. Review the shared classes in `alpaca/trading/models.py`.
2. Confirm envelope behavior and coercion in `tests/trading/test_activities.py`.
3. API-reference additions are mechanical and safe to skim.

This PR is stacked on #732 and contains 316 parent-relative changed lines. Merge #732 first, then retarget this PR to `master`.

## Checklist

- [x] Parent activity-request fixes merged forward
- [x] Full tests pass
- [x] Formatting and documentation build pass
- [x] Concrete Activity V2 event classes excluded

## References

- Extracted from #698
- Depends on #732

Made with [Cursor](https://cursor.com)