### PR TITLE
fix: add CGD account activity type

### DIFF
--- a/alpaca/trading/enums.py
+++ b/alpaca/trading/enums.py
@@ -13,6 +13,7 @@ class ActivityType(str, Enum):
     ACATC = "ACATC"
     ACATS = "ACATS"
     CFEE = "CFEE"
+    CGD = "CGD"
     CIL = "CIL"
     CSD = "CSD"
     CSW = "CSW"

--- a/tests/broker/test_enums.py
+++ b/tests/broker/test_enums.py
@@ -1,6 +1,10 @@
 from alpaca.trading.enums import ActivityType
 
 
+def test_activity_type_parses_capital_gain_distribution():
+    assert ActivityType("CGD") == "CGD"
+
+
 def test_activity_type_is_trade_activity():
     """This seems like an overly simple test right now but will probably be more useful in the future"""
 


### PR DESCRIPTION
## Summary

- add `CGD` (Capital Gain Distribution) to the broker `ActivityType` enum
- add regression coverage for parsing `CGD` through the public enum

## Root cause

The Broker API emits `CGD` activities, but the SDK enum omitted that supported value. This caused model validation to reject real CGD payloads and prevented typed CGD filters in `GetAccountActivitiesRequest`.

Closes #682.

## Validation

- `poetry run pytest -q` (244 passed)
- `poetry run black --check alpaca/ tests/`
- `pre-commit run --files alpaca/trading/enums.py tests/broker/test_enums.py` (all hooks passed, including the full pytest and Sphinx doc checks)
- direct smoke coverage for `NonTradeActivity.model_validate(...)` and CGD request serialization