### PR TITLE
fix: BarSet (and other data sets) __contains__ always returns False

### DIFF
--- a/alpaca/data/models/base.py
+++ b/alpaca/data/models/base.py
@@ -74,10 +74,12 @@ class BaseDataSet(BaseModel):
         ``__getitem__`` expects a symbol string, not an index.
 
         Args:
-            symbol (str): The ticker identifier to check for
+            symbol (str): The data key to check for (a ticker for most
+                datasets, but e.g. "news" for NewsSet or an action type
+                like "forward_splits" for the corporate actions set)
 
         Returns:
-            bool: True if data for the given symbol is present
+            bool: True if data for the given key is present
         """
         return symbol in self.data
 

--- a/alpaca/data/models/base.py
+++ b/alpaca/data/models/base.py
@@ -65,6 +65,22 @@ class BaseDataSet(BaseModel):
 
         return self.data[symbol]
 
+    def __contains__(self, symbol: str) -> bool:
+        """Gives dictionary-like membership checks for multi-symbol data.
+
+        Without this, ``symbol in dataset`` falls back to Python's default
+        sequence-based containment check (iterating integer indices via
+        ``__getitem__``), which always returns False here since
+        ``__getitem__`` expects a symbol string, not an index.
+
+        Args:
+            symbol (str): The ticker identifier to check for
+
+        Returns:
+            bool: True if data for the given symbol is present
+        """
+        return symbol in self.data
+
     def dict(self, **kwargs) -> dict:
         """
         Gives dictionary representation of data.

--- a/tests/data/test_historical_stock_data.py
+++ b/tests/data/test_historical_stock_data.py
@@ -76,6 +76,39 @@ def test_get_bars(reqmock, stock_client: StockHistoricalDataClient):
     assert reqmock.called_once
 
 
+def test_barset_contains():
+    """`symbol in barset` must agree with `symbol in barset.data` and `barset[symbol]`.
+
+    Without a __contains__ implementation, `in` falls back to Python's default
+    sequence-based containment check (iterating integer indices via
+    __getitem__), which always returns False here since __getitem__ expects a
+    symbol string, not an index - even though the symbol's data exists.
+    """
+    barset = BarSet(
+        raw_data={
+            "SPY": [
+                {
+                    "t": "2022-02-01T05:00:00Z",
+                    "o": 174,
+                    "h": 174.84,
+                    "l": 172.31,
+                    "c": 174.61,
+                    "v": 85998033,
+                    "n": 732412,
+                    "vw": 173.703516,
+                }
+            ]
+        }
+    )
+
+    assert "SPY" in barset
+    assert "SPY" in barset.data
+    assert len(barset["SPY"]) == 1
+
+    assert "AAPL" not in barset
+    assert "AAPL" not in barset.data
+
+
 def test_get_bars_desc(reqmock, stock_client: StockHistoricalDataClient):
     symbol = "TSLA"
     timeframe = TimeFrame.Day


### PR DESCRIPTION
## Summary

Fixes #641.

`'SPY' in bars` returns `False` even when `bars['SPY']` has data, because `BaseDataSet` only defines `__getitem__`, not `__contains__`. Without `__contains__`, Python's `in` operator falls back to the legacy sequence protocol (iterating integer indices via `__getitem__` and catching `IndexError`), which doesn't match this class's dict-keyed usage (`__getitem__` expects a symbol string, not an index) and so always returns `False`, regardless of what's actually in `.data`.

## Fix

Added `__contains__` to `BaseDataSet` itself, not just `BarSet` - `BarSet`, `QuoteSet`, `TradeSet`, `NewsSet`, and the corporate actions set all inherit from `BaseDataSet` and share this exact same bug, so fixing it at the shared base class fixes all of them at once rather than just the one reported symptom.

## Testing

Added `test_barset_contains`, constructing a `BarSet` directly (no network mocking needed) and checking `'SPY' in barset` agrees with `'SPY' in barset.data` and `barset['SPY']`, for both a present and an absent symbol. Ran the full `tests/data/` suite (57 tests, all pass) and `black --check`, both clean.