### PR TITLE
feat(trading): add advanced order schemas

### DIFF
--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -40,6 +40,7 @@ from alpaca.trading.requests import (
     GetOrdersRequest,
     GetPortfolioHistoryRequest,
     OrderRequest,
+    PatchOrderRequest,
     ReplaceOrderRequest,
     UpdateWatchlistRequest,
 )
@@ -176,14 +177,14 @@ class TradingClient(RESTClient):
     def replace_order_by_id(
         self,
         order_id: Union[UUID, str],
-        order_data: Optional[ReplaceOrderRequest] = None,
+        order_data: Optional[Union[ReplaceOrderRequest, PatchOrderRequest]] = None,
     ) -> Union[Order, RawData]:
         """
         Updates an order with new parameters.
 
         Args:
             order_id (Union[UUID, str]): The unique uuid identifier for the order being replaced.
-            order_data (Optional[ReplaceOrderRequest]): The parameters we wish to update.
+            order_data (Optional[Union[ReplaceOrderRequest, PatchOrderRequest]]): The parameters we wish to update.
 
         Returns:
             alpaca.trading.models.Order: The updated order.

--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -417,3 +417,27 @@ class PositionIntent(str, Enum):
     BUY_TO_CLOSE = "buy_to_close"
     SELL_TO_OPEN = "sell_to_open"
     SELL_TO_CLOSE = "sell_to_close"
+
+
+class AdvancedInstructionsAlgorithm(str, Enum):
+    """
+    Routing algorithm for the Alpaca Elite Smart Router (AdvancedInstructions).
+
+    See https://docs.alpaca.markets/docs/alpaca-elite-smart-router
+    """
+
+    DMA = "DMA"
+    TWAP = "TWAP"
+    VWAP = "VWAP"
+
+
+class AdvancedInstructionsDestination(str, Enum):
+    """
+    Target exchange destination for the Alpaca Elite Smart Router (AdvancedInstructions).
+
+    See https://docs.alpaca.markets/docs/alpaca-elite-smart-router
+    """
+
+    NYSE = "NYSE"
+    NASDAQ = "NASDAQ"
+    ARCA = "ARCA"

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -727,10 +727,9 @@ class AdvancedInstructions(BaseModel):
         max_percentage (Optional[str]): Maximum percentage of the ticker's period volume
             this order may participate in (0 < value < 1, up to 3 decimal points).
 
-    .. todo::
-        Simplify ``algorithm`` to ``AdvancedInstructionsAlgorithm`` and ``destination`` to
-        ``AdvancedInstructionsDestination`` (drop the ``Literal`` fallback) on the next
-        breaking release.
+    Compatibility note: simplify ``algorithm`` to ``AdvancedInstructionsAlgorithm`` and
+    ``destination`` to ``AdvancedInstructionsDestination`` (drop the ``Literal`` fallback)
+    on the next breaking release.
     """
 
     # TODO: simplify to just AdvancedInstructionsAlgorithm / AdvancedInstructionsDestination

--- a/alpaca/trading/models.py
+++ b/alpaca/trading/models.py
@@ -1,8 +1,10 @@
 from alpaca.common.models import ModelWithID, ValidateBaseModel as BaseModel
 from uuid import UUID
 from datetime import datetime, date
