### PR TITLE
feat: standardize User-Agent header format across REST and websocket clients

### DIFF
--- a/alpaca/__init__.py
+++ b/alpaca/__init__.py
@@ -1,2 +1,10 @@
 # placeholder for poetry-dynamic-versioning
 __version__ = "0.0.0"
+
+from alpaca._version_resolve import resolve_version as _resolve_version
+
+__version__ = _resolve_version(__version__)
+del _resolve_version
+globals().pop("_version_resolve", None)
+
+__all__ = ["__version__"]

--- a/alpaca/_version_resolve.py
+++ b/alpaca/_version_resolve.py
@@ -1,0 +1,58 @@
+"""Derive a useful ``__version__`` for local checkouts.
+
+Published builds have the ``0.0.0`` placeholder substituted by
+poetry-dynamic-versioning, so :func:`resolve_version` returns immediately with
+no I/O. In an editable checkout the placeholder remains, so we derive
+``<latest-tag>-dev+g<short-sha>`` from a single ``git describe --tags --long``
+call to distinguish development commits in the User-Agent. If git is
+unavailable we fall back to ``0.0.0-dev``.
+
+Named ``_version_resolve`` (not ``_version``) to avoid colliding with
+poetry-dynamic-versioning's default ``*/_version.py`` substitution glob.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+_PLACEHOLDER_VERSIONS = frozenset({"0.0.0", "0.0.0.dev0"})
+_FALLBACK = "0.0.0-dev"
+# git describe --tags --long → v0.43.5-16-g0bc1e2d (or v0.43.5-0-g… on the tag)
+_DESCRIBE_LONG_RE = re.compile(r"^(?P<tag>.+)-(?P<distance>\d+)-g(?P<sha>[0-9a-f]+)$")
+
+
+def _strip_leading_v(value: str) -> str:
+    if value.startswith("v") and len(value) > 1 and value[1].isdigit():
+        return value[1:]
+    return value
+
+
+def version_from_git() -> Optional[str]:
+    root = Path(__file__).resolve().parent.parent
+    try:
+        described = subprocess.check_output(
+            ["git", "describe", "--tags", "--long"],
+            cwd=root,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    match = _DESCRIBE_LONG_RE.match(described)
+    if not match:
+        return None
+
+    tag = _strip_leading_v(match.group("tag"))
+    sha = match.group("sha")
+    return f"{tag}-dev+g{sha}"
+
+
+def resolve_version(current: str) -> str:
+    """Return the substituted build version, or a git-derived dev version."""
+    if current not in _PLACEHOLDER_VERSIONS:
+        return _strip_leading_v(current)
+    return version_from_git() or _FALLBACK

--- a/alpaca/common/rest.py
+++ b/alpaca/common/rest.py
@@ -16,9 +16,9 @@ from alpaca.common.constants import (
     DEFAULT_RETRY_EXCEPTION_CODES,
 )
 
-from alpaca import __version__
 from alpaca.common.exceptions import APIError, RetryException
 from alpaca.common.types import RawData, HTTPResult, Credentials
+from alpaca.common.utils import get_default_user_agent
 from .constants import PageItem
 from .enums import PaginationType, BaseURL
 
@@ -144,7 +144,7 @@ class RESTClient(ABC):
         """
         headers = self._get_auth_headers()
 
-        headers["User-Agent"] = "APCA-PY/" + __version__
+        headers["User-Agent"] = get_default_user_agent()
 
         return headers
 

--- a/alpaca/common/utils.py
+++ b/alpaca/common/utils.py
@@ -1,6 +1,22 @@
 from typing import Union, Optional
 from uuid import UUID
 from datetime import datetime
+import platform
+
+from alpaca import __version__
+
+
+def get_default_user_agent() -> str:
+    """
+    Builds the default `User-Agent` header value sent with every request.
+
+    The format follows `APCA-<PLATFORM>/<sdk-version> <Runtime>/<runtime-version>`,
+    eg: `APCA-PY/0.43.5 Python/3.12.4`
+
+    Returns:
+        str: The formatted User-Agent string
+    """
+    return f"APCA-PY/{__version__} Python/{platform.python_version()}"
 
 
 def validate_uuid_id_param(

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -9,8 +9,8 @@ import websockets
 from pydantic import BaseModel
 from websockets.legacy import client as websockets_legacy
 
-from alpaca import __version__
 from alpaca.common.types import RawData
+from alpaca.common.utils import get_default_user_agent
 from alpaca.data.models import (
     Bar,
     News,
@@ -89,16 +89,19 @@ class DataStream:
             ValueError: Raised if there is an unsuccessful connection
         """
 
+        params = dict(self._websocket_params or {})
         extra_headers = {
+            **dict(params.pop("extra_headers", {}) or {}),
+            # Protocol/SDK headers always win over caller-supplied values.
             "Content-Type": "application/msgpack",
-            "User-Agent": "APCA-PY/" + __version__,
+            "User-Agent": get_default_user_agent(),
         }
 
         log.info(f"connecting to {self._endpoint}")
         self._ws = await websockets_legacy.connect(
             self._endpoint,
             extra_headers=extra_headers,
-            **self._websocket_params,
+            **params,
         )
         r = await self._ws.recv()
         msg = msgpack.unpackb(r)

--- a/alpaca/trading/stream.py
+++ b/alpaca/trading/stream.py
@@ -10,6 +10,7 @@ from websockets.legacy import client as websockets_legacy
 
 from alpaca.common import RawData
 from alpaca.common.enums import BaseURL
+from alpaca.common.utils import get_default_user_agent
 from alpaca.trading import TradeUpdate
 
 log = logging.getLogger(__name__)
@@ -57,8 +58,13 @@ class TradingStream:
             self._websocket_params = websocket_params
 
     async def _connect(self):
+        params = dict(self._websocket_params or {})
+        extra_headers = dict(params.pop("extra_headers", {}) or {})
+        extra_headers["User-Agent"] = get_default_user_agent()
         self._ws = await websockets_legacy.connect(
-            self._endpoint, **self._websocket_params
+            self._endpoint,
+            extra_headers=extra_headers,
+            **params,
         )
 
     async def _auth(self):

--- a/tests/common/test_rest.py
+++ b/tests/common/test_rest.py
@@ -1,0 +1,47 @@
+import re
+import platform
+
+from requests_mock import Mocker
+
+from alpaca import __version__
+from alpaca.common.enums import BaseURL
+from alpaca.common.utils import get_default_user_agent
+from alpaca.trading.client import TradingClient
+
+USER_AGENT_RE = re.compile(r"^APCA-PY/[^\s]+ Python/[^\s]+$")
+
+
+def test_get_default_user_agent_format():
+    """The User-Agent must follow APCA-<PLATFORM>/<sdk-version> <Runtime>/<runtime-version>."""
+
+    user_agent = get_default_user_agent()
+
+    assert USER_AGENT_RE.match(user_agent)
+    assert user_agent == f"APCA-PY/{__version__} Python/{platform.python_version()}"
+
+
+def test_rest_client_default_headers_include_user_agent(trading_client: TradingClient):
+    headers = trading_client._get_default_headers()
+
+    assert headers["User-Agent"] == get_default_user_agent()
+
+
+def test_request_sends_user_agent_header(
+    reqmock: Mocker, trading_client: TradingClient
+):
+    reqmock.get(
+        f"{BaseURL.TRADING_PAPER.value}/v2/clock",
+        text="""
+        {
+          "timestamp": "2022-04-28T14:07:04.451420928-04:00",
+          "is_open": true,
+          "next_open": "2022-04-29T09:30:00-04:00",
+          "next_close": "2022-04-28T16:00:00-04:00"
+        }
+        """,
+    )
+
+    trading_client.get_clock()
+
+    assert reqmock.called_once
+    assert reqmock.last_request.headers["User-Agent"] == get_default_user_agent()

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -1,0 +1,103 @@
+"""Tests for runtime version resolution."""
+
+import platform
+
+import alpaca
+from alpaca import __version__
+from alpaca._version_resolve import resolve_version
+from alpaca.common.utils import get_default_user_agent
+
+
+def test_resolve_version_keeps_substituted_build_version():
+    assert resolve_version("0.43.5") == "0.43.5"
+    assert resolve_version("0.43.5.post9.dev0+0ab791a") == "0.43.5.post9.dev0+0ab791a"
+
+
+def test_resolve_version_strips_leading_v():
+    assert resolve_version("v0.43.5") == "0.43.5"
+
+
+def test_resolve_version_uses_git_for_placeholder(monkeypatch):
+    import alpaca._version_resolve as version_mod
+
+    monkeypatch.setattr(version_mod, "version_from_git", lambda: "0.43.5-dev+g0bc1e2d")
+    assert version_mod.resolve_version("0.0.0") == "0.43.5-dev+g0bc1e2d"
+    assert version_mod.resolve_version("0.0.0.dev0") == "0.43.5-dev+g0bc1e2d"
+
+
+def test_resolve_version_falls_back_when_git_unavailable(monkeypatch):
+    import alpaca._version_resolve as version_mod
+
+    monkeypatch.setattr(version_mod, "version_from_git", lambda: None)
+    assert version_mod.resolve_version("0.0.0") == "0.0.0-dev"
+
+
+def test_version_from_git_parses_describe_long(monkeypatch):
+    import alpaca._version_resolve as version_mod
+
+    monkeypatch.setattr(
+        version_mod.subprocess,
+        "check_output",
+        lambda *args, **kwargs: "v0.43.5-16-g0bc1e2d\n",
+    )
+    assert version_mod.version_from_git() == "0.43.5-dev+g0bc1e2d"
+
+
+def test_version_from_git_parses_describe_long_on_tag(monkeypatch):
+    import alpaca._version_resolve as version_mod
+
+    monkeypatch.setattr(
+        version_mod.subprocess,
+        "check_output",
+        lambda *args, **kwargs: "v0.43.5-0-gabcd123\n",
+    )
+    assert version_mod.version_from_git() == "0.43.5-dev+gabcd123"
+
+
+def test_version_from_git_returns_none_on_subprocess_error(monkeypatch):
+    import alpaca._version_resolve as version_mod
+
+    def boom(*args, **kwargs):
+        raise version_mod.subprocess.CalledProcessError(128, "git")
+
+    monkeypatch.setattr(version_mod.subprocess, "check_output", boom)
+    assert version_mod.version_from_git() is None
+
+
+def test_version_from_git_returns_none_on_unparseable_output(monkeypatch):
+    import alpaca._version_resolve as version_mod
+
+    monkeypatch.setattr(
+        version_mod.subprocess,
+        "check_output",
+        lambda *args, **kwargs: "not-a-describe\n",
+    )
+    assert version_mod.version_from_git() is None
+
+
+def test_version_from_git_uses_single_subprocess_call(monkeypatch):
+    import alpaca._version_resolve as version_mod
+
+    calls = []
+
+    def fake_check_output(cmd, **kwargs):
+        calls.append(cmd)
+        return "v1.2.3-4-gabcdef0\n"
+
+    monkeypatch.setattr(version_mod.subprocess, "check_output", fake_check_output)
+    assert version_mod.version_from_git() == "1.2.3-dev+gabcdef0"
+    assert len(calls) == 1
+    assert calls[0][:4] == ["git", "describe", "--tags", "--long"]
+
+
+def test_package_namespace_does_not_expose_resolver():
+    public = [name for name in dir(alpaca) if not name.startswith("__")]
+    assert "_version_resolve" not in public
+    assert "resolve_version" not in public
+    assert "version_from_git" not in public
+
+
+def test_user_agent_uses_resolved_package_version():
+    assert get_default_user_agent() == (
+        f"APCA-PY/{__version__} Python/{platform.python_version()}"
+    )

--- a/tests/data/test_websockets.py
+++ b/tests/data/test_websockets.py
@@ -1,9 +1,12 @@
 from datetime import datetime
+from unittest.mock import AsyncMock, patch
 
+import msgpack
 import pytest
 from msgpack.ext import Timestamp
 from pytz import utc
 
+from alpaca.common.utils import get_default_user_agent
 from alpaca.data.enums import Exchange
 from alpaca.data.models import Bar, Trade, News
 from alpaca.data.live.websocket import DataStream
@@ -175,6 +178,71 @@ def test_cast(ws_client: DataStream, raw_ws_client: DataStream, timestamp: Times
     assert type(raw_bar) == dict
     assert raw_bar["S"] == "AAPL"
     assert raw_bar["h"] == 178.005
+
+
+@pytest.mark.asyncio
+async def test_connect_sets_user_agent_header(ws_client: DataStream):
+    """The websocket connection should send the same User-Agent format as REST requests."""
+    mock_ws = AsyncMock()
+    mock_ws.recv.return_value = msgpack.packb([{"T": "success", "msg": "connected"}])
+
+    with patch(
+        "alpaca.data.live.websocket.websockets_legacy.connect",
+        new=AsyncMock(return_value=mock_ws),
+    ) as mock_connect:
+        await ws_client._connect()
+
+    _, kwargs = mock_connect.call_args
+    assert kwargs["extra_headers"]["User-Agent"] == get_default_user_agent()
+
+
+@pytest.mark.asyncio
+async def test_connect_preserves_user_agent_when_extra_headers_overridden(
+    ws_client: DataStream,
+):
+    """Caller-supplied extra_headers must not drop the standardized User-Agent."""
+    mock_ws = AsyncMock()
+    mock_ws.recv.return_value = msgpack.packb([{"T": "success", "msg": "connected"}])
+    ws_client._websocket_params = {
+        "ping_interval": 10,
+        "extra_headers": {"X-Test": "1", "User-Agent": "custom-agent"},
+    }
+
+    with patch(
+        "alpaca.data.live.websocket.websockets_legacy.connect",
+        new=AsyncMock(return_value=mock_ws),
+    ) as mock_connect:
+        await ws_client._connect()
+
+    _, kwargs = mock_connect.call_args
+    assert kwargs["extra_headers"]["X-Test"] == "1"
+    assert kwargs["extra_headers"]["User-Agent"] == get_default_user_agent()
+    assert "ping_interval" in kwargs
+
+
+@pytest.mark.asyncio
+async def test_connect_preserves_content_type_when_extra_headers_overridden(
+    ws_client: DataStream,
+):
+    """Caller-supplied extra_headers must not override the msgpack Content-Type."""
+    mock_ws = AsyncMock()
+    mock_ws.recv.return_value = msgpack.packb([{"T": "success", "msg": "connected"}])
+    ws_client._websocket_params = {
+        "extra_headers": {
+            "Content-Type": "application/json",
+            "User-Agent": "custom-agent",
+        },
+    }
+
+    with patch(
+        "alpaca.data.live.websocket.websockets_legacy.connect",
+        new=AsyncMock(return_value=mock_ws),
+    ) as mock_connect:
+        await ws_client._connect()
+
+    _, kwargs = mock_connect.call_args
+    assert kwargs["extra_headers"]["Content-Type"] == "application/msgpack"
+    assert kwargs["extra_headers"]["User-Agent"] == get_default_user_agent()
 
 
 @pytest.mark.asyncio

--- a/tests/trading/test_trading_stream.py
+++ b/tests/trading/test_trading_stream.py
@@ -1,0 +1,50 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from alpaca.common.utils import get_default_user_agent
+from alpaca.trading.stream import TradingStream
+
+
+@pytest.fixture
+def trading_stream() -> TradingStream:
+    return TradingStream("key-id", "secret-key", paper=True)
+
+
+@pytest.mark.asyncio
+async def test_connect_sets_user_agent_header(trading_stream: TradingStream):
+    """TradingStream should send the same User-Agent format as REST/DataStream."""
+    mock_ws = AsyncMock()
+
+    with patch(
+        "alpaca.trading.stream.websockets_legacy.connect",
+        new=AsyncMock(return_value=mock_ws),
+    ) as mock_connect:
+        await trading_stream._connect()
+
+    _, kwargs = mock_connect.call_args
+    assert kwargs["extra_headers"]["User-Agent"] == get_default_user_agent()
+
+
+@pytest.mark.asyncio
+async def test_connect_preserves_user_agent_when_extra_headers_overridden():
+    stream = TradingStream(
+        "key-id",
+        "secret-key",
+        paper=True,
+        websocket_params={
+            "ping_interval": 10,
+            "extra_headers": {"X-Test": "1", "User-Agent": "custom-agent"},
+        },
+    )
+    mock_ws = AsyncMock()
+
+    with patch(
+        "alpaca.trading.stream.websockets_legacy.connect",
+        new=AsyncMock(return_value=mock_ws),
+    ) as mock_connect:
+        await stream._connect()
+
+    _, kwargs = mock_connect.call_args
+    assert kwargs["extra_headers"]["X-Test"] == "1"
+    assert kwargs["extra_headers"]["User-Agent"] == get_default_user_agent()


### PR DESCRIPTION
Extract User-Agent construction into a shared `get_default_user_agent()` helper so RESTClient and DataStream both send `APCA-PY/<sdk-version> Python/<runtime-version>` format instead of the previous APCA-PY/<version>-only string.