### PR TITLE
Fix streaming reconnect reliability (#740)

### DIFF
--- a/alpaca/common/utils.py
+++ b/alpaca/common/utils.py
@@ -1,3 +1,4 @@
+import random
 from typing import Union, Optional
 from uuid import UUID
 from datetime import datetime
@@ -17,6 +18,38 @@ def get_default_user_agent() -> str:
         str: The formatted User-Agent string
     """
     return f"APCA-PY/{__version__} Python/{platform.python_version()}"
+
+
+def reconnect_delay(
+    retries: int,
+    min_backoff: float,
+    max_backoff: float,
+) -> float:
+    """Computes the delay before the next websocket reconnection attempt.
+
+    Uses exponential backoff with equal jitter so repeated failures (e.g. a
+    stream that only allows a single connection and is being rejected while a
+    stale connection is reaped) do not turn into a tight reconnect/HTTP 429 storm.
+
+    Args:
+        retries (int): The number of consecutive failed attempts (>= 1).
+        min_backoff (float): The base delay in seconds for the first retry.
+        max_backoff (float): The maximum delay in seconds to cap the backoff at.
+
+    Returns:
+        float: The number of seconds to wait before retrying, in the range
+        [capped / 2, capped] where ``capped`` is the exponentially-grown,
+        max-capped delay.
+    """
+    capped = min_backoff
+    for _ in range(max(0, retries - 1)):
+        if capped >= max_backoff / 2:
+            capped = max_backoff
+            break
+        capped *= 2
+    capped = min(max_backoff, capped)
+    # equal jitter: wait between half and the full computed delay
+    return capped / 2 + random.uniform(0, capped / 2)
 
 
 def validate_uuid_id_param(

--- a/alpaca/data/live/crypto.py
+++ b/alpaca/data/live/crypto.py
@@ -22,6 +22,7 @@ class CryptoDataStream(DataStream):
         feed: CryptoFeed = CryptoFeed.US,
         url_override: Optional[str] = None,
         websocket_params: Optional[Dict] = None,
+        data_timeout: Optional[float] = 60,
     ) -> None:
         """
         Instantiates a WebSocket client for accessing live cryptocurrency data.
@@ -34,6 +35,10 @@ class CryptoDataStream(DataStream):
             websocket_params (Optional[Dict], optional): Any parameters for configuring websocket connection. Defaults to None.
             url_override (Optional[str]): If specified allows you to override the base url the client
               points to for proxy/testing. Defaults to None.
+            data_timeout (Optional[float], optional): Maximum number of seconds to wait without
+                receiving market data before treating the connection as stale and forcing a
+                reconnect. Detects "connected-but-mute" sockets. Defaults to ``60``.
+                Pass ``None`` to disable for sparse subscriptions.
         """
         super().__init__(
             endpoint=(
@@ -45,6 +50,7 @@ class CryptoDataStream(DataStream):
             secret_key=secret_key,
             raw_data=raw_data,
             websocket_params=websocket_params,
+            data_timeout=data_timeout,
         )
 
     def subscribe_trades(

--- a/alpaca/data/live/crypto.py
+++ b/alpaca/data/live/crypto.py
@@ -22,7 +22,7 @@ class CryptoDataStream(DataStream):
         feed: CryptoFeed = CryptoFeed.US,
         url_override: Optional[str] = None,
         websocket_params: Optional[Dict] = None,
-        data_timeout: Optional[float] = 60,
+        data_timeout: Optional[float] = None,
     ) -> None:
         """
         Instantiates a WebSocket client for accessing live cryptocurrency data.
@@ -37,8 +37,8 @@ class CryptoDataStream(DataStream):
               points to for proxy/testing. Defaults to None.
             data_timeout (Optional[float], optional): Maximum number of seconds to wait without
                 receiving market data before treating the connection as stale and forcing a
-                reconnect. Detects "connected-but-mute" sockets. Defaults to ``60``.
-                Pass ``None`` to disable for sparse subscriptions.
+                reconnect. Detects "connected-but-mute" sockets. Defaults to ``None`` (disabled).
+                Pass a positive number of seconds to opt in for frequently-updated subscriptions.
         """
         super().__init__(
             endpoint=(

--- a/alpaca/data/live/news.py
+++ b/alpaca/data/live/news.py
@@ -17,6 +17,7 @@ class NewsDataStream(DataStream):
         raw_data: bool = False,
         websocket_params: Optional[Dict] = None,
         url_override: Optional[str] = None,
+        data_timeout: Optional[float] = None,
     ) -> None:
         """
         Instantiates a WebSocket client for accessing live news.
@@ -28,6 +29,10 @@ class NewsDataStream(DataStream):
                 connection. Defaults to None.
             url_override (Optional[str]): If specified allows you to override the base url the client
                 points to for proxy/testing. Defaults to None.
+            data_timeout (Optional[float], optional): Maximum number of seconds to wait without
+                receiving market data before treating the connection as stale and forcing a
+                reconnect. Detects "connected-but-mute" sockets. Defaults to ``None``
+                (disabled) because news is typically sparse; pass a positive value to enable.
         """
         super().__init__(
             endpoint=(
@@ -39,6 +44,7 @@ class NewsDataStream(DataStream):
             secret_key=secret_key,
             raw_data=raw_data,
             websocket_params=websocket_params,
+            data_timeout=data_timeout,
         )
 
     def subscribe_news(

--- a/alpaca/data/live/option.py
+++ b/alpaca/data/live/option.py
@@ -20,6 +20,7 @@ class OptionDataStream(DataStream):
         feed: OptionsFeed = OptionsFeed.INDICATIVE,
         websocket_params: Optional[Dict] = None,
         url_override: Optional[str] = None,
+        data_timeout: Optional[float] = 60,
     ) -> None:
         """
         Instantiates a WebSocket client for accessing live option data.
@@ -34,6 +35,10 @@ class OptionDataStream(DataStream):
                 connection. Defaults to None.
             url_override (Optional[str]): If specified allows you to override the base url the client
                 points to for proxy/testing. Defaults to None.
+            data_timeout (Optional[float], optional): Maximum number of seconds to wait without
+                receiving market data before treating the connection as stale and forcing a
+                reconnect. Detects "connected-but-mute" sockets. Defaults to ``60``.
+                Pass ``None`` to disable for sparse subscriptions.
         """
         super().__init__(
             endpoint=(
@@ -45,6 +50,7 @@ class OptionDataStream(DataStream):
             secret_key=secret_key,
             raw_data=raw_data,
             websocket_params=websocket_params,
+            data_timeout=data_timeout,
         )
 
     def subscribe_trades(

--- a/alpaca/data/live/option.py
+++ b/alpaca/data/live/option.py
@@ -20,7 +20,7 @@ class OptionDataStream(DataStream):
         feed: OptionsFeed = OptionsFeed.INDICATIVE,
         websocket_params: Optional[Dict] = None,
         url_override: Optional[str] = None,
-        data_timeout: Optional[float] = 60,
+        data_timeout: Optional[float] = None,
     ) -> None:
         """
         Instantiates a WebSocket client for accessing live option data.
@@ -37,8 +37,8 @@ class OptionDataStream(DataStream):
                 points to for proxy/testing. Defaults to None.
             data_timeout (Optional[float], optional): Maximum number of seconds to wait without
                 receiving market data before treating the connection as stale and forcing a
-                reconnect. Detects "connected-but-mute" sockets. Defaults to ``60``.
-                Pass ``None`` to disable for sparse subscriptions.
+                reconnect. Detects "connected-but-mute" sockets. Defaults to ``None`` (disabled).
+                Pass a positive number of seconds to opt in for frequently-updated subscriptions.
         """
         super().__init__(
             endpoint=(

--- a/alpaca/data/live/stock.py
+++ b/alpaca/data/live/stock.py
@@ -22,6 +22,7 @@ class StockDataStream(DataStream):
         feed: DataFeed = DataFeed.IEX,
         websocket_params: Optional[Dict] = None,
         url_override: Optional[str] = None,
+        data_timeout: Optional[float] = 60,
     ) -> None:
         """
         Instantiates a WebSocket client for accessing live stock data.
@@ -35,6 +36,10 @@ class StockDataStream(DataStream):
             websocket_params (Optional[Dict], optional): Any parameters for configuring websocket connection. Defaults to None.
             url_override (Optional[str]): If specified allows you to override the base url the client
                 points to for proxy/testing. Defaults to None.
+            data_timeout (Optional[float], optional): Maximum number of seconds to wait without
+                receiving market data before treating the connection as stale and forcing a
+                reconnect. Detects "connected-but-mute" sockets. Defaults to ``60``.
+                Pass ``None`` to disable for sparse subscriptions (for example infrequent bars).
 
         Raises:
             ValueError: Only IEX or SIP market data feeds are supported
@@ -52,6 +57,7 @@ class StockDataStream(DataStream):
             secret_key=secret_key,
             raw_data=raw_data,
             websocket_params=websocket_params,
+            data_timeout=data_timeout,
         )
 
     def subscribe_trades(

--- a/alpaca/data/live/stock.py
+++ b/alpaca/data/live/stock.py
@@ -22,7 +22,7 @@ class StockDataStream(DataStream):
         feed: DataFeed = DataFeed.IEX,
         websocket_params: Optional[Dict] = None,
         url_override: Optional[str] = None,
-        data_timeout: Optional[float] = 60,
+        data_timeout: Optional[float] = None,
     ) -> None:
         """
         Instantiates a WebSocket client for accessing live stock data.
@@ -38,8 +38,8 @@ class StockDataStream(DataStream):
                 points to for proxy/testing. Defaults to None.
             data_timeout (Optional[float], optional): Maximum number of seconds to wait without
                 receiving market data before treating the connection as stale and forcing a
-                reconnect. Detects "connected-but-mute" sockets. Defaults to ``60``.
-                Pass ``None`` to disable for sparse subscriptions (for example infrequent bars).
+                reconnect. Detects "connected-but-mute" sockets. Defaults to ``None`` (disabled).
+                Pass a positive number of seconds to opt in for frequently-updated subscriptions.
 
         Raises:
             ValueError: Only IEX or SIP market data feeds are supported

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from websockets.legacy import client as websockets_legacy
 
 from alpaca.common.types import RawData
-from alpaca.common.utils import get_default_user_agent
+from alpaca.common.utils import get_default_user_agent, reconnect_delay
 from alpaca.data.models import (
     Bar,
     News,
@@ -23,6 +23,29 @@ from alpaca.data.models import (
 )
 
 log = logging.getLogger(__name__)
+
+# Recognized market-data frames. Control, unknown, and malformed frames must not
+# reset the staleness clock because they aren't dispatched as market data.
+_CHANNEL_TYPES = {
+    "t": "trades",
+    "q": "quotes",
+    "o": "orderbooks",
+    "b": "bars",
+    "u": "updatedBars",
+    "d": "dailyBars",
+    "s": "statuses",
+    "l": "lulds",
+    "n": "news",
+    "c": "corrections",
+    "x": "cancelErrors",
+}
+
+
+def _is_market_data(msg: Dict) -> bool:
+    msg_type = msg.get("T")
+    if msg_type == "n":
+        return "symbols" in msg
+    return msg_type in _CHANNEL_TYPES and "S" in msg
 
 
 class DataStream:
@@ -37,6 +60,7 @@ class DataStream:
         secret_key: str,
         raw_data: bool = False,
         websocket_params: Optional[Dict] = None,
+        data_timeout: Optional[float] = 60,
     ) -> None:
         """Creates a new DataStream instance.
 
@@ -46,6 +70,12 @@ class DataStream:
             secret_key (str): Alpaca API secret key.
             raw_data (bool, optional): Whether to return raw API data or parsed data. Defaults to False.
             websocket_params (Optional[Dict], optional): Any websocket connection configuration parameters. Defaults to None.
+            data_timeout (Optional[float], optional): Maximum number of seconds to wait without
+                receiving market data before treating the connection as stale and forcing a
+                reconnect. This detects "connected-but-mute" sockets that the transport-level
+                ping/pong keepalive cannot catch. Defaults to ``60``. Pass ``None`` to disable
+                for sparse subscriptions (for example news or infrequent bars), since a
+                legitimately quiet market would otherwise trigger periodic reconnects.
         """
         self._endpoint = endpoint
         self._api_key = api_key
@@ -53,8 +83,15 @@ class DataStream:
         self._ws = None
         self._running = False
         self._loop = None
+        if data_timeout is not None and data_timeout <= 0:
+            raise ValueError("data_timeout must be a positive number of seconds")
         self._raw_data = raw_data
+        self._data_timeout = data_timeout
+        self._data_received = False
+        self._reconnect_min_backoff = 1.0
+        self._reconnect_max_backoff = 30.0
         self._stop_stream_queue = queue.Queue()
+        self._stop_stream_event: Optional[asyncio.Event] = None
         self._handlers = {
             "trades": {},
             "quotes": {},
@@ -80,6 +117,30 @@ class DataStream:
 
         if websocket_params:
             self._websocket_params = websocket_params
+
+    def _reconnect_delay(self, retries: int) -> float:
+        """Computes the delay before the next reconnection attempt.
+
+        Args:
+            retries (int): The number of consecutive failed attempts (>= 1).
+
+        Returns:
+            float: The number of seconds to wait before retrying.
+        """
+        return reconnect_delay(
+            retries, self._reconnect_min_backoff, self._reconnect_max_backoff
+        )
+
+    async def _wait_before_reconnect(self, retries: int) -> None:
+        if self._stop_stream_event is None or self._stop_stream_event.is_set():
+            return
+        try:
+            await asyncio.wait_for(
+                self._stop_stream_event.wait(),
+                timeout=self._reconnect_delay(retries),
+            )
+        except asyncio.TimeoutError:
+            pass
 
     async def _connect(self) -> None:
         """Attempts to connect to the websocket endpoint.
@@ -141,30 +202,69 @@ class DataStream:
     async def close(self) -> None:
         """Closes the websocket connection."""
         if self._ws:
-            await self._ws.close()
-            self._ws = None
+            try:
+                await self._ws.close()
+            finally:
+                self._ws = None
+                self._running = False
+        else:
             self._running = False
 
     async def stop_ws(self) -> None:
         """Signals websocket connection should close by adding a closing message to the stop_stream_queue"""
         self._should_run = False
+        if self._stop_stream_event is not None:
+            self._stop_stream_event.set()
         if self._stop_stream_queue.empty():
             self._stop_stream_queue.put_nowait({"should_stop": True})
         await asyncio.sleep(0)
 
-    async def _consume(self) -> None:
-        """Distributes data from websocket connection to appropriate callbacks"""
+    async def _consume(self) -> bool:
+        """Distributes data from websocket connection to appropriate callbacks.
+
+        Returns:
+            bool: True if the loop exited because the connection went stale (no
+            market data received within ``data_timeout``) and should be reconnected;
+            False if it exited because a stop was requested.
+        """
+        loop = asyncio.get_running_loop()
+        last_data_time = loop.time()
+        self._data_received = False
         while True:
             if not self._stop_stream_queue.empty():
                 self._stop_stream_queue.get(timeout=1)
                 await self.close()
-                break
+                return False
             else:
+                receive_timeout = 5.0
+                if self._data_timeout is not None:
+                    elapsed = loop.time() - last_data_time
+                    if elapsed >= self._data_timeout:
+                        log.warning(
+                            "no data received on %s stream for %.1fs, reconnecting",
+                            self._name,
+                            self._data_timeout,
+                        )
+                        await self.close()
+                        return True
+                    receive_timeout = min(receive_timeout, self._data_timeout - elapsed)
                 try:
-                    r = await asyncio.wait_for(self._ws.recv(), 5)
+                    r = await asyncio.wait_for(self._ws.recv(), receive_timeout)
                     msgs = msgpack.unpackb(r)
                     for msg in msgs:
+                        # Only actual market data resets the staleness clock and
+                        # counts toward recovery; control frames (subscription
+                        # acks, errors) must not, otherwise a subscribed-but-mute
+                        # stream would look healthy and the escalating backoff
+                        # would never engage.
+                        is_market_data = _is_market_data(msg)
+                        if msg.get("T") in _CHANNEL_TYPES and not is_market_data:
+                            continue
+                        if is_market_data:
+                            self._data_received = True
                         await self._dispatch(msg)
+                        if is_market_data:
+                            last_data_time = loop.time()
                 except asyncio.TimeoutError:
                     # ws.recv is hanging when no data is received. by using
                     # wait_for we break when no data is received, allowing us
@@ -243,20 +343,7 @@ class DataStream:
                 await asyncio.gather(*handlers_to_call)
             return
 
-        channel_types = {
-            "t": "trades",
-            "q": "quotes",
-            "o": "orderbooks",
-            "b": "bars",
-            "u": "updatedBars",
-            "d": "dailyBars",
-            "s": "statuses",
-            "l": "lulds",
-            "n": "news",
-            "c": "corrections",
-            "x": "cancelErrors",
-        }
-        channel = channel_types.get(msg_type)
+        channel = _CHANNEL_TYPES.get(msg_type)
         if not channel:
             return
         symbol = msg.get("S")
@@ -334,7 +421,11 @@ class DataStream:
             await asyncio.sleep(0)
         log.info(f"started {self._name} stream")
         self._should_run = True
+        while not self._stop_stream_queue.empty():
+            self._stop_stream_queue.get_nowait()
+        self._stop_stream_event = asyncio.Event()
         self._running = False
+        retries = 0
         while True:
             try:
                 if not self._should_run:
@@ -343,23 +434,44 @@ class DataStream:
                     return
                 if not self._running:
                     log.info("starting {} websocket connection".format(self._name))
+                    self._data_received = False
                     await self._start_ws()
                     await self._send_subscribe_msg()
                     self._running = True
-                await self._consume()
+                stale = await self._consume()
+                if stale:
+                    if self._data_received:
+                        retries = 0
+                    retries += 1
+                    # A reconnect forced by data-staleness hits the same
+                    # single-connection / slow-reap window as an error reconnect,
+                    # so back off here too instead of reconnecting immediately.
+                    # All consecutive reconnect failures share this counter;
+                    # actual market data resets it.
+                    await self._wait_before_reconnect(retries)
             except websockets.WebSocketException as wse:
                 await self.close()
                 self._running = False
+                if self._data_received:
+                    retries = 0
+                retries += 1
                 log.warning("data websocket error, restarting connection: " + str(wse))
-            except ValueError as ve:
-                if "insufficient subscription" in str(ve):
-                    await self.close()
-                    self._running = False
-                    log.exception(f"error during websocket communication: {str(ve)}")
-                    return
-                log.exception(f"error during websocket communication: {str(ve)}")
+                await self._wait_before_reconnect(retries)
             except Exception as e:
+                if isinstance(e, ValueError) and "insufficient subscription" in str(e):
+                    await self.close()
+                    log.exception(f"error during websocket communication: {str(e)}")
+                    return
                 log.exception(f"error during websocket communication: {str(e)}")
+                if not self._running:
+                    # Close any half-open socket from a failed connect/auth so
+                    # abandoned sessions do not keep consuming the
+                    # single-connection slot and cause HTTP 429s.
+                    await self.close()
+                    retries += 1
+                    await self._wait_before_reconnect(retries)
+                elif self._data_received:
+                    retries = 0
             finally:
                 await asyncio.sleep(0)
 

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -44,7 +44,7 @@ _CHANNEL_TYPES = {
 def _is_market_data(msg: Dict) -> bool:
     msg_type = msg.get("T")
     if msg_type == "n":
-        return "symbols" in msg
+        return True
     return msg_type in _CHANNEL_TYPES and "S" in msg
 
 

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import queue
 from collections import defaultdict
+from enum import Enum
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import msgpack
@@ -24,26 +25,45 @@ from alpaca.data.models import (
 
 log = logging.getLogger(__name__)
 
+
+class _MsgType(str, Enum):
+    """Wire ``T`` values for market-data and control frames."""
+
+    TRADE = "t"
+    QUOTE = "q"
+    ORDERBOOK = "o"
+    BAR = "b"
+    UPDATED_BAR = "u"
+    DAILY_BAR = "d"
+    STATUS = "s"
+    LULD = "l"
+    NEWS = "n"
+    CORRECTION = "c"
+    CANCEL_ERROR = "x"
+    SUBSCRIPTION = "subscription"
+    ERROR = "error"
+
+
 # Recognized market-data frames. Control, unknown, and malformed frames must not
 # reset the staleness clock because they aren't dispatched as market data.
 _CHANNEL_TYPES = {
-    "t": "trades",
-    "q": "quotes",
-    "o": "orderbooks",
-    "b": "bars",
-    "u": "updatedBars",
-    "d": "dailyBars",
-    "s": "statuses",
-    "l": "lulds",
-    "n": "news",
-    "c": "corrections",
-    "x": "cancelErrors",
+    _MsgType.TRADE: "trades",
+    _MsgType.QUOTE: "quotes",
+    _MsgType.ORDERBOOK: "orderbooks",
+    _MsgType.BAR: "bars",
+    _MsgType.UPDATED_BAR: "updatedBars",
+    _MsgType.DAILY_BAR: "dailyBars",
+    _MsgType.STATUS: "statuses",
+    _MsgType.LULD: "lulds",
+    _MsgType.NEWS: "news",
+    _MsgType.CORRECTION: "corrections",
+    _MsgType.CANCEL_ERROR: "cancelErrors",
 }
 
 
 def _is_market_data(msg: Dict) -> bool:
     msg_type = msg.get("T")
-    if msg_type == "n":
+    if msg_type == _MsgType.NEWS:
         return True
     return msg_type in _CHANNEL_TYPES and "S" in msg
 
@@ -93,19 +113,7 @@ class DataStream:
         self._reconnect_max_backoff = 30.0
         self._stop_stream_queue = queue.Queue()
         self._stop_stream_event: Optional[asyncio.Event] = None
-        self._handlers = {
-            "trades": {},
-            "quotes": {},
-            "orderbooks": {},
-            "bars": {},
-            "updatedBars": {},
-            "dailyBars": {},
-            "statuses": {},
-            "lulds": {},
-            "news": {},
-            "corrections": {},
-            "cancelErrors": {},
-        }
+        self._handlers = {channel: {} for channel in _CHANNEL_TYPES.values()}
         self._name = "data"
         self._should_run = True
         self._max_frame_size = 32768
@@ -287,7 +295,7 @@ class DataStream:
         msg_type = msg.get("T")
         if "t" in msg:
             msg["t"] = msg["t"].to_datetime()
-        if msg_type == "n":
+        if msg_type == _MsgType.NEWS:
             msg["created_at"] = msg["created_at"].to_datetime()
             msg["updated_at"] = msg["updated_at"].to_datetime()
             # The API always sends "symbols" (possibly []), but normalize
@@ -297,19 +305,19 @@ class DataStream:
             return News(msg)
         if "S" not in msg:
             return msg
-        if msg_type == "t":
+        if msg_type == _MsgType.TRADE:
             return Trade(msg["S"], msg)
-        if msg_type == "q":
+        if msg_type == _MsgType.QUOTE:
             return Quote(msg["S"], msg)
-        if msg_type == "o":
+        if msg_type == _MsgType.ORDERBOOK:
             return Orderbook(msg["S"], msg)
-        if msg_type in ("b", "u", "d"):
+        if msg_type in (_MsgType.BAR, _MsgType.UPDATED_BAR, _MsgType.DAILY_BAR):
             return Bar(msg["S"], msg)
-        if msg_type == "s":
+        if msg_type == _MsgType.STATUS:
             return TradingStatus(msg["S"], msg)
-        if msg_type == "c":
+        if msg_type == _MsgType.CORRECTION:
             return TradeCorrection(msg["S"], msg)
-        if msg_type == "x":
+        if msg_type == _MsgType.CANCEL_ERROR:
             return TradeCancel(msg["S"], msg)
         return msg
 
@@ -320,27 +328,28 @@ class DataStream:
             msg (Dict): The message from the websocket connection
         """
         msg_type = msg.get("T")
-        if msg_type == "subscription":
+        if msg_type == _MsgType.SUBSCRIPTION:
             sub = [f"{k}: {msg.get(k, [])}" for k in self._handlers if msg.get(k)]
             log.info(f'subscribed to {", ".join(sub)}')
             return
 
-        if msg_type == "error":
+        if msg_type == _MsgType.ERROR:
             log.error(f'error: {msg.get("msg")} ({msg.get("code")})')
             return
 
-        if msg_type == "n":
+        if msg_type == _MsgType.NEWS:
             # Missing or empty symbols -> wildcard so unsymbolized/global news
             # still reaches the "*" handler under both raw and parsed modes.
             symbols = msg.get("symbols") or ["*"]
             star_handler_called = False
             handlers_to_call = []
             news = self._cast(msg)
+            news_handlers = self._handlers[_CHANNEL_TYPES[_MsgType.NEWS]]
             for symbol in set(symbols):
-                if symbol in self._handlers["news"]:
-                    handler = self._handlers["news"].get(symbol)
+                if symbol in news_handlers:
+                    handler = news_handlers.get(symbol)
                 elif not star_handler_called:
-                    handler = self._handlers["news"].get("*")
+                    handler = news_handlers.get("*")
                     star_handler_called = True
                 else:
                     handler = None

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -60,7 +60,7 @@ class DataStream:
         secret_key: str,
         raw_data: bool = False,
         websocket_params: Optional[Dict] = None,
-        data_timeout: Optional[float] = 60,
+        data_timeout: Optional[float] = None,
     ) -> None:
         """Creates a new DataStream instance.
 
@@ -73,9 +73,10 @@ class DataStream:
             data_timeout (Optional[float], optional): Maximum number of seconds to wait without
                 receiving market data before treating the connection as stale and forcing a
                 reconnect. This detects "connected-but-mute" sockets that the transport-level
-                ping/pong keepalive cannot catch. Defaults to ``60``. Pass ``None`` to disable
-                for sparse subscriptions (for example news or infrequent bars), since a
-                legitimately quiet market would otherwise trigger periodic reconnects.
+                ping/pong keepalive cannot catch. Defaults to ``None`` (disabled), since a
+                legitimately quiet subscription (for example news or infrequent bars) would
+                otherwise trigger periodic reconnects. Pass a positive number of seconds to
+                opt in for subscriptions that are expected to receive frequent data.
         """
         self._endpoint = endpoint
         self._api_key = api_key

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -290,6 +290,10 @@ class DataStream:
         if msg_type == "n":
             msg["created_at"] = msg["created_at"].to_datetime()
             msg["updated_at"] = msg["updated_at"].to_datetime()
+            # The API always sends "symbols" (possibly []), but normalize
+            # defensively here rather than loosening the shared News model,
+            # which is also used by the strict historical REST client.
+            msg.setdefault("symbols", [])
             return News(msg)
         if "S" not in msg:
             return msg
@@ -326,7 +330,9 @@ class DataStream:
             return
 
         if msg_type == "n":
-            symbols = msg.get("symbols", "*")
+            # Missing or empty symbols -> wildcard so unsymbolized/global news
+            # still reaches the "*" handler under both raw and parsed modes.
+            symbols = msg.get("symbols") or ["*"]
             star_handler_called = False
             handlers_to_call = []
             news = self._cast(msg)

--- a/alpaca/data/models/news.py
+++ b/alpaca/data/models/news.py
@@ -32,7 +32,9 @@ class News(BaseModel):
         summary (str): Summary text for the article (may be first sentence of content)
         created_at (datetime): Date article was created (RFC 3339)
         updated_at (datetime): Date article was updated (RFC 3339)
-        symbols (List[str]): List of related or mentioned symbols
+        symbols (List[str]): List of related or mentioned symbols. May be
+            empty for unsymbolized/global news, but the API always includes
+            the key, so it is intentionally not defaulted here.
         content (str): Content of the news article (might contain HTML)
         author (str): Original author of news article
         images (List[NewsImage]): List of images (URLs) related to given article (may be empty)

--- a/alpaca/trading/stream.py
+++ b/alpaca/trading/stream.py
@@ -10,7 +10,7 @@ from websockets.legacy import client as websockets_legacy
 
 from alpaca.common import RawData
 from alpaca.common.enums import BaseURL
-from alpaca.common.utils import get_default_user_agent
+from alpaca.common.utils import get_default_user_agent, reconnect_delay
 from alpaca.trading import TradeUpdate
 
 log = logging.getLogger(__name__)
@@ -47,7 +47,11 @@ class TradingStream:
         self._loop = None
         self._raw_data = raw_data
         self._stop_stream_queue = queue.Queue()
+        self._stop_stream_event: Optional[asyncio.Event] = None
         self._should_run = True
+        self._data_received = False
+        self._reconnect_min_backoff = 1.0
+        self._reconnect_max_backoff = 30.0
         self._websocket_params = {
             "ping_interval": 10,
             "ping_timeout": 180,
@@ -56,6 +60,30 @@ class TradingStream:
 
         if websocket_params:
             self._websocket_params = websocket_params
+
+    def _reconnect_delay(self, retries: int) -> float:
+        """Computes the delay before the next reconnection attempt.
+
+        Args:
+            retries (int): The number of consecutive failed attempts (>= 1).
+
+        Returns:
+            float: The number of seconds to wait before retrying.
+        """
+        return reconnect_delay(
+            retries, self._reconnect_min_backoff, self._reconnect_max_backoff
+        )
+
+    async def _wait_before_reconnect(self, retries: int) -> None:
+        if self._stop_stream_event is None or self._stop_stream_event.is_set():
+            return
+        try:
+            await asyncio.wait_for(
+                self._stop_stream_event.wait(),
+                timeout=self._reconnect_delay(retries),
+            )
+        except asyncio.TimeoutError:
+            pass
 
     async def _connect(self):
         params = dict(self._websocket_params or {})
@@ -149,6 +177,8 @@ class TradingStream:
                 try:
                     r = await asyncio.wait_for(self._ws.recv(), 5)
                     msg = json.loads(r)
+                    if msg.get("stream") == "trade_updates":
+                        self._data_received = True
                     await self._dispatch(msg)
                 except asyncio.TimeoutError:
                     # ws.recv is hanging when no data is received. by using
@@ -166,7 +196,11 @@ class TradingStream:
             await asyncio.sleep(0.1)
         log.info("started trading stream")
         self._should_run = True
+        while not self._stop_stream_queue.empty():
+            self._stop_stream_queue.get_nowait()
+        self._stop_stream_event = asyncio.Event()
         self._running = False
+        retries = 0
         while True:
             try:
                 if not self._should_run:
@@ -174,34 +208,54 @@ class TradingStream:
                     return
                 if not self._running:
                     log.info("starting trading websocket connection")
+                    self._data_received = False
                     await self._start_ws()
                     self._running = True
-                    await self._consume()
+                await self._consume()
             except websockets.WebSocketException as wse:
                 await self.close()
                 self._running = False
+                if self._data_received:
+                    retries = 0
+                retries += 1
                 log.warning(
                     "trading stream websocket error, restarting "
                     + " connection: "
                     + str(wse)
                 )
+                await self._wait_before_reconnect(retries)
             except Exception as e:
                 log.exception(
                     "error during websocket " "communication: {}".format(str(e))
                 )
+                if not self._running:
+                    # Close any half-open socket from a failed connect/auth so
+                    # abandoned sessions do not keep consuming the
+                    # single-connection slot and cause HTTP 429s.
+                    await self.close()
+                    retries += 1
+                    await self._wait_before_reconnect(retries)
+                elif self._data_received:
+                    retries = 0
             finally:
                 await asyncio.sleep(0.01)
 
     async def close(self) -> None:
         """Closes the websocket connection."""
         if self._ws:
-            await self._ws.close()
-            self._ws = None
+            try:
+                await self._ws.close()
+            finally:
+                self._ws = None
+                self._running = False
+        else:
             self._running = False
 
     async def stop_ws(self) -> None:
         """Signals websocket connection should close by adding a closing message to the stop_stream_queue"""
         self._should_run = False
+        if self._stop_stream_event is not None:
+            self._stop_stream_event.set()
         if self._stop_stream_queue.empty():
             self._stop_stream_queue.put_nowait({"should_stop": True})
 

--- a/docs/market_data.rst
+++ b/docs/market_data.rst
@@ -155,18 +155,18 @@ for crypto data, stock data and option data. These clients are different from th
 have methods which return data immediately. Instead, the methods in these clients allow you to assign
 methods to receive real-time data.
 
-Stock, crypto, and option stream clients default ``data_timeout`` to ``60`` seconds so the
-client reconnects if the socket stays open but stops delivering market data. Pass
-``data_timeout=None`` for sparse subscriptions (for example infrequently updated bars) so a
-quiet market does not trigger unnecessary reconnects. ``NewsDataStream`` defaults to
-``None`` because news is typically sparse.
+All stream clients default ``data_timeout`` to ``None`` (disabled), so a quiet subscription
+(for example statuses or infrequently updated bars) does not trigger unnecessary reconnects.
+Pass a positive number of seconds (for example ``data_timeout=60``) to opt in to staleness
+detection for subscriptions that are expected to receive frequent market data; the client
+then reconnects if the socket stays open but stops delivering data.
 
 
 .. code-block:: python
 
     from alpaca.data.live import CryptoDataStream, OptionDataStream, StockDataStream
 
-    # keys are required for live data; data_timeout defaults to 60
+    # keys are required for live data; data_timeout defaults to None (disabled)
     crypto_stream = CryptoDataStream("api-key", "secret-key")
 
     # keys required

--- a/docs/market_data.rst
+++ b/docs/market_data.rst
@@ -155,12 +155,18 @@ for crypto data, stock data and option data. These clients are different from th
 have methods which return data immediately. Instead, the methods in these clients allow you to assign
 methods to receive real-time data.
 
+Stock, crypto, and option stream clients default ``data_timeout`` to ``60`` seconds so the
+client reconnects if the socket stays open but stops delivering market data. Pass
+``data_timeout=None`` for sparse subscriptions (for example infrequently updated bars) so a
+quiet market does not trigger unnecessary reconnects. ``NewsDataStream`` defaults to
+``None`` because news is typically sparse.
+
 
 .. code-block:: python
 
     from alpaca.data.live import CryptoDataStream, OptionDataStream, StockDataStream
 
-    # keys are required for live data
+    # keys are required for live data; data_timeout defaults to 60
     crypto_stream = CryptoDataStream("api-key", "secret-key")
 
     # keys required

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -191,6 +191,8 @@ this:
 
     from alpaca.data.live import StockDataStream
 
+    # data_timeout defaults to 60 so a connected-but-mute socket reconnects;
+    # pass data_timeout=None for sparse subscriptions.
     stream = StockDataStream(API_KEY, SECRET_KEY)
 
     async def handle_quote(quote):

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -191,8 +191,8 @@ this:
 
     from alpaca.data.live import StockDataStream
 
-    # data_timeout defaults to 60 so a connected-but-mute socket reconnects;
-    # pass data_timeout=None for sparse subscriptions.
+    # data_timeout defaults to None (disabled); pass a positive number of
+    # seconds (e.g. data_timeout=60) to reconnect a connected-but-mute socket.
     stream = StockDataStream(API_KEY, SECRET_KEY)
 
     async def handle_quote(quote):

--- a/tests/test_streaming_reconnect_issues.py
+++ b/tests/test_streaming_reconnect_issues.py
@@ -1,0 +1,967 @@
+"""Tests for the streaming reconnect fixes (issue #740).
+
+These originally reproduced the buggy behavior; they now assert the corrected
+behavior after the fixes:
+
+* Silent-but-open data socket: ``DataStream`` gained a ``data_timeout`` (default
+  ``60``; pass ``None`` to disable). When set, a connected socket that stops
+  delivering data (but still answers transport pings) now breaks the consume
+  loop and reconnects instead of looping forever with ``_running`` stuck True.
+
+* Reconnect backoff: both ``DataStream`` and ``TradingStream`` now reconnect with
+  exponential backoff + jitter (``_reconnect_delay``) instead of a fixed ~10ms
+  retry, avoiding the HTTP 429 storm on single-connection streams.
+
+"""
+
+import asyncio
+import json
+
+import msgpack
+import pytest
+import websockets
+
+from alpaca.data.enums import DataFeed
+from alpaca.data.live.crypto import CryptoDataStream
+from alpaca.data.live.news import NewsDataStream
+from alpaca.data.live.option import OptionDataStream
+from alpaca.data.live.stock import StockDataStream
+from alpaca.data.live.websocket import DataStream
+from alpaca.trading.stream import TradingStream
+
+# ---------------------------------------------------------------------------
+# Fix 1: silent-but-open data socket now triggers a reconnect via data_timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_data_stream_reconnects_on_silent_socket():
+    """With ``data_timeout`` set, a mute-but-alive socket breaks the loop.
+
+    ``recv`` repeatedly times out without delivering data while advancing the
+    clock a little each call. Once the elapsed silence exceeds ``data_timeout``,
+    ``_consume`` closes the socket and returns so ``_run_forever`` can reconnect.
+    """
+    close_calls = 0
+
+    class MuteSocket:
+        def __init__(self):
+            self.recv_calls = 0
+
+        async def recv(self):
+            self.recv_calls += 1
+            await asyncio.sleep(0.01)  # advance the clock; deliver no data
+            raise asyncio.TimeoutError
+
+        async def close(self):
+            nonlocal close_calls
+            close_calls += 1
+
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=0.05)
+    stream._ws = MuteSocket()
+    stream._running = True
+
+    # Previously this looped forever; now it returns once the staleness
+    # threshold is crossed. The outer timeout only guards against regressions.
+    stale = await asyncio.wait_for(stream._consume(), timeout=2)
+
+    assert stale is True  # signals _run_forever to reconnect
+    assert close_calls == 1
+    assert stream._running is False
+    assert stream._ws is None
+
+
+@pytest.mark.asyncio
+async def test_data_timeout_shorter_than_receive_poll_interval_is_enforced():
+    """The configured timeout is not delayed by the five-second receive poll."""
+
+    class MuteSocket:
+        async def recv(self):
+            await asyncio.Event().wait()
+
+        async def close(self):
+            pass
+
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=0.01)
+    stream._ws = MuteSocket()
+    stream._running = True
+
+    stale = await asyncio.wait_for(stream._consume(), timeout=0.5)
+
+    assert stale is True
+
+
+@pytest.mark.asyncio
+async def test_slow_handler_does_not_make_active_stream_stale():
+    """Callback execution time is excluded from the data-staleness window."""
+
+    class Socket:
+        def __init__(self):
+            self.recv_calls = 0
+
+        async def recv(self):
+            self.recv_calls += 1
+            if self.recv_calls == 1:
+                return msgpack.packb([{"T": "t", "S": "AAPL"}])
+            await stream.stop_ws()
+            return msgpack.packb([{"T": "subscription", "trades": ["AAPL"]}])
+
+        async def close(self):
+            pass
+
+    stream = DataStream(
+        "endpoint", "key-id", "secret-key", raw_data=True, data_timeout=0.02
+    )
+
+    async def handler(_):
+        await asyncio.sleep(0.04)
+
+    stream._handlers["trades"]["AAPL"] = handler
+    stream._ws = Socket()
+    stream._running = True
+
+    stale = await asyncio.wait_for(stream._consume(), timeout=1)
+
+    assert stale is False
+    assert stream._ws is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "control_message",
+    [
+        {"T": "subscription", "trades": ["AAPL"]},
+        {"T": "error", "code": 400, "msg": "boom"},
+        {"T": "heartbeat"},
+        {},
+        {"T": "t"},
+        {"T": "n"},
+    ],
+)
+async def test_continuous_control_frames_do_not_hide_stale_data(control_message):
+    """Control traffic cannot keep a stream with no market data alive forever."""
+    control_frame = msgpack.packb([control_message])
+
+    class ControlOnlySocket:
+        async def recv(self):
+            await asyncio.sleep(0.005)
+            return control_frame
+
+        async def close(self):
+            pass
+
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=0.03)
+    stream._ws = ControlOnlySocket()
+    stream._running = True
+
+    stale = await asyncio.wait_for(stream._consume(), timeout=0.5)
+
+    assert stale is True
+
+
+@pytest.mark.asyncio
+async def test_data_stream_run_forever_reconnects_and_resubscribes_after_stale():
+    """End-to-end recovery: a stale session leads to a fresh connect + resubscribe.
+
+    Drives the real ``_run_forever`` loop with a fake connect/consume sequence:
+    the first session goes mute (``_consume`` returns True), and the second
+    session requests a stop. We assert the loop connected and resubscribed a
+    second time (the user-visible recovery).
+    """
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=0.01)
+
+    async def handler(_):
+        pass
+
+    stream._handlers["trades"]["AAPL"] = handler
+
+    connects = 0
+    subscribes = 0
+    consume_calls = 0
+
+    async def fake_start_ws():
+        nonlocal connects
+        connects += 1
+        stream._ws = object()
+
+    async def fake_send_subscribe_msg():
+        nonlocal subscribes
+        subscribes += 1
+
+    async def fake_consume():
+        nonlocal consume_calls
+        consume_calls += 1
+        if consume_calls == 1:
+            # First session goes mute: close and report a stale exit.
+            stream._data_received = False
+            await stream.close()
+            return True
+        # Second session: signal stop so _run_forever exits cleanly.
+        await stream.stop_ws()
+        return False
+
+    async def fake_close():
+        stream._ws = None
+        stream._running = False
+
+    stream._start_ws = fake_start_ws
+    stream._send_subscribe_msg = fake_send_subscribe_msg
+    stream._consume = fake_consume
+    stream.close = fake_close
+
+    await asyncio.wait_for(stream._run_forever(), timeout=2)
+
+    # Reconnected and resubscribed after the mute session (recovery happened).
+    assert connects == 2
+    assert subscribes == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "frames, expect_data_received",
+    [
+        # Only a subscription ack arrives, then the stream goes mute: the ack is
+        # a control frame and must NOT count as market data (so escalation can
+        # engage on a subscribed-but-mute stream).
+        ([[{"T": "subscription", "trades": ["AAPL"]}]], False),
+        # An error control frame likewise does not count as market data.
+        ([[{"T": "error", "code": 400, "msg": "boom"}]], False),
+        # A real trade after the ack does count as market data.
+        (
+            [
+                [{"T": "subscription", "trades": ["AAPL"]}],
+                [{"T": "t", "S": "AAPL"}],
+            ],
+            True,
+        ),
+    ],
+)
+async def test_data_received_tracks_market_data_not_control_frames(
+    frames, expect_data_received
+):
+    """``_data_received`` reflects market data only, not subscription/error acks."""
+    encoded = [msgpack.packb(f) for f in frames]
+
+    class Socket:
+        def __init__(self):
+            self._frames = list(encoded)
+
+        async def recv(self):
+            if self._frames:
+                return self._frames.pop(0)
+            await asyncio.sleep(0.01)  # advance clock; go mute
+            raise asyncio.TimeoutError
+
+        async def close(self):
+            pass
+
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=0.05)
+    stream._ws = Socket()
+    stream._running = True
+
+    stale = await asyncio.wait_for(stream._consume(), timeout=2)
+
+    assert stale is True
+    assert stream._data_received is expect_data_received
+
+
+@pytest.mark.asyncio
+async def test_subscribed_but_mute_stream_escalates_backoff():
+    """A stream that only ever receives the ack then mutes escalates its backoff.
+
+    Each reconnect cycle receives only a subscription ack (no market data), so
+    ``_data_received`` stays False and the retry count must keep growing rather
+    than resetting to 1 every cycle.
+    """
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=0.01)
+
+    async def handler(_):
+        pass
+
+    stream._handlers["trades"]["AAPL"] = handler
+
+    seen_retries = []
+    consume_calls = 0
+
+    async def fake_start_ws():
+        stream._ws = object()
+
+    async def fake_send_subscribe_msg():
+        pass
+
+    async def fake_consume():
+        nonlocal consume_calls
+        consume_calls += 1
+        # Simulate "subscribe ok, then mute": no market data seen this session.
+        stream._data_received = False
+        await stream.close()
+        return True
+
+    async def fake_close():
+        stream._ws = None
+        stream._running = False
+
+    def fake_reconnect_delay(retries):
+        seen_retries.append(retries)
+        if len(seen_retries) >= 5:
+            stream._should_run = False
+        return 0
+
+    stream._start_ws = fake_start_ws
+    stream._send_subscribe_msg = fake_send_subscribe_msg
+    stream._consume = fake_consume
+    stream.close = fake_close
+    stream._reconnect_delay = fake_reconnect_delay
+
+    await asyncio.wait_for(stream._run_forever(), timeout=5)
+
+    assert seen_retries == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_data_stream_without_timeout_stays_silent():
+    """Explicit ``data_timeout=None`` disables staleness detection.
+
+    Confirms sparse streams can opt out so a legitimately quiet market does not
+    force reconnects. A large number of silent receive windows do not close the
+    socket; only an injected non-timeout error ends the loop.
+    """
+    close_calls = 0
+    silent_cycles = 50
+
+    class BreakLoop(Exception):
+        pass
+
+    class MuteSocket:
+        def __init__(self):
+            self.recv_calls = 0
+
+        async def recv(self):
+            self.recv_calls += 1
+            if self.recv_calls > silent_cycles:
+                raise BreakLoop
+            await asyncio.sleep(0)
+            raise asyncio.TimeoutError
+
+        async def close(self):
+            nonlocal close_calls
+            close_calls += 1
+
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=None)
+    stream._ws = MuteSocket()
+    stream._running = True
+
+    with pytest.raises(BreakLoop):
+        await stream._consume()
+
+    assert close_calls == 0
+    assert stream._running is True
+
+
+@pytest.mark.asyncio
+async def test_data_stream_surfaces_transport_exception_for_reconnect():
+    """A transport error still propagates out of ``_consume`` to the reconnect path."""
+
+    class DeadSocket:
+        async def recv(self):
+            raise websockets.WebSocketException("connection closed")
+
+        async def close(self):
+            pass
+
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=None)
+    stream._ws = DeadSocket()
+    stream._running = True
+
+    with pytest.raises(websockets.WebSocketException):
+        await stream._consume()
+
+
+def test_data_timeout_defaults_and_is_configurable():
+    """Active streams default to 60s; ``None`` disables; overrides are honored."""
+    default = DataStream("endpoint", "key-id", "secret-key")
+    assert default._data_timeout == 60
+
+    disabled = DataStream("endpoint", "key-id", "secret-key", data_timeout=None)
+    assert disabled._data_timeout is None
+
+    configured = DataStream("endpoint", "key-id", "secret-key", data_timeout=30)
+    assert configured._data_timeout == 30
+
+    assert StockDataStream("key-id", "secret-key")._data_timeout == 60
+    assert CryptoDataStream("key-id", "secret-key")._data_timeout == 60
+    assert OptionDataStream("key-id", "secret-key")._data_timeout == 60
+    # News is sparse by default.
+    assert NewsDataStream("key-id", "secret-key")._data_timeout is None
+
+    subclass_streams = [
+        StockDataStream("key-id", "secret-key", feed=DataFeed.SIP, data_timeout=45),
+        CryptoDataStream("key-id", "secret-key", data_timeout=45),
+        OptionDataStream("key-id", "secret-key", data_timeout=45),
+        NewsDataStream("key-id", "secret-key", data_timeout=45),
+    ]
+    for stream in subclass_streams:
+        assert stream._data_timeout == 45
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, -0.5])
+def test_data_timeout_rejects_non_positive_values(bad_value):
+    """A zero/negative ``data_timeout`` is a misconfiguration and is rejected."""
+    with pytest.raises(ValueError):
+        DataStream("endpoint", "key-id", "secret-key", data_timeout=bad_value)
+    with pytest.raises(ValueError):
+        StockDataStream("key-id", "secret-key", data_timeout=bad_value)
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: reconnect uses exponential backoff + jitter (no 429 storm)
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_delay_grows_and_caps():
+    """``_reconnect_delay`` grows exponentially with jitter and caps at the max.
+
+    Bounds hold for any random draw (equal jitter => delay in [capped/2, capped]).
+    """
+    for stream in (
+        DataStream("endpoint", "key-id", "secret-key"),
+        TradingStream("key-id", "secret-key"),
+    ):
+        for retries, capped in [
+            (1, 1.0),
+            (2, 2.0),
+            (3, 4.0),
+            (10, 30.0),
+            (50, 30.0),
+            (1025, 30.0),
+        ]:
+            delays = [stream._reconnect_delay(retries) for _ in range(50)]
+            assert min(delays) >= capped / 2 - 1e-9
+            assert max(delays) <= capped + 1e-9
+
+        # Never exceeds the configured cap, regardless of attempt count.
+        assert all(stream._reconnect_delay(r) <= 30.0 for r in range(1, 100))
+
+
+@pytest.mark.asyncio
+async def test_trading_stream_reconnect_uses_backoff():
+    """Repeated connection failures escalate the backoff instead of storming.
+
+    Deterministic (no wall-clock thresholds): ``_reconnect_delay`` is stubbed to
+    record the ``retries`` it is called with and to return no delay, and it stops
+    the loop after a fixed number of attempts. We assert the retry counter grows
+    monotonically (1, 2, 3, ...) across consecutive failures — i.e. backoff is
+    applied and never reset while the connection keeps failing.
+    """
+    stream = TradingStream("key-id", "secret-key")
+
+    async def handler(_):
+        pass
+
+    stream._trade_updates_handler = handler
+
+    async def fake_start_ws():
+        raise websockets.WebSocketException("connection rejected (HTTP 429)")
+
+    async def fake_close():
+        stream._ws = None
+        stream._running = False
+
+    seen_retries = []
+
+    def fake_reconnect_delay(retries):
+        seen_retries.append(retries)
+        if len(seen_retries) >= 5:
+            self_stop()
+        return 0  # no real waiting
+
+    def self_stop():
+        stream._should_run = False
+
+    stream._start_ws = fake_start_ws
+    stream.close = fake_close
+    stream._reconnect_delay = fake_reconnect_delay
+
+    await asyncio.wait_for(stream._run_forever(), timeout=5)
+
+    # Backoff escalates monotonically with each consecutive failure (no reset,
+    # no fixed ~10ms cadence).
+    assert seen_retries == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream_type", [DataStream, TradingStream])
+async def test_failed_start_closes_half_open_socket(stream_type):
+    """Connect/auth ValueErrors must close the socket before backoff retries."""
+
+    async def handler(_):
+        pass
+
+    if stream_type is DataStream:
+        stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=None)
+        stream._handlers["trades"]["AAPL"] = handler
+    else:
+        stream = TradingStream("key-id", "secret-key")
+        stream._trade_updates_handler = handler
+
+    close_calls = 0
+
+    class HalfOpenSocket:
+        async def close(self):
+            nonlocal close_calls
+            close_calls += 1
+
+    async def fake_start_ws():
+        # Simulate connect succeeding then auth failing, leaving _ws set.
+        stream._ws = HalfOpenSocket()
+        raise ValueError("failed to authenticate")
+
+    seen_retries = []
+
+    def fake_reconnect_delay(retries):
+        seen_retries.append(retries)
+        # Abandoned sessions must not keep the single-connection slot.
+        assert stream._ws is None
+        if len(seen_retries) >= 3:
+            stream._should_run = False
+        return 0
+
+    stream._start_ws = fake_start_ws
+    stream._reconnect_delay = fake_reconnect_delay
+
+    await asyncio.wait_for(stream._run_forever(), timeout=5)
+
+    assert seen_retries == [1, 2, 3]
+    assert close_calls == 3
+    assert stream._ws is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream_type", [DataStream, TradingStream])
+async def test_post_connect_disconnects_escalate_backoff(stream_type):
+    """A connection that drops after authentication still escalates backoff."""
+
+    async def handler(_):
+        pass
+
+    if stream_type is DataStream:
+        stream = DataStream("endpoint", "key-id", "secret-key")
+        stream._handlers["trades"]["AAPL"] = handler
+
+        async def fake_send_subscribe_msg():
+            pass
+
+        stream._send_subscribe_msg = fake_send_subscribe_msg
+    else:
+        stream = TradingStream("key-id", "secret-key")
+        stream._trade_updates_handler = handler
+
+    async def fake_start_ws():
+        stream._ws = object()
+
+    async def fake_consume():
+        raise websockets.WebSocketException("connection dropped after authentication")
+
+    async def fake_close():
+        stream._ws = None
+        stream._running = False
+
+    seen_retries = []
+
+    def fake_reconnect_delay(retries):
+        seen_retries.append(retries)
+        if len(seen_retries) >= 5:
+            stream._should_run = False
+        return 0
+
+    stream._start_ws = fake_start_ws
+    stream._consume = fake_consume
+    stream.close = fake_close
+    stream._reconnect_delay = fake_reconnect_delay
+
+    await asyncio.wait_for(stream._run_forever(), timeout=5)
+
+    assert seen_retries == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_trading_listening_ack_does_not_reset_backoff():
+    """A control acknowledgement alone does not make the connection healthy."""
+    stream = TradingStream("key-id", "secret-key")
+
+    async def handler(_):
+        pass
+
+    stream._trade_updates_handler = handler
+
+    class ListeningOnlySocket:
+        def __init__(self):
+            self._sent_ack = False
+
+        async def recv(self):
+            if not self._sent_ack:
+                self._sent_ack = True
+                return json.dumps(
+                    {"stream": "listening", "data": {"streams": ["trade_updates"]}}
+                )
+            raise websockets.WebSocketException(
+                "connection dropped after listening acknowledgement"
+            )
+
+        async def close(self):
+            pass
+
+    async def fake_start_ws():
+        stream._ws = ListeningOnlySocket()
+
+    seen_retries = []
+
+    def fake_reconnect_delay(retries):
+        seen_retries.append(retries)
+        if len(seen_retries) >= 5:
+            stream._should_run = False
+        return 0
+
+    stream._start_ws = fake_start_ws
+    stream._reconnect_delay = fake_reconnect_delay
+
+    await asyncio.wait_for(stream._run_forever(), timeout=5)
+
+    assert seen_retries == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_healthy_stale_session_resets_transport_backoff():
+    """Receiving market data resets earlier transport-failure retries."""
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=0.01)
+
+    async def handler(_):
+        pass
+
+    stream._handlers["trades"]["AAPL"] = handler
+    start_attempts = 0
+    consume_calls = 0
+
+    async def fake_start_ws():
+        nonlocal start_attempts
+        start_attempts += 1
+        if start_attempts <= 2:
+            raise websockets.WebSocketException("connection rejected")
+        stream._ws = object()
+
+    async def fake_send_subscribe_msg():
+        pass
+
+    async def fake_consume():
+        nonlocal consume_calls
+        consume_calls += 1
+        if consume_calls == 1:
+            stream._data_received = True
+            await stream.close()
+            return True
+        raise websockets.WebSocketException("connection dropped")
+
+    async def fake_close():
+        stream._ws = None
+        stream._running = False
+
+    seen_retries = []
+
+    def fake_reconnect_delay(retries):
+        seen_retries.append(retries)
+        if len(seen_retries) >= 4:
+            stream._should_run = False
+        return 0
+
+    stream._start_ws = fake_start_ws
+    stream._send_subscribe_msg = fake_send_subscribe_msg
+    stream._consume = fake_consume
+    stream.close = fake_close
+    stream._reconnect_delay = fake_reconnect_delay
+
+    await asyncio.wait_for(stream._run_forever(), timeout=5)
+
+    assert seen_retries == [1, 2, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_healthy_transport_session_resets_stale_backoff():
+    """Receiving market data resets earlier stale-session retries."""
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=0.01)
+
+    async def handler(_):
+        pass
+
+    stream._handlers["trades"]["AAPL"] = handler
+    consume_calls = 0
+
+    async def fake_start_ws():
+        stream._ws = object()
+
+    async def fake_send_subscribe_msg():
+        pass
+
+    async def fake_consume():
+        nonlocal consume_calls
+        consume_calls += 1
+        if consume_calls in (1, 2, 4):
+            stream._data_received = False
+            await stream.close()
+            return True
+        stream._data_received = True
+        raise websockets.WebSocketException("healthy connection dropped")
+
+    async def fake_close():
+        stream._ws = None
+        stream._running = False
+
+    seen_retries = []
+
+    def fake_reconnect_delay(retries):
+        seen_retries.append(retries)
+        if len(seen_retries) >= 4:
+            stream._should_run = False
+        return 0
+
+    stream._start_ws = fake_start_ws
+    stream._send_subscribe_msg = fake_send_subscribe_msg
+    stream._consume = fake_consume
+    stream.close = fake_close
+    stream._reconnect_delay = fake_reconnect_delay
+
+    await asyncio.wait_for(stream._run_forever(), timeout=5)
+
+    assert seen_retries == [1, 2, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_stale_and_transport_failures_share_backoff():
+    """Changing failure modes does not reset backoff without market data."""
+    stream = DataStream("endpoint", "key-id", "secret-key", data_timeout=0.01)
+
+    async def handler(_):
+        pass
+
+    stream._handlers["trades"]["AAPL"] = handler
+    connection_attempts = 0
+
+    async def fake_start_ws():
+        nonlocal connection_attempts
+        connection_attempts += 1
+        if connection_attempts == 4:
+            raise websockets.WebSocketException("connection rejected")
+        stream._ws = object()
+
+    async def fake_send_subscribe_msg():
+        pass
+
+    async def fake_consume():
+        stream._data_received = False
+        await stream.close()
+        return True
+
+    async def fake_close():
+        stream._ws = None
+        stream._running = False
+
+    seen_retries = []
+
+    def fake_reconnect_delay(retries):
+        seen_retries.append(retries)
+        if len(seen_retries) >= 4:
+            stream._should_run = False
+        return 0
+
+    stream._start_ws = fake_start_ws
+    stream._send_subscribe_msg = fake_send_subscribe_msg
+    stream._consume = fake_consume
+    stream.close = fake_close
+    stream._reconnect_delay = fake_reconnect_delay
+
+    await asyncio.wait_for(stream._run_forever(), timeout=5)
+
+    assert seen_retries == [1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [ValueError, RuntimeError])
+@pytest.mark.parametrize("stream_type", [DataStream, TradingStream])
+async def test_handler_errors_do_not_apply_reconnect_backoff(error_type, stream_type):
+    """Errors on an active socket resume consumption without reconnect backoff."""
+    handler_calls = 0
+    start_calls = 0
+
+    async def handler(_):
+        nonlocal handler_calls
+        handler_calls += 1
+        if handler_calls <= 3:
+            raise error_type("handler failed")
+        await stream.stop_ws()
+
+    if stream_type is DataStream:
+        stream = DataStream("endpoint", "key-id", "secret-key", raw_data=True)
+        stream._handlers["trades"]["AAPL"] = handler
+
+        async def fake_send_subscribe_msg():
+            pass
+
+        stream._send_subscribe_msg = fake_send_subscribe_msg
+    else:
+        stream = TradingStream("key-id", "secret-key", raw_data=True)
+        stream._trade_updates_handler = handler
+
+    class Socket:
+        async def recv(self):
+            if stream_type is DataStream:
+                return msgpack.packb([{"T": "t", "S": "AAPL"}])
+            return json.dumps({"stream": "trade_updates", "data": {}})
+
+        async def close(self):
+            pass
+
+    async def fake_start_ws():
+        nonlocal start_calls
+        start_calls += 1
+        stream._ws = Socket()
+
+    seen_retries = []
+
+    def fake_reconnect_delay(retries):
+        seen_retries.append(retries)
+        return 0
+
+    stream._start_ws = fake_start_ws
+    stream._reconnect_delay = fake_reconnect_delay
+
+    await asyncio.wait_for(stream._run_forever(), timeout=5)
+
+    assert handler_calls == 4
+    assert start_calls == 1
+    assert seen_retries == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream_type", [DataStream, TradingStream])
+async def test_stop_interrupts_reconnect_backoff(stream_type):
+    """Stopping either stream interrupts an in-progress reconnect delay."""
+
+    async def handler(_):
+        pass
+
+    if stream_type is DataStream:
+        stream = DataStream("endpoint", "key-id", "secret-key")
+        stream._handlers["trades"]["AAPL"] = handler
+    else:
+        stream = TradingStream("key-id", "secret-key")
+        stream._trade_updates_handler = handler
+
+    connection_attempted = asyncio.Event()
+
+    async def fake_start_ws():
+        connection_attempted.set()
+        raise websockets.WebSocketException("connection rejected")
+
+    stream._start_ws = fake_start_ws
+    stream._reconnect_delay = lambda _: 60
+
+    run_task = asyncio.create_task(stream._run_forever())
+    await asyncio.wait_for(connection_attempted.wait(), timeout=0.5)
+    await stream.stop_ws()
+
+    await asyncio.wait_for(run_task, timeout=0.5)
+
+
+@pytest.mark.parametrize("stream_type", [DataStream, TradingStream])
+def test_stream_can_restart_on_a_new_event_loop(stream_type):
+    """The stop-aware backoff state is recreated when a stream is run again."""
+
+    async def handler(_):
+        pass
+
+    if stream_type is DataStream:
+        stream = DataStream("endpoint", "key-id", "secret-key")
+        stream._handlers["trades"]["AAPL"] = handler
+    else:
+        stream = TradingStream("key-id", "secret-key")
+        stream._trade_updates_handler = handler
+
+    async def run_once():
+        connection_attempted = asyncio.Event()
+
+        async def fake_start_ws():
+            connection_attempted.set()
+            raise websockets.WebSocketException("connection rejected")
+
+        stream._start_ws = fake_start_ws
+        stream._reconnect_delay = lambda _: 60
+
+        run_task = asyncio.create_task(stream._run_forever())
+        await asyncio.wait_for(connection_attempted.wait(), timeout=0.5)
+        await stream.stop_ws()
+        await asyncio.wait_for(run_task, timeout=0.5)
+
+    asyncio.run(run_once())
+    asyncio.run(run_once())
+
+
+@pytest.mark.parametrize("stream_type", [DataStream, TradingStream])
+def test_restart_after_backoff_stop_connects_once(stream_type):
+    """A stop signal from the prior run is not consumed by the restarted stream."""
+
+    async def handler(_):
+        pass
+
+    if stream_type is DataStream:
+        stream = DataStream("endpoint", "key-id", "secret-key")
+        stream._handlers["trades"]["AAPL"] = handler
+
+        async def fake_send_subscribe_msg():
+            pass
+
+        stream._send_subscribe_msg = fake_send_subscribe_msg
+    else:
+        stream = TradingStream("key-id", "secret-key")
+        stream._trade_updates_handler = handler
+
+    async def stop_during_backoff():
+        connection_attempted = asyncio.Event()
+
+        async def failing_start_ws():
+            connection_attempted.set()
+            raise websockets.WebSocketException("connection rejected")
+
+        stream._start_ws = failing_start_ws
+        stream._reconnect_delay = lambda _: 60
+
+        run_task = asyncio.create_task(stream._run_forever())
+        await asyncio.wait_for(connection_attempted.wait(), timeout=0.5)
+        await stream.stop_ws()
+        await asyncio.wait_for(run_task, timeout=0.5)
+
+    async def restart_successfully():
+        connection_attempts = 0
+
+        class Socket:
+            async def recv(self):
+                await stream.stop_ws()
+                if stream_type is DataStream:
+                    return msgpack.packb([{"T": "subscription", "trades": ["AAPL"]}])
+                return json.dumps(
+                    {"stream": "listening", "data": {"streams": ["trade_updates"]}}
+                )
+
+            async def close(self):
+                pass
+
+        async def successful_start_ws():
+            nonlocal connection_attempts
+            connection_attempts += 1
+            stream._ws = Socket()
+
+        stream._start_ws = successful_start_ws
+        await asyncio.wait_for(stream._run_forever(), timeout=0.5)
+
+        assert connection_attempts == 1
+
+    asyncio.run(stop_during_backoff())
+    asyncio.run(restart_successfully())

--- a/tests/test_streaming_reconnect_issues.py
+++ b/tests/test_streaming_reconnect_issues.py
@@ -17,10 +17,13 @@ behavior after the fixes:
 
 import asyncio
 import json
+from datetime import datetime, timezone
+from typing import Dict
 
 import msgpack
 import pytest
 import websockets
+from msgpack import Timestamp
 
 from alpaca.data.enums import DataFeed
 from alpaca.data.live.crypto import CryptoDataStream
@@ -28,6 +31,7 @@ from alpaca.data.live.news import NewsDataStream
 from alpaca.data.live.option import OptionDataStream
 from alpaca.data.live.stock import StockDataStream
 from alpaca.data.live.websocket import DataStream
+from alpaca.data.models import News
 from alpaca.trading.stream import TradingStream
 
 # ---------------------------------------------------------------------------
@@ -193,6 +197,81 @@ async def test_news_without_symbols_is_dispatched_to_wildcard_handler():
 
     assert stale is False
     assert received == [{"T": "n", "headline": "global"}]
+
+
+def _unsymbolized_news_frame(created_at: datetime, omit_symbols_key: bool) -> Dict:
+    frame = {
+        "T": "n",
+        "id": 1,
+        "headline": "global",
+        "summary": "",
+        "author": "desk",
+        "created_at": Timestamp.from_datetime(created_at),
+        "updated_at": Timestamp.from_datetime(created_at),
+        "url": "https://example.com",
+        "content": "",
+        "source": "benzinga",
+    }
+    if not omit_symbols_key:
+        # This is the shape the real Alpaca API actually sends for
+        # unsymbolized/global news: the "symbols" key is always present,
+        # just with an empty list. See docs.alpaca.markets streaming-real-time-news.
+        frame["symbols"] = []
+    return frame
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "omit_symbols_key",
+    [
+        pytest.param(False, id="empty_symbols_list"),
+        # Defense-in-depth: the real API always sends the "symbols" key, but
+        # we tolerate a fully missing key too rather than assuming the
+        # documented shape everywhere.
+        pytest.param(True, id="missing_symbols_key"),
+    ],
+)
+async def test_parsed_news_without_symbols_reaches_wildcard_handler(
+    omit_symbols_key: bool,
+):
+    """Default raw_data=False path must parse unsymbolized news, not reconnect."""
+    received = []
+    created_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+    class Socket:
+        def __init__(self):
+            self.recv_calls = 0
+
+        async def recv(self):
+            self.recv_calls += 1
+            if self.recv_calls == 1:
+                return msgpack.packb(
+                    [_unsymbolized_news_frame(created_at, omit_symbols_key)]
+                )
+            await stream.stop_ws()
+            return msgpack.packb([{"T": "subscription", "news": ["*"]}])
+
+        async def close(self):
+            pass
+
+    stream = DataStream(
+        "endpoint", "key-id", "secret-key", raw_data=False, data_timeout=0.05
+    )
+
+    async def handler(msg):
+        received.append(msg)
+
+    stream._handlers["news"]["*"] = handler
+    stream._ws = Socket()
+    stream._running = True
+
+    stale = await asyncio.wait_for(stream._consume(), timeout=1)
+
+    assert stale is False
+    assert len(received) == 1
+    assert isinstance(received[0], News)
+    assert received[0].headline == "global"
+    assert received[0].symbols == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming_reconnect_issues.py
+++ b/tests/test_streaming_reconnect_issues.py
@@ -136,7 +136,6 @@ async def test_slow_handler_does_not_make_active_stream_stale():
         {"T": "heartbeat"},
         {},
         {"T": "t"},
-        {"T": "n"},
     ],
 )
 async def test_continuous_control_frames_do_not_hide_stale_data(control_message):
@@ -158,6 +157,42 @@ async def test_continuous_control_frames_do_not_hide_stale_data(control_message)
     stale = await asyncio.wait_for(stream._consume(), timeout=0.5)
 
     assert stale is True
+
+
+@pytest.mark.asyncio
+async def test_news_without_symbols_is_dispatched_to_wildcard_handler():
+    """News frames may omit symbols; they must still reach the '*' handler."""
+    received = []
+
+    class Socket:
+        def __init__(self):
+            self.recv_calls = 0
+
+        async def recv(self):
+            self.recv_calls += 1
+            if self.recv_calls == 1:
+                return msgpack.packb([{"T": "n", "headline": "global"}])
+            await stream.stop_ws()
+            return msgpack.packb([{"T": "subscription", "news": ["*"]}])
+
+        async def close(self):
+            pass
+
+    stream = DataStream(
+        "endpoint", "key-id", "secret-key", raw_data=True, data_timeout=0.05
+    )
+
+    async def handler(msg):
+        received.append(msg)
+
+    stream._handlers["news"]["*"] = handler
+    stream._ws = Socket()
+    stream._running = True
+
+    stale = await asyncio.wait_for(stream._consume(), timeout=1)
+
+    assert stale is False
+    assert received == [{"T": "n", "headline": "global"}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming_reconnect_issues.py
+++ b/tests/test_streaming_reconnect_issues.py
@@ -3,10 +3,11 @@
 These originally reproduced the buggy behavior; they now assert the corrected
 behavior after the fixes:
 
-* Silent-but-open data socket: ``DataStream`` gained a ``data_timeout`` (default
-  ``60``; pass ``None`` to disable). When set, a connected socket that stops
-  delivering data (but still answers transport pings) now breaks the consume
-  loop and reconnects instead of looping forever with ``_running`` stuck True.
+* Silent-but-open data socket: ``DataStream`` gained an opt-in ``data_timeout``
+  (default ``None``; pass a positive number of seconds to enable). When set, a
+  connected socket that stops delivering data (but still answers transport pings)
+  breaks the consume loop and reconnects instead of looping forever with
+  ``_running`` stuck True.
 
 * Reconnect backoff: both ``DataStream`` and ``TradingStream`` now reconnect with
   exponential backoff + jitter (``_reconnect_delay``) instead of a fixed ~10ms
@@ -378,9 +379,9 @@ async def test_data_stream_surfaces_transport_exception_for_reconnect():
 
 
 def test_data_timeout_defaults_and_is_configurable():
-    """Active streams default to 60s; ``None`` disables; overrides are honored."""
+    """Staleness detection is opt-in (default ``None``); overrides are honored."""
     default = DataStream("endpoint", "key-id", "secret-key")
-    assert default._data_timeout == 60
+    assert default._data_timeout is None
 
     disabled = DataStream("endpoint", "key-id", "secret-key", data_timeout=None)
     assert disabled._data_timeout is None
@@ -388,10 +389,11 @@ def test_data_timeout_defaults_and_is_configurable():
     configured = DataStream("endpoint", "key-id", "secret-key", data_timeout=30)
     assert configured._data_timeout == 30
 
-    assert StockDataStream("key-id", "secret-key")._data_timeout == 60
-    assert CryptoDataStream("key-id", "secret-key")._data_timeout == 60
-    assert OptionDataStream("key-id", "secret-key")._data_timeout == 60
-    # News is sparse by default.
+    # All stream clients default to disabled so quiet subscriptions are not
+    # reconnected; callers opt in per subscription.
+    assert StockDataStream("key-id", "secret-key")._data_timeout is None
+    assert CryptoDataStream("key-id", "secret-key")._data_timeout is None
+    assert OptionDataStream("key-id", "secret-key")._data_timeout is None
     assert NewsDataStream("key-id", "secret-key")._data_timeout is None
 
     subclass_streams = [


### PR DESCRIPTION
Detect connected-but-mute data sockets with a default 60s data_timeout, and back off reconnects with jitter so single-connection streams do not HTTP 429. Close half-open sockets on connect/auth failure before retry.

Fixes #740 