-from typing import Any, Optional, List, Union, Dict
+from typing import Any, Literal, Optional, List, Union, Dict
 from alpaca.trading.enums import (
+    AdvancedInstructionsAlgorithm,
+    AdvancedInstructionsDestination,
     AssetClass,
     AssetStatus,
     AssetExchange,
@@ -700,3 +702,47 @@ class OptionContractsResponse(BaseModel):
 
     option_contracts: Optional[List[OptionContract]] = None
     next_page_token: Optional[str] = None
+
+
+class AdvancedInstructions(BaseModel):
+    """
+    Advanced instructions for the Alpaca Elite Smart Router.
+    See https://docs.alpaca.markets/docs/alpaca-elite-smart-router
+
+    Attributes:
+        algorithm (Optional[Union[AdvancedInstructionsAlgorithm, Literal["DMA","TWAP","VWAP"]]]):
+            Advanced routing algorithm to use. Accepts the ``AdvancedInstructionsAlgorithm``
+            enum or a raw string; values are still validated against the allowed set for
+            backward compatibility.
+        destination (Optional[Union[AdvancedInstructionsDestination, Literal["NYSE","NASDAQ","ARCA"]]]):
+            Target exchange for execution. Accepts the ``AdvancedInstructionsDestination``
+            enum or a raw string; values are still validated against the allowed set for
+            backward compatibility.
+        display_qty (Optional[str]): Maximum shares displayed on the exchange at any time
+            (must be in round-lot increments).
+        start_time (Optional[datetime]): When the algorithm starts executing
+            (must be within current market trading hours).
+        end_time (Optional[datetime]): When the algorithm finishes executing
+            (must be within current market trading hours).
+        max_percentage (Optional[str]): Maximum percentage of the ticker's period volume
+            this order may participate in (0 < value < 1, up to 3 decimal points).
+
+    .. todo::
+        Simplify ``algorithm`` to ``AdvancedInstructionsAlgorithm`` and ``destination`` to
+        ``AdvancedInstructionsDestination`` (drop the ``Literal`` fallback) on the next
+        breaking release.
+    """
+
+    # TODO: simplify to just AdvancedInstructionsAlgorithm / AdvancedInstructionsDestination
+    # on next breaking release (drop the Literal fallback — it exists only so callers passing
+    # raw strings still get validated against the allowed set, matching the original strictness).
+    algorithm: Optional[
+        Union[AdvancedInstructionsAlgorithm, Literal["DMA", "TWAP", "VWAP"]]
+    ] = None
+    destination: Optional[
+        Union[AdvancedInstructionsDestination, Literal["NYSE", "NASDAQ", "ARCA"]]
+    ] = None
+    display_qty: Optional[str] = None
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
+    max_percentage: Optional[str] = None

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -351,6 +351,18 @@ class PatchOrderRequest(NonEmptyRequest):
     client_order_id: Optional[str] = None
     advanced_instructions: Optional[AdvancedInstructions] = None
 
+    @model_validator(mode="before")
+    def root_validator(cls, values: dict) -> dict:
+        qty = values.get("qty", None)
+        notional = values.get("notional", None)
+
+        if qty is not None and notional is not None:
+            raise ValueError(
+                "Only one of qty or notional may be provided to PatchOrderRequest, got both."
+            )
+
+        return values
+
 
 class CancelOrderResponse(ModelWithID):
     """

--- a/alpaca/trading/requests.py
+++ b/alpaca/trading/requests.py
@@ -22,6 +22,7 @@ from alpaca.trading.enums import (
     QueryOrderStatus,
     TimeInForce,
 )
+from alpaca.trading.models import AdvancedInstructions
 
 
 class ClosePositionRequest(NonEmptyRequest):
@@ -314,6 +315,41 @@ class ReplaceOrderRequest(NonEmptyRequest):
             raise ValueError("trail must be greater than 0")
 
         return values
+
+
+class PatchOrderRequest(NonEmptyRequest):
+    """
+    Request to patch (replace) an existing open order.
+
+    Note: ``qty`` and ``notional`` are mutually exclusive. ``notional`` is only valid for
+    IPO indications of interest (``asset_class: "ipo"``); non-IPO notional orders cannot
+    be replaced at all — cancel and resubmit instead.
+
+    Attributes:
+        qty (Optional[str]): Number of shares to trade (full shares only). Fractional qty
+            and non-IPO notional orders cannot be changed via patch.
+        notional (Optional[str]): New dollar amount for IPO orders only.
+        time_in_force (Optional[TimeInForce]): New time-in-force for the order.
+        limit_price (Optional[str]): Required if the original order type is ``limit`` or
+            ``stop_limit``. For multi-leg orders, positive = debit, negative = credit.
+        stop_price (Optional[str]): Required if the original order type is ``stop`` or
+            ``stop_limit``.
+        trail (Optional[str]): New ``trail_price`` or ``trail_percent`` value
+            (trailing-stop orders only).
+        client_order_id (Optional[str]): Unique identifier for the replacement order
+            (max 128 characters).
+        advanced_instructions (Optional[AdvancedInstructions]): Elite Smart Router
+            instructions for the replacement order.
+    """
+
+    qty: Optional[str] = None
+    notional: Optional[str] = None
+    time_in_force: Optional[TimeInForce] = None
+    limit_price: Optional[str] = None
+    stop_price: Optional[str] = None
+    trail: Optional[str] = None
+    client_order_id: Optional[str] = None
+    advanced_instructions: Optional[AdvancedInstructions] = None
 
 
 class CancelOrderResponse(ModelWithID):

--- a/docs/api_reference/trading/enums.rst
+++ b/docs/api_reference/trading/enums.rst
@@ -120,3 +120,15 @@ PositionIntent
 ----------------------
 
 .. autoenum:: alpaca.trading.enums.PositionIntent
+
+
+AdvancedInstructionsAlgorithm
+-----------------------------
+
+.. autoenum:: alpaca.trading.enums.AdvancedInstructionsAlgorithm
+
+
+AdvancedInstructionsDestination
+-------------------------------
+
+.. autoenum:: alpaca.trading.enums.AdvancedInstructionsDestination

--- a/docs/api_reference/trading/models.rst
+++ b/docs/api_reference/trading/models.rst
@@ -96,3 +96,9 @@ OptionContractsResponse
 -----------------------
 
 .. autoclass:: alpaca.trading.models.OptionContractsResponse
+
+
+AdvancedInstructions
+--------------------
+
+.. autoclass:: alpaca.trading.models.AdvancedInstructions

--- a/docs/api_reference/trading/requests.rst
+++ b/docs/api_reference/trading/requests.rst
@@ -56,6 +56,12 @@ ReplaceOrderRequest
 .. autoclass:: alpaca.trading.requests.ReplaceOrderRequest
 
 
+PatchOrderRequest
+-----------------
+
+.. autoclass:: alpaca.trading.requests.PatchOrderRequest
+
+
 TakeProfitRequest
 -----------------
 

--- a/tests/trading/test_advanced_orders.py
+++ b/tests/trading/test_advanced_orders.py
@@ -1,0 +1,95 @@
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from alpaca.trading.enums import (
+    AdvancedInstructionsAlgorithm,
+    AdvancedInstructionsDestination,
+)
+from alpaca.trading.models import AdvancedInstructions
+from alpaca.trading.requests import PatchOrderRequest
+
+
+def test_advanced_instruction_enum_values() -> None:
+    assert [member.value for member in AdvancedInstructionsAlgorithm] == [
+        "DMA",
+        "TWAP",
+        "VWAP",
+    ]
+    assert [member.value for member in AdvancedInstructionsDestination] == [
+        "NYSE",
+        "NASDAQ",
+        "ARCA",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("algorithm", "destination"),
+    [
+        (
+            AdvancedInstructionsAlgorithm.DMA,
+            AdvancedInstructionsDestination.NYSE,
+        ),
+        ("TWAP", "NASDAQ"),
+    ],
+)
+def test_advanced_instructions_accepts_enum_and_raw_values(
+    algorithm: AdvancedInstructionsAlgorithm | str,
+    destination: AdvancedInstructionsDestination | str,
+) -> None:
+    instructions = AdvancedInstructions(
+        algorithm=algorithm,
+        destination=destination,
+    )
+
+    assert instructions.algorithm == algorithm
+    assert instructions.destination == destination
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("algorithm", "POV"),
+        ("destination", "IEX"),
+    ],
+)
+def test_advanced_instructions_rejects_unsupported_values(
+    field: str, value: str
+) -> None:
+    with pytest.raises(ValidationError):
+        AdvancedInstructions(**{field: value})
+
+
+def test_patch_order_request_serializes_advanced_instructions() -> None:
+    start_time = datetime(2026, 7, 14, 13, 30, tzinfo=timezone.utc)
+    end_time = datetime(2026, 7, 14, 14, 30, tzinfo=timezone.utc)
+    request = PatchOrderRequest(
+        qty="100",
+        time_in_force="day",
+        limit_price="225.50",
+        client_order_id="replacement-order",
+        advanced_instructions=AdvancedInstructions(
+            algorithm=AdvancedInstructionsAlgorithm.VWAP,
+            destination=AdvancedInstructionsDestination.ARCA,
+            display_qty="100",
+            start_time=start_time,
+            end_time=end_time,
+            max_percentage="0.125",
+        ),
+    )
+
+    assert request.to_request_fields() == {
+        "qty": "100",
+        "time_in_force": "day",
+        "limit_price": "225.50",
+        "client_order_id": "replacement-order",
+        "advanced_instructions": {
+            "algorithm": "VWAP",
+            "destination": "ARCA",
+            "display_qty": "100",
+            "start_time": start_time.isoformat(),
+            "end_time": end_time.isoformat(),
+            "max_percentage": "0.125",
+        },
+    }

--- a/tests/trading/test_advanced_orders.py
+++ b/tests/trading/test_advanced_orders.py
@@ -93,3 +93,27 @@ def test_patch_order_request_serializes_advanced_instructions() -> None:
             "max_percentage": "0.125",
         },
     }
+
+
+@pytest.mark.parametrize(
+    ("fields", "expected"),
+    [
+        ({"qty": "001.250"}, {"qty": "001.250"}),
+        ({"notional": "1250.00"}, {"notional": "1250.00"}),
+        ({}, {}),
+    ],
+)
+def test_patch_order_request_accepts_at_most_one_quantity_field(
+    fields: dict[str, str], expected: dict[str, str]
+) -> None:
+    request = PatchOrderRequest(**fields)
+
+    assert request.to_request_fields() == expected
+
+
+def test_patch_order_request_rejects_qty_and_notional_together() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="Only one of qty or notional may be provided to PatchOrderRequest, got both",
+    ):
+        PatchOrderRequest(qty="100", notional="2500.00")

--- a/tests/trading/test_advanced_orders.py
+++ b/tests/trading/test_advanced_orders.py
@@ -117,3 +117,11 @@ def test_patch_order_request_rejects_qty_and_notional_together() -> None:
         match="Only one of qty or notional may be provided to PatchOrderRequest, got both",
     ):
         PatchOrderRequest(qty="100", notional="2500.00")
+
+
+def test_patch_order_request_rejects_falsey_qty_with_notional() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="Only one of qty or notional may be provided to PatchOrderRequest, got both",
+    ):
+        PatchOrderRequest(qty="", notional="1")

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -1,5 +1,7 @@
 import warnings
+from typing import get_args, get_type_hints
 from uuid import UUID
+
 import pytest
 
 from alpaca.common.enums import BaseURL
@@ -12,7 +14,7 @@ from alpaca.trading.enums import (
     PositionIntent,
     TimeInForce,
 )
-from alpaca.trading.models import Order
+from alpaca.trading.models import AdvancedInstructions, Order
 from alpaca.trading.requests import (
     CancelOrderResponse,
     GetOrderByIdRequest,
@@ -20,6 +22,7 @@ from alpaca.trading.requests import (
     LimitOrderRequest,
     MarketOrderRequest,
     OptionLegRequest,
+    PatchOrderRequest,
     ReplaceOrderRequest,
     StopLossRequest,
     TakeProfitRequest,
@@ -284,6 +287,37 @@ def test_replace_order(reqmock, trading_client: TradingClient):
     order = trading_client.replace_order_by_id(order_id, replace_order_request)
 
     assert type(order) is Order
+
+
+def test_replace_order_accepts_patch_order_request(reqmock):
+    order_id = "61e69015-8549-4bfd-b9c3-01e75843f47d"
+    trading_client = TradingClient("key-id", "secret-key", raw_data=True)
+    reqmock.patch(
+        f"{BaseURL.TRADING_PAPER.value}/v2/orders/{order_id}",
+        json={},
+    )
+    request = PatchOrderRequest(
+        notional="1000.00",
+        advanced_instructions=AdvancedInstructions(
+            algorithm="TWAP",
+            destination="NASDAQ",
+            max_percentage="0.125",
+        ),
+    )
+
+    response = trading_client.replace_order_by_id(order_id, request)
+
+    order_data_type = get_type_hints(TradingClient.replace_order_by_id)["order_data"]
+    assert PatchOrderRequest in get_args(order_data_type)
+    assert reqmock.last_request.json() == {
+        "notional": "1000.00",
+        "advanced_instructions": {
+            "algorithm": "TWAP",
+            "destination": "NASDAQ",
+            "max_percentage": "0.125",
+        },
+    }
+    assert response == {}
 
 
 def test_replace_order_validate_replace_request() -> None:


### PR DESCRIPTION
## What

Adds advanced-routing, order-replacement, and patch-order schemas to the Trading client.

## Why

This advanced-order extraction from #698 keeps request validation and client integration separate from the broader order response-model migration.

## Changes

- Adds advanced routing enums and response models.
- Adds `PatchOrderRequest` with robust qty/notional mutual exclusion.
- Types `replace_order_by_id` with the new request model.
- Adds API references and focused schema and route coverage.

## Testing

- Full suite: 255 passed on Python 3.11.
- Black and warnings-fatal Sphinx build passed.

## Desired feedback

Please focus on falsey quantity handling, PATCH payload serialization, and backwards compatibility of the typed client method.

## Checklist

- [x] 311 changed lines, below the split cap
- [x] Full tests pass
- [x] Formatting and documentation build pass
- [x] Client integration covered

## References

- Extracted from #698

Made with [Cursor](https://cursor.com)