### PR TITLE
feat: add opt-in live paper/sandbox probe tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Trading / Market Data (paper keys recommended)
+APCA_API_KEY_ID=
+APCA_API_SECRET_KEY=
+
+# Broker (sandbox keys recommended)
+ALPACA_BROKER_API_KEY=
+ALPACA_BROKER_API_SECRET=
+
+# Optional environment overrides (defaults: trading paper=true, broker sandbox=true)
+# ALPACA_TRADING_PAPER=true
+# ALPACA_BROKER_SANDBOX=true
+
+# Optional alternate gate instead of pytest --run-live
+# ALPACA_RUN_LIVE=1
+
+# Optional streaming probe knobs
+# ALPACA_LIVE_STREAM_TIMEOUT=30
+# ALPACA_LIVE_OPTION_SYMBOL=SPY240119C00500000

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Live probe proof artifacts
+artifacts/
+
 # Distribution / packaging
 .Python
 build/

--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -1,0 +1,109 @@
+# Live probe (paper/sandbox smoke tests)
+
+Opt-in pytest suite that hits real Alpaca APIs to prove a method works after an SDK change.
+
+Default `poetry run pytest` / CI **skips** these tests. Artifacts are written under `artifacts/live_probe/` (gitignored).
+
+## Quick start
+
+1. Copy `.env.example` to `.env` and fill credentials (or export the same env vars).
+2. Prove one method you changed:
+
+```bash
+poetry run pytest tests/live -k get_account --run-live
+```
+
+Redacted **request + response** are printed to the console automatically (no `-s` needed). JSON artifacts are also written under `artifacts/live_probe/<timestamp>/`.
+
+Use `--live-quiet` to suppress console dumps.
+
+## Common commands
+
+```bash
+# list live tests
+poetry run pytest tests/live --collect-only -q
+
+# trading paper smokes
+poetry run pytest tests/live/test_trading_rest.py --run-live
+
+# data smokes
+poetry run pytest tests/live/test_data_rest.py --run-live
+
+# broker sandbox smokes
+poetry run pytest tests/live/test_broker_rest.py --run-live
+
+# streaming smokes (crypto quotes are reliable off-hours)
+poetry run pytest tests/live/test_streaming.py --run-live
+poetry run pytest tests/live -k crypto_data_stream --run-live
+
+# alternate gate
+ALPACA_RUN_LIVE=1 poetry run pytest tests/live -k get_clock
+```
+
+## Credentials
+
+| Use | Variables |
+|---|---|
+| Trading + Market Data | `APCA_API_KEY_ID`, `APCA_API_SECRET_KEY` |
+| Broker | `ALPACA_BROKER_API_KEY`, `ALPACA_BROKER_API_SECRET` |
+
+Env vars override values loaded from `.env`.
+
+## Environments
+
+| Area | Default | Override |
+|---|---|---|
+| Trading | paper | `ALPACA_TRADING_PAPER=false` for live trading API |
+| Broker | sandbox | `ALPACA_BROKER_SANDBOX=false` for production broker API |
+| Stream wait | 30s | `ALPACA_LIVE_STREAM_TIMEOUT` (seconds) |
+| Option symbol | connect-only | `ALPACA_LIVE_OPTION_SYMBOL` (OCC) to require a quote |
+
+## Safety
+
+- Starter tests are **read-only**.
+- Mutative tests (when added) must use `@pytest.mark.live_mutative` and require `--allow-mutative` in addition to `--run-live`.
+- Missing credentials with `--run-live` fail fast (`pytest.UsageError`).
+
+## Adding coverage
+
+Add a normal pytest function in `tests/live/`, mark it `@pytest.mark.live`, and use `live_call` so failures are still recorded:
+
+```python
+@pytest.mark.live
+def test_get_account(trading_client_live, live_call):
+    account = live_call("get_account", trading_client_live.get_account)
+    assert account is not None
+```
+
+Name the test after the method so `-k` targeting stays easy (`test_get_orders` → `-k get_orders`).
+
+## Artifact shape
+
+```json
+{
+  "id": "tests/live/test_trading_rest.py::test_get_account",
+  "method": "get_account",
+  "status_code": 200,
+  "passed": true,
+  "request": {
+    "method": "GET",
+    "url": "https://paper-api.alpaca.markets/v2/account",
+    "headers": {"APCA-API-KEY-ID": "***REDACTED***"},
+    "body": null
+  },
+  "response_body": {},
+  "error": null
+}
+```
+
+## Streaming probes
+
+`tests/live/test_streaming.py` covers `TradingStream`, `StockDataStream`, `CryptoDataStream`, `OptionDataStream`, and `NewsDataStream`.
+
+- Stock / crypto quotes **require ≥1 message** within the timeout.
+- Trading + news prove **connect + auth + subscribe** (updates/news can be idle).
+- Artifacts use `"method": "WS"` with captured `User-Agent` headers and a small message sample.
+
+## Optional CI
+
+Default PR CI should keep skipping these tests. A secrets-gated nightly or `workflow_dispatch` job can run the same suite later (`pytest tests/live --run-live`) without changing the test layout.

--- a/tests/live/__init__.py
+++ b/tests/live/__init__.py
@@ -1,0 +1,1 @@
+# Live API smoke tests (opt-in via --run-live).

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -294,9 +294,7 @@ def record_live(
             status_code if status_code is not None else http_capture.get("status_code")
         )
         captured_request = (
-            request_data
-            if request_data is not None
-            else http_capture.get("request")
+            request_data if request_data is not None else http_capture.get("request")
         )
         path = write_artifact(
             live_run_dir,

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -19,6 +19,7 @@ from tests.live.recording import (
     attach_http_capture,
     format_exchange_report,
     invoke_and_record,
+    reconcile_results_with_test_outcome,
     write_artifact,
     write_summary,
 )
@@ -112,6 +113,14 @@ def pytest_collection_modifyitems(
         elif "live" in markers:
             if not run_live:
                 item.add_marker(skip_live)
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]):
+    """Stash per-phase reports so fixtures can reconcile live artifact outcomes."""
+    outcome = yield
+    rep = outcome.get_result()
+    setattr(item, f"rep_{rep.when}", rep)
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
@@ -257,7 +266,12 @@ def record_live(
     pytestconfig: pytest.Config,
     capsys: pytest.CaptureFixture[str],
 ):
-    """Record a proof artifact and print redacted request/response to the console."""
+    """Record a proof artifact and print redacted request/response to the console.
+
+    Success may be recorded before post-call asserts; on teardown, provisional
+    ``passed=true`` entries are flipped if the pytest case failed.
+    """
+    recorded_for_test: List[Dict[str, Any]] = []
 
     def _record(
         method: str,
@@ -307,17 +321,29 @@ def record_live(
             with capsys.disabled():
                 print(report, flush=True)
         results: List[Dict[str, Any]] = pytestconfig._live_results  # type: ignore[attr-defined]
-        results.append(
-            {
-                "id": request.node.nodeid,
-                "method": method,
-                "passed": passed,
-                "error": error,
-                "artifact": str(path),
-            }
-        )
+        entry = {
+            "id": request.node.nodeid,
+            "method": method,
+            "passed": passed,
+            "error": error,
+            "artifact": str(path),
+        }
+        results.append(entry)
+        recorded_for_test.append(entry)
         return path
 
+    def _finalize() -> None:
+        rep = getattr(request.node, "rep_call", None)
+        if rep is None:
+            return
+        failure_error = str(rep.longrepr) if rep.failed and rep.longrepr else None
+        reconcile_results_with_test_outcome(
+            recorded_for_test,
+            test_failed=bool(rep.failed),
+            error=failure_error,
+        )
+
+    request.addfinalizer(_finalize)
     return _record
 
 

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -1,0 +1,397 @@
+"""Fixtures and gates for opt-in live Alpaca API smoke tests."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import pytest
+
+from alpaca.broker.client import BrokerClient
+from alpaca.data.historical import StockHistoricalDataClient
+from alpaca.data.historical.crypto import CryptoHistoricalDataClient
+from alpaca.data.historical.news import NewsClient
+from alpaca.trading.client import TradingClient
+
+from tests.live.recording import (
+    attach_http_capture,
+    format_exchange_report,
+    invoke_and_record,
+    write_artifact,
+    write_summary,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUT_DIR = REPO_ROOT / "artifacts" / "live_probe"
+
+
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _load_dotenv(path: Path) -> None:
+    """Load KEY=VALUE pairs from .env without overriding existing env vars."""
+    if not path.is_file():
+        return
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip("'").strip('"')
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("live")
+    group.addoption(
+        "--run-live",
+        action="store_true",
+        default=False,
+        help="Run @pytest.mark.live tests against real Alpaca APIs",
+    )
+    group.addoption(
+        "--allow-mutative",
+        action="store_true",
+        default=False,
+        help="Allow @pytest.mark.live_mutative tests (requires --run-live)",
+    )
+    group.addoption(
+        "--live-out-dir",
+        action="store",
+        default=None,
+        help="Directory for live proof artifacts (default: artifacts/live_probe)",
+    )
+    group.addoption(
+        "--live-quiet",
+        action="store_true",
+        default=False,
+        help="Do not print redacted request/response to the console during live runs",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers", "live: live API smoke tests (requires --run-live)"
+    )
+    config.addinivalue_line(
+        "markers",
+        "live_mutative: mutative live API tests (requires --run-live --allow-mutative)",
+    )
+    if _run_live_enabled(config):
+        _load_dotenv(REPO_ROOT / ".env")
+
+
+def _run_live_enabled(config: pytest.Config) -> bool:
+    return bool(config.getoption("--run-live")) or _env_flag("ALPACA_RUN_LIVE")
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: List[pytest.Item]
+) -> None:
+    run_live = _run_live_enabled(config)
+    allow_mutative = bool(config.getoption("--allow-mutative"))
+    skip_live = pytest.mark.skip(
+        reason="live tests require --run-live or ALPACA_RUN_LIVE=1"
+    )
+    skip_mutative = pytest.mark.skip(
+        reason="mutative live tests require --allow-mutative"
+    )
+
+    for item in items:
+        markers = {m.name for m in item.iter_markers()}
+        if "live_mutative" in markers:
+            if not run_live:
+                item.add_marker(skip_live)
+            elif not allow_mutative:
+                item.add_marker(skip_mutative)
+        elif "live" in markers:
+            if not run_live:
+                item.add_marker(skip_live)
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    session.config._live_results = []  # type: ignore[attr-defined]
+    session.config._live_run_dir = None  # type: ignore[attr-defined]
+    if not _run_live_enabled(session.config):
+        return
+    out = session.config.getoption("--live-out-dir")
+    root = Path(out) if out else DEFAULT_OUT_DIR
+    run_dir = root / datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    session.config._live_run_dir = run_dir  # type: ignore[attr-defined]
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    run_dir = getattr(session.config, "_live_run_dir", None)
+    results = getattr(session.config, "_live_results", None)
+    if run_dir is not None and results is not None:
+        write_summary(Path(run_dir), list(results))
+
+
+def _require_pair(
+    key_names: Tuple[str, ...], secret_names: Tuple[str, ...]
+) -> Tuple[str, str]:
+    key = next((os.environ[n] for n in key_names if os.environ.get(n)), None)
+    secret = next((os.environ[n] for n in secret_names if os.environ.get(n)), None)
+    if not key or not secret:
+        raise pytest.UsageError(
+            "Live credentials missing. Set "
+            f"{key_names[0]} and {secret_names[0]} "
+            "(or load them via a gitignored .env). "
+            "See tests/live/README.md."
+        )
+    return key, secret
+
+
+@pytest.fixture(scope="session")
+def live_run_dir(pytestconfig: pytest.Config) -> Path:
+    run_dir = getattr(pytestconfig, "_live_run_dir", None)
+    if run_dir is None:
+        pytest.skip("live run directory only available with --run-live")
+    return Path(run_dir)
+
+
+@pytest.fixture
+def http_capture() -> Dict[str, Any]:
+    return {"status_code": None, "body": None, "request": None}
+
+
+@pytest.fixture(scope="session")
+def trading_api_credentials() -> Tuple[str, str]:
+    return _require_pair(
+        ("APCA_API_KEY_ID", "ALPACA_API_KEY_ID"),
+        ("APCA_API_SECRET_KEY", "ALPACA_API_SECRET_KEY"),
+    )
+
+
+@pytest.fixture(scope="session")
+def broker_api_credentials() -> Tuple[str, str]:
+    return _require_pair(
+        ("ALPACA_BROKER_API_KEY", "APCA_BROKER_API_KEY"),
+        ("ALPACA_BROKER_API_SECRET", "APCA_BROKER_SECRET_KEY"),
+    )
+
+
+@pytest.fixture(scope="session")
+def trading_paper() -> bool:
+    # Default paper=True; set ALPACA_TRADING_PAPER=false for live trading API.
+    if "ALPACA_TRADING_PAPER" not in os.environ:
+        return True
+    return _env_flag("ALPACA_TRADING_PAPER")
+
+
+@pytest.fixture(scope="session")
+def broker_sandbox() -> bool:
+    if "ALPACA_BROKER_SANDBOX" not in os.environ:
+        return True
+    return _env_flag("ALPACA_BROKER_SANDBOX")
+
+
+@pytest.fixture
+def trading_client_live(
+    trading_api_credentials: Tuple[str, str],
+    trading_paper: bool,
+    http_capture: Dict[str, Any],
+) -> TradingClient:
+    key, secret = trading_api_credentials
+    client = TradingClient(api_key=key, secret_key=secret, paper=trading_paper)
+    attach_http_capture(client._session, http_capture)
+    return client
+
+
+@pytest.fixture
+def stock_client_live(
+    trading_api_credentials: Tuple[str, str],
+    http_capture: Dict[str, Any],
+) -> StockHistoricalDataClient:
+    key, secret = trading_api_credentials
+    client = StockHistoricalDataClient(api_key=key, secret_key=secret)
+    attach_http_capture(client._session, http_capture)
+    return client
+
+
+@pytest.fixture
+def crypto_client_live(
+    trading_api_credentials: Tuple[str, str],
+    http_capture: Dict[str, Any],
+) -> CryptoHistoricalDataClient:
+    key, secret = trading_api_credentials
+    client = CryptoHistoricalDataClient(api_key=key, secret_key=secret)
+    attach_http_capture(client._session, http_capture)
+    return client
+
+
+@pytest.fixture
+def news_client_live(
+    trading_api_credentials: Tuple[str, str],
+    http_capture: Dict[str, Any],
+) -> NewsClient:
+    key, secret = trading_api_credentials
+    client = NewsClient(api_key=key, secret_key=secret)
+    attach_http_capture(client._session, http_capture)
+    return client
+
+
+@pytest.fixture
+def broker_client_live(
+    broker_api_credentials: Tuple[str, str],
+    broker_sandbox: bool,
+    http_capture: Dict[str, Any],
+) -> BrokerClient:
+    key, secret = broker_api_credentials
+    client = BrokerClient(api_key=key, secret_key=secret, sandbox=broker_sandbox)
+    attach_http_capture(client._session, http_capture)
+    return client
+
+
+@pytest.fixture
+def record_live(
+    request: pytest.FixtureRequest,
+    live_run_dir: Path,
+    http_capture: Dict[str, Any],
+    pytestconfig: pytest.Config,
+    capsys: pytest.CaptureFixture[str],
+):
+    """Record a proof artifact and print redacted request/response to the console."""
+
+    def _record(
+        method: str,
+        response: Any = None,
+        *,
+        passed: bool = True,
+        error: Optional[str] = None,
+        status_code: Optional[int] = None,
+        response_body: Any = None,
+        request_data: Optional[Dict[str, Any]] = None,
+    ) -> Path:
+        # Prefer explicit response/response_body so tests can truncate large payloads.
+        if response_body is not None:
+            body = response_body
+        elif response is not None:
+            body = response
+        else:
+            body = http_capture.get("body")
+        code = (
+            status_code if status_code is not None else http_capture.get("status_code")
+        )
+        captured_request = (
+            request_data
+            if request_data is not None
+            else http_capture.get("request")
+        )
+        path = write_artifact(
+            live_run_dir,
+            test_id=request.node.nodeid,
+            method=method,
+            passed=passed,
+            status_code=code,
+            response_body=body,
+            request=captured_request,
+            error=error,
+        )
+        if not pytestconfig.getoption("--live-quiet"):
+            report = format_exchange_report(
+                method=method,
+                request=captured_request,
+                status_code=code,
+                response_body=body,
+                error=error,
+                passed=passed,
+            )
+            # Bypass pytest output capture so evidence shows without needing -s.
+            with capsys.disabled():
+                print(report, flush=True)
+        results: List[Dict[str, Any]] = pytestconfig._live_results  # type: ignore[attr-defined]
+        results.append(
+            {
+                "id": request.node.nodeid,
+                "method": method,
+                "passed": passed,
+                "error": error,
+                "artifact": str(path),
+            }
+        )
+        return path
+
+    return _record
+
+
+@pytest.fixture
+def live_call(record_live):
+    """Invoke an SDK method and always record evidence (including failures)."""
+
+    def _call(
+        method: str,
+        fn: Callable[..., Any],
+        *args: Any,
+        response_transform: Optional[Callable[[Any], Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        return invoke_and_record(
+            method,
+            fn,
+            record_live,
+            *args,
+            response_transform=response_transform,
+            **kwargs,
+        )
+
+    return _call
+
+
+@pytest.fixture
+def live_stream_call(record_live):
+    """Run a short stream probe and always record WS request/response evidence."""
+
+    from tests.live.streaming import StreamProbeResult, probe_stream
+
+    def _call(
+        method: str,
+        stream: Any,
+        *,
+        subscribe: Callable[[Any, Callable], None],
+        connect_path: str,
+        timeout: Optional[float] = None,
+        min_messages: int = 1,
+        require_message: bool = True,
+    ) -> StreamProbeResult:
+        try:
+            result = probe_stream(
+                stream,
+                subscribe=subscribe,
+                connect_path=connect_path,
+                timeout=timeout,
+                min_messages=min_messages,
+                require_message=require_message,
+            )
+        except Exception as exc:
+            record_live(
+                method,
+                passed=False,
+                error=f"{type(exc).__name__}: {exc}",
+                status_code=None,
+            )
+            raise
+
+        passed = result.error is None and result.connected
+        if require_message:
+            passed = passed and len(result.messages) >= min_messages
+
+        record_live(
+            method,
+            passed=passed,
+            error=result.error,
+            status_code=None,
+            request_data=result.as_request(),
+            response_body=result.as_response_body(),
+        )
+        if not passed:
+            raise AssertionError(result.error or "stream probe failed")
+        return result
+
+    return _call

--- a/tests/live/recording.py
+++ b/tests/live/recording.py
@@ -1,0 +1,240 @@
+"""Artifact recording helpers for live smoke tests."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set
+from uuid import UUID
+
+from pydantic import BaseModel
+
+_SECRET_KEYS = {
+    "apca-api-key-id",
+    "apca-api-secret-key",
+    "authorization",
+    "api_key",
+    "secret_key",
+    "oauth_token",
+    "password",
+}
+
+# Header-only: "token" is too broad for response bodies.
+_SECRET_HEADER_KEYS = _SECRET_KEYS | {"token"}
+
+_SECRET_PATTERN = re.compile(
+    r"(?i)(APCA-API-(?:KEY-ID|SECRET-KEY)|Bearer|Basic)\s+[^\s\"']+"
+)
+
+
+def serialize_response(obj: Any) -> Any:
+    """Best-effort JSON-serializable form of an SDK return value."""
+    if obj is None:
+        return None
+    if isinstance(obj, BaseModel):
+        return obj.model_dump(mode="json")
+    if isinstance(obj, dict):
+        return {str(k): serialize_response(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [serialize_response(v) for v in obj]
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, UUID):
+        return str(obj)
+    if isinstance(obj, Decimal):
+        return str(obj)
+    if isinstance(obj, (str, int, float, bool)):
+        return obj
+    if hasattr(obj, "model_dump"):
+        try:
+            return obj.model_dump(mode="json")
+        except TypeError:
+            return obj.model_dump()
+    if hasattr(obj, "__dict__"):
+        return serialize_response(
+            {k: v for k, v in vars(obj).items() if not k.startswith("_")}
+        )
+    return str(obj)
+
+
+def redact(value: Any, *, secret_keys: Optional[Set[str]] = None) -> Any:
+    """Recursively redact secret-looking keys and auth header values."""
+    keys = secret_keys if secret_keys is not None else _SECRET_KEYS
+    if isinstance(value, dict):
+        out: Dict[str, Any] = {}
+        for k, v in value.items():
+            if str(k).lower() in keys:
+                out[str(k)] = "***REDACTED***"
+            else:
+                out[str(k)] = redact(v, secret_keys=keys)
+        return out
+    if isinstance(value, list):
+        return [redact(v, secret_keys=keys) for v in value]
+    if isinstance(value, str):
+        return _SECRET_PATTERN.sub(r"\1 ***REDACTED***", value)
+    return value
+
+
+def redact_request(request: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Redact a captured HTTP request; apply header-only secret key names."""
+    if request is None:
+        return None
+    serialized = serialize_response(request)
+    if not isinstance(serialized, dict):
+        return redact(serialized)
+    out = dict(serialized)
+    if "headers" in out:
+        out["headers"] = redact(out["headers"], secret_keys=_SECRET_HEADER_KEYS)
+    if "body" in out:
+        out["body"] = redact(out["body"])
+    return out
+
+
+def _decode_request_body(body: Any) -> Any:
+    if body is None:
+        return None
+    if isinstance(body, bytes):
+        try:
+            text = body.decode("utf-8")
+        except UnicodeDecodeError:
+            return f"<binary {len(body)} bytes>"
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return text
+    if isinstance(body, str):
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return body
+    return body
+
+
+def attach_http_capture(session: Any, capture: Dict[str, Any]) -> None:
+    """Record the last HTTP request/response seen on a requests Session."""
+
+    def _hook(response: Any, *args: Any, **kwargs: Any) -> Any:
+        req = response.request
+        capture["request"] = {
+            "method": getattr(req, "method", None),
+            "url": getattr(req, "url", None),
+            "headers": dict(getattr(req, "headers", {}) or {}),
+            "body": _decode_request_body(getattr(req, "body", None)),
+        }
+        capture["status_code"] = response.status_code
+        try:
+            capture["body"] = response.json()
+        except ValueError:
+            capture["body"] = response.text
+        return response
+
+    session.hooks.setdefault("response", []).append(_hook)
+
+
+def format_exchange_report(
+    *,
+    method: str,
+    request: Optional[Dict[str, Any]] = None,
+    status_code: Optional[int] = None,
+    response_body: Any = None,
+    error: Optional[str] = None,
+    passed: bool = True,
+) -> str:
+    """Human-readable redacted request/response block for console evidence."""
+    lines = [
+        "",
+        "=" * 72,
+        f"LIVE PROBE  method={method}  passed={passed}",
+        "-" * 72,
+        "REQUEST",
+    ]
+    if request:
+        safe_req = redact_request(request) or {}
+        lines.append(f"  {safe_req.get('method')} {safe_req.get('url')}")
+        headers = safe_req.get("headers") or {}
+        if headers:
+            lines.append("  headers:")
+            for key, value in headers.items():
+                lines.append(f"    {key}: {value}")
+        body = safe_req.get("body")
+        if body is not None:
+            lines.append("  body:")
+            body_json = json.dumps(body, indent=2, default=str)
+            lines.extend(f"    {line}" for line in body_json.splitlines())
+    else:
+        lines.append("  <not captured>")
+
+    lines.extend(["-" * 72, "RESPONSE", f"  status_code: {status_code}"])
+    if error:
+        lines.append(f"  error: {error}")
+    safe_body = redact(serialize_response(response_body))
+    if safe_body is not None:
+        body_json = json.dumps(safe_body, indent=2, default=str)
+        lines.append("  body:")
+        lines.extend(f"    {line}" for line in body_json.splitlines())
+    else:
+        lines.append("  body: null")
+    lines.extend(["=" * 72, ""])
+    return "\n".join(lines)
+
+
+def write_artifact(
+    run_dir: Path,
+    *,
+    test_id: str,
+    method: str,
+    passed: bool,
+    status_code: Optional[int] = None,
+    response_body: Any = None,
+    request: Optional[Dict[str, Any]] = None,
+    error: Optional[str] = None,
+) -> Path:
+    """Write one minimal per-test artifact JSON file."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = re.sub(r"[^\w.\-]+", "_", test_id)
+    path = run_dir / f"{safe_name}.json"
+    payload = {
+        "id": test_id,
+        "method": method,
+        "status_code": status_code,
+        "passed": passed,
+        "request": redact_request(request),
+        "response_body": redact(serialize_response(response_body)),
+        "error": error,
+    }
+    path.write_text(json.dumps(payload, indent=2, default=str) + "\n", encoding="utf-8")
+    return path
+
+
+def write_summary(run_dir: Path, results: List[Dict[str, Any]]) -> Path:
+    """Write summary.json for a live run."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = run_dir / "summary.json"
+    path.write_text(json.dumps(results, indent=2, default=str) + "\n", encoding="utf-8")
+    return path
+
+
+def invoke_and_record(
+    method: str,
+    fn: Callable[..., Any],
+    record: Callable[..., Any],
+    *args: Any,
+    response_transform: Optional[Callable[[Any], Any]] = None,
+    **kwargs: Any,
+) -> Any:
+    """Invoke an SDK method and always record evidence (including failures)."""
+    try:
+        result = fn(*args, **kwargs)
+    except Exception as exc:
+        record(
+            method,
+            passed=False,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        raise
+    to_record = response_transform(result) if response_transform else result
+    record(method, to_record)
+    return result

--- a/tests/live/recording.py
+++ b/tests/live/recording.py
@@ -217,6 +217,43 @@ def write_summary(run_dir: Path, results: List[Dict[str, Any]]) -> Path:
     return path
 
 
+def update_artifact_outcome(
+    path: Path,
+    *,
+    passed: bool,
+    error: Optional[str] = None,
+) -> None:
+    """Update passed/error on an existing per-test artifact file."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["passed"] = passed
+    payload["error"] = error
+    path.write_text(json.dumps(payload, indent=2, default=str) + "\n", encoding="utf-8")
+
+
+def reconcile_results_with_test_outcome(
+    results: List[Dict[str, Any]],
+    *,
+    test_failed: bool,
+    error: Optional[str],
+) -> None:
+    """Flip provisional passed=true entries when the pytest case failed.
+
+    ``invoke_and_record`` records success as soon as the SDK call returns
+    without raising. Live tests often validate the value afterward; if that
+    assert fails, artifacts/summary must not keep ``passed=true``.
+    """
+    if not test_failed:
+        return
+    for entry in results:
+        if not entry.get("passed"):
+            continue
+        entry["passed"] = False
+        entry["error"] = error
+        artifact = entry.get("artifact")
+        if artifact:
+            update_artifact_outcome(Path(artifact), passed=False, error=error)
+
+
 def invoke_and_record(
     method: str,
     fn: Callable[..., Any],
@@ -225,7 +262,13 @@ def invoke_and_record(
     response_transform: Optional[Callable[[Any], Any]] = None,
     **kwargs: Any,
 ) -> Any:
-    """Invoke an SDK method and always record evidence (including failures)."""
+    """Invoke an SDK method and always record evidence (including failures).
+
+    On a non-raising return, records ``passed=True`` immediately. Callers that
+    validate the result afterward (e.g. pytest asserts) must reconcile that
+    provisional outcome with the final test result — the ``record_live``
+    fixture does this via :func:`reconcile_results_with_test_outcome`.
+    """
     try:
         result = fn(*args, **kwargs)
     except Exception as exc:

--- a/tests/live/streaming.py
+++ b/tests/live/streaming.py
@@ -1,0 +1,155 @@
+"""Helpers for opt-in live WebSocket stream smoke probes."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+from unittest.mock import patch
+
+from websockets.legacy import client as websockets_legacy
+
+from tests.live.recording import serialize_response
+
+SubscribeFn = Callable[[Any, Callable], None]
+
+
+def stream_timeout_seconds(default: float = 30.0) -> float:
+    raw = os.getenv("ALPACA_LIVE_STREAM_TIMEOUT", "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+@dataclass
+class StreamProbeResult:
+    """Outcome of a short live stream connect/subscribe/receive cycle."""
+
+    url: Optional[str] = None
+    headers: Dict[str, Any] = field(default_factory=dict)
+    connected: bool = False
+    messages: List[Any] = field(default_factory=list)
+    error: Optional[str] = None
+
+    def as_request(self) -> Dict[str, Any]:
+        return {
+            "method": "WS",
+            "url": self.url,
+            "headers": dict(self.headers),
+            "body": None,
+        }
+
+    def as_response_body(self, *, max_messages: int = 3) -> Dict[str, Any]:
+        samples = [serialize_response(m) for m in self.messages[:max_messages]]
+        return {
+            "connected": self.connected,
+            "message_count": len(self.messages),
+            "messages": samples,
+        }
+
+
+def probe_stream(
+    stream: Any,
+    *,
+    subscribe: SubscribeFn,
+    connect_path: str,
+    timeout: Optional[float] = None,
+    min_messages: int = 1,
+    require_message: bool = True,
+) -> StreamProbeResult:
+    """Connect a stream briefly, optionally wait for messages, then disconnect.
+
+    Patches ``websockets_legacy.connect`` at ``connect_path`` so the live
+    User-Agent / URL are captured while still performing a real handshake.
+    """
+    timeout = stream_timeout_seconds() if timeout is None else timeout
+    result = StreamProbeResult()
+    real_connect = websockets_legacy.connect
+    got_enough = threading.Event()
+    stop_lock = threading.Lock()
+    stopped = False
+
+    async def capturing_connect(uri: Any, *args: Any, **kwargs: Any) -> Any:
+        # str(Enum) can print "BaseURL.X"; prefer the URL value when present.
+        result.url = getattr(uri, "value", None) or str(uri)
+        result.headers = dict(kwargs.get("extra_headers") or {})
+        ws = await real_connect(uri, *args, **kwargs)
+        result.connected = True
+        return ws
+
+    async def handler(data: Any) -> None:
+        result.messages.append(data)
+        if len(result.messages) >= min_messages:
+            got_enough.set()
+            await _safe_stop_ws(stream)
+
+    def stop_stream() -> None:
+        nonlocal stopped
+        with stop_lock:
+            if stopped:
+                return
+            stopped = True
+        try:
+            if getattr(stream, "_loop", None) is not None:
+                stream.stop()
+        except Exception as exc:  # noqa: BLE001 — probe must always unwind
+            if result.error is None:
+                result.error = f"{type(exc).__name__}: {exc}"
+
+    def runner() -> None:
+        try:
+            with patch(connect_path, new=capturing_connect):
+                stream.run()
+        except Exception as exc:  # noqa: BLE001
+            result.error = f"{type(exc).__name__}: {exc}"
+        finally:
+            got_enough.set()
+
+    subscribe(stream, handler)
+    thread = threading.Thread(target=runner, name="live-stream-probe", daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + timeout
+    # Wait until websocket is up (auth completed → _running) or timeout.
+    while time.monotonic() < deadline and not result.error:
+        if result.connected and getattr(stream, "_running", False):
+            break
+        if got_enough.is_set() and result.messages:
+            break
+        time.sleep(0.05)
+
+    if require_message:
+        remaining = max(0.0, deadline - time.monotonic())
+        got_enough.wait(timeout=remaining)
+    else:
+        # Brief soak so auth + subscribe have time to complete.
+        soak = min(2.0, max(0.0, deadline - time.monotonic()))
+        if soak:
+            time.sleep(soak)
+
+    stop_stream()
+    thread.join(timeout=10.0)
+
+    if thread.is_alive():
+        result.error = result.error or "stream thread did not exit after stop"
+    elif require_message and len(result.messages) < min_messages and not result.error:
+        result.error = (
+            f"expected at least {min_messages} message(s) within {timeout}s, "
+            f"got {len(result.messages)}"
+        )
+    elif not result.connected and not result.error:
+        result.error = "websocket did not connect before timeout"
+
+    return result
+
+
+async def _safe_stop_ws(stream: Any) -> None:
+    stop_ws = getattr(stream, "stop_ws", None)
+    if stop_ws is None:
+        return
+    await stop_ws()

--- a/tests/live/test_broker_rest.py
+++ b/tests/live/test_broker_rest.py
@@ -1,0 +1,29 @@
+"""Read-only live BrokerClient smoke tests (sandbox by default)."""
+
+import pytest
+
+
+@pytest.mark.live
+def test_get_clock(broker_client_live, live_call):
+    clock = live_call("get_clock", broker_client_live.get_clock)
+    assert clock is not None
+
+
+@pytest.mark.live
+def test_get_calendar(broker_client_live, live_call):
+    calendar = live_call(
+        "get_calendar",
+        broker_client_live.get_calendar,
+        response_transform=lambda c: c[:5] if isinstance(c, list) else c,
+    )
+    assert calendar is not None
+
+
+@pytest.mark.live
+def test_list_accounts(broker_client_live, live_call):
+    accounts = live_call(
+        "list_accounts",
+        broker_client_live.list_accounts,
+        response_transform=lambda a: a[:5] if isinstance(a, list) else a,
+    )
+    assert accounts is not None

--- a/tests/live/test_data_rest.py
+++ b/tests/live/test_data_rest.py
@@ -1,0 +1,61 @@
+"""Read-only live market data smoke tests."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from alpaca.data.requests import (
+    CryptoLatestQuoteRequest,
+    NewsRequest,
+    StockBarsRequest,
+    StockLatestQuoteRequest,
+)
+from alpaca.data.timeframe import TimeFrame
+
+
+@pytest.mark.live
+def test_get_stock_latest_quote(stock_client_live, live_call):
+    quote = live_call(
+        "get_stock_latest_quote",
+        stock_client_live.get_stock_latest_quote,
+        StockLatestQuoteRequest(symbol_or_symbols="AAPL"),
+    )
+    assert quote is not None
+
+
+@pytest.mark.live
+def test_get_stock_bars(stock_client_live, live_call):
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=5)
+    bars = live_call(
+        "get_stock_bars",
+        stock_client_live.get_stock_bars,
+        StockBarsRequest(
+            symbol_or_symbols="AAPL",
+            timeframe=TimeFrame.Day,
+            start=start,
+            end=end,
+            limit=5,
+        ),
+    )
+    assert bars is not None
+
+
+@pytest.mark.live
+def test_get_crypto_latest_quote(crypto_client_live, live_call):
+    quote = live_call(
+        "get_crypto_latest_quote",
+        crypto_client_live.get_crypto_latest_quote,
+        CryptoLatestQuoteRequest(symbol_or_symbols="BTC/USD"),
+    )
+    assert quote is not None
+
+
+@pytest.mark.live
+def test_get_news(news_client_live, live_call):
+    news = live_call(
+        "get_news",
+        news_client_live.get_news,
+        NewsRequest(symbols="AAPL", limit=3),
+    )
+    assert news is not None

--- a/tests/live/test_live_call.py
+++ b/tests/live/test_live_call.py
@@ -1,0 +1,45 @@
+"""Unit tests for live_call failure recording (no network)."""
+
+import pytest
+
+from tests.live.recording import invoke_and_record
+
+
+def test_invoke_and_record_records_failures():
+    recorded = []
+
+    def fake_record(method, response=None, *, passed=True, error=None, **_kwargs):
+        recorded.append(
+            {"method": method, "passed": passed, "error": error, "response": response}
+        )
+
+    def boom():
+        raise RuntimeError("upstream failed")
+
+    with pytest.raises(RuntimeError, match="upstream failed"):
+        invoke_and_record("get_account", boom, fake_record)
+
+    assert len(recorded) == 1
+    assert recorded[0]["method"] == "get_account"
+    assert recorded[0]["passed"] is False
+    assert "RuntimeError: upstream failed" in recorded[0]["error"]
+
+
+def test_invoke_and_record_records_success_with_transform():
+    recorded = []
+
+    def fake_record(method, response=None, *, passed=True, error=None, **_kwargs):
+        recorded.append(
+            {"method": method, "passed": passed, "error": error, "response": response}
+        )
+
+    result = invoke_and_record(
+        "get_calendar",
+        lambda: [1, 2, 3, 4],
+        fake_record,
+        response_transform=lambda items: items[:2],
+    )
+
+    assert result == [1, 2, 3, 4]
+    assert recorded[0]["passed"] is True
+    assert recorded[0]["response"] == [1, 2]

--- a/tests/live/test_live_call.py
+++ b/tests/live/test_live_call.py
@@ -41,5 +41,6 @@ def test_invoke_and_record_records_success_with_transform():
     )
 
     assert result == [1, 2, 3, 4]
+    # Provisional: call did not raise; pytest record_live reconciles if asserts fail.
     assert recorded[0]["passed"] is True
     assert recorded[0]["response"] == [1, 2]

--- a/tests/live/test_recording_helpers.py
+++ b/tests/live/test_recording_helpers.py
@@ -6,9 +6,11 @@ from pydantic import BaseModel
 
 from tests.live.recording import (
     format_exchange_report,
+    reconcile_results_with_test_outcome,
     redact,
     redact_request,
     serialize_response,
+    update_artifact_outcome,
     write_artifact,
 )
 
@@ -91,3 +93,87 @@ def test_format_exchange_report_includes_request_and_response():
     assert "***REDACTED***" in report
     assert '"equity": "1000"' in report
     assert "status_code: 200" in report
+
+
+def test_reconcile_flips_provisional_pass_when_test_fails(tmp_path: Path):
+    path = write_artifact(
+        tmp_path,
+        test_id="tests/live/test_x.py::test_get_account",
+        method="get_account",
+        passed=True,
+        status_code=200,
+        response_body={"id": "abc"},
+        error=None,
+    )
+    results = [
+        {
+            "id": "tests/live/test_x.py::test_get_account",
+            "method": "get_account",
+            "passed": True,
+            "error": None,
+            "artifact": str(path),
+        },
+        {
+            "id": "tests/live/test_x.py::test_get_account",
+            "method": "get_account",
+            "passed": False,
+            "error": "RuntimeError: boom",
+            "artifact": None,
+        },
+    ]
+
+    reconcile_results_with_test_outcome(
+        results,
+        test_failed=True,
+        error="AssertionError: account is None",
+    )
+
+    assert results[0]["passed"] is False
+    assert results[0]["error"] == "AssertionError: account is None"
+    assert results[1]["passed"] is False
+    assert results[1]["error"] == "RuntimeError: boom"
+    updated = path.read_text(encoding="utf-8")
+    assert '"passed": false' in updated
+    assert "AssertionError: account is None" in updated
+
+
+def test_reconcile_noop_when_test_passes(tmp_path: Path):
+    path = write_artifact(
+        tmp_path,
+        test_id="tests/live/test_x.py::test_get_account",
+        method="get_account",
+        passed=True,
+        status_code=200,
+        response_body={"id": "abc"},
+        error=None,
+    )
+    results = [
+        {
+            "id": "tests/live/test_x.py::test_get_account",
+            "method": "get_account",
+            "passed": True,
+            "error": None,
+            "artifact": str(path),
+        }
+    ]
+
+    reconcile_results_with_test_outcome(results, test_failed=False, error=None)
+
+    assert results[0]["passed"] is True
+    assert '"passed": true' in path.read_text(encoding="utf-8")
+
+
+def test_update_artifact_outcome(tmp_path: Path):
+    path = write_artifact(
+        tmp_path,
+        test_id="tests/live/test_x.py::test_get_account",
+        method="get_account",
+        passed=True,
+        status_code=200,
+        response_body={"id": "abc"},
+        error=None,
+    )
+    update_artifact_outcome(path, passed=False, error="AssertionError: bad")
+    text = path.read_text(encoding="utf-8")
+    assert '"passed": false' in text
+    assert "AssertionError: bad" in text

--- a/tests/live/test_recording_helpers.py
+++ b/tests/live/test_recording_helpers.py
@@ -1,0 +1,93 @@
+"""Unit tests for live recording helpers (no network)."""
+
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from tests.live.recording import (
+    format_exchange_report,
+    redact,
+    redact_request,
+    serialize_response,
+    write_artifact,
+)
+
+
+class _Sample(BaseModel):
+    name: str
+    value: int
+
+
+def test_serialize_response_pydantic():
+    assert serialize_response(_Sample(name="a", value=1)) == {
+        "name": "a",
+        "value": 1,
+    }
+
+
+def test_redact_secret_keys_and_headers():
+    payload = {
+        "APCA-API-KEY-ID": "key",
+        "nested": {"authorization": "Bearer abc.def"},
+        "message": "Authorization Bearer abc.def ok",
+    }
+    redacted = redact(payload)
+    assert redacted["APCA-API-KEY-ID"] == "***REDACTED***"
+    assert redacted["nested"]["authorization"] == "***REDACTED***"
+    assert "***REDACTED***" in redacted["message"]
+
+
+def test_redact_does_not_scrub_body_token_field():
+    assert redact({"token": "keep-me"}) == {"token": "keep-me"}
+
+
+def test_redact_request_scrubs_header_token():
+    redacted = redact_request(
+        {
+            "method": "GET",
+            "url": "https://example",
+            "headers": {"Token": "secret", "X-Other": "ok"},
+            "body": {"token": "keep-me"},
+        }
+    )
+    assert redacted["headers"]["Token"] == "***REDACTED***"
+    assert redacted["headers"]["X-Other"] == "ok"
+    assert redacted["body"]["token"] == "keep-me"
+
+
+def test_write_artifact(tmp_path: Path):
+    path = write_artifact(
+        tmp_path,
+        test_id="tests/live/test_x.py::test_get_account",
+        method="get_account",
+        passed=True,
+        status_code=200,
+        response_body={"id": "abc"},
+        request={"method": "GET", "url": "https://example/v2/account", "headers": {}},
+        error=None,
+    )
+    assert path.is_file()
+    text = path.read_text(encoding="utf-8")
+    assert '"method": "get_account"' in text
+    assert '"passed": true' in text
+    assert '"request"' in text
+
+
+def test_format_exchange_report_includes_request_and_response():
+    report = format_exchange_report(
+        method="get_account",
+        request={
+            "method": "GET",
+            "url": "https://paper-api.alpaca.markets/v2/account",
+            "headers": {"APCA-API-KEY-ID": "secret-key"},
+            "body": None,
+        },
+        status_code=200,
+        response_body={"equity": "1000"},
+        passed=True,
+    )
+    assert "LIVE PROBE  method=get_account" in report
+    assert "GET https://paper-api.alpaca.markets/v2/account" in report
+    assert "***REDACTED***" in report
+    assert '"equity": "1000"' in report
+    assert "status_code: 200" in report

--- a/tests/live/test_streaming.py
+++ b/tests/live/test_streaming.py
@@ -12,6 +12,7 @@ from alpaca.data.live.news import NewsDataStream
 from alpaca.data.live.option import OptionDataStream
 from alpaca.data.live.stock import StockDataStream
 from alpaca.trading.stream import TradingStream
+from tests.live.streaming import stream_timeout_seconds
 
 DATA_CONNECT = "alpaca.data.live.websocket.websockets_legacy.connect"
 TRADING_CONNECT = "alpaca.trading.stream.websockets_legacy.connect"
@@ -37,7 +38,7 @@ def test_trading_stream_connect(
         subscribe=lambda s, h: s.subscribe_trade_updates(h),
         connect_path=TRADING_CONNECT,
         require_message=False,
-        timeout=15,
+        timeout=stream_timeout_seconds(15),
     )
     assert result.connected
     _assert_user_agent(result)
@@ -58,7 +59,7 @@ def test_stock_data_stream_quotes(
         subscribe=lambda s, h: s.subscribe_quotes(h, "SPY"),
         connect_path=DATA_CONNECT,
         require_message=True,
-        timeout=45,
+        timeout=stream_timeout_seconds(45),
     )
     assert result.connected
     assert len(result.messages) >= 1
@@ -80,7 +81,7 @@ def test_crypto_data_stream_quotes(
         subscribe=lambda s, h: s.subscribe_quotes(h, "BTC/USD"),
         connect_path=DATA_CONNECT,
         require_message=True,
-        timeout=30,
+        timeout=stream_timeout_seconds(30),
     )
     assert result.connected
     assert len(result.messages) >= 1
@@ -104,7 +105,7 @@ def test_option_data_stream_quotes(
             subscribe=lambda s, h: s.subscribe_quotes(h, symbol),
             connect_path=DATA_CONNECT,
             require_message=True,
-            timeout=45,
+            timeout=stream_timeout_seconds(45),
         )
         assert len(result.messages) >= 1
     else:
@@ -116,7 +117,7 @@ def test_option_data_stream_quotes(
             subscribe=lambda s, h: s.subscribe_quotes(h, "SPY240119C00500000"),
             connect_path=DATA_CONNECT,
             require_message=False,
-            timeout=15,
+            timeout=stream_timeout_seconds(15),
         )
     assert result.connected
     _assert_user_agent(result)
@@ -137,7 +138,7 @@ def test_news_data_stream_connect(
         subscribe=lambda s, h: s.subscribe_news(h, "*"),
         connect_path=DATA_CONNECT,
         require_message=False,
-        timeout=15,
+        timeout=stream_timeout_seconds(15),
     )
     assert result.connected
     _assert_user_agent(result)

--- a/tests/live/test_streaming.py
+++ b/tests/live/test_streaming.py
@@ -1,0 +1,143 @@
+"""Live WebSocket stream smoke probes (paper / market-data keys)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from alpaca.common.utils import get_default_user_agent
+from alpaca.data.live.crypto import CryptoDataStream
+from alpaca.data.live.news import NewsDataStream
+from alpaca.data.live.option import OptionDataStream
+from alpaca.data.live.stock import StockDataStream
+from alpaca.trading.stream import TradingStream
+
+DATA_CONNECT = "alpaca.data.live.websocket.websockets_legacy.connect"
+TRADING_CONNECT = "alpaca.trading.stream.websockets_legacy.connect"
+
+
+def _assert_user_agent(result) -> None:
+    assert result.headers.get("User-Agent") == get_default_user_agent()
+
+
+@pytest.mark.live
+def test_trading_stream_connect(
+    trading_api_credentials,
+    trading_paper,
+    live_stream_call,
+):
+    """TradingStream: connect + auth + listen (trade updates may be idle)."""
+    key, secret = trading_api_credentials
+    stream = TradingStream(api_key=key, secret_key=secret, paper=trading_paper)
+
+    result = live_stream_call(
+        "TradingStream.subscribe_trade_updates",
+        stream,
+        subscribe=lambda s, h: s.subscribe_trade_updates(h),
+        connect_path=TRADING_CONNECT,
+        require_message=False,
+        timeout=15,
+    )
+    assert result.connected
+    _assert_user_agent(result)
+
+
+@pytest.mark.live
+def test_stock_data_stream_quotes(
+    trading_api_credentials,
+    live_stream_call,
+):
+    """StockDataStream: connect and receive at least one SPY quote."""
+    key, secret = trading_api_credentials
+    stream = StockDataStream(api_key=key, secret_key=secret)
+
+    result = live_stream_call(
+        "StockDataStream.subscribe_quotes",
+        stream,
+        subscribe=lambda s, h: s.subscribe_quotes(h, "SPY"),
+        connect_path=DATA_CONNECT,
+        require_message=True,
+        timeout=45,
+    )
+    assert result.connected
+    assert len(result.messages) >= 1
+    _assert_user_agent(result)
+
+
+@pytest.mark.live
+def test_crypto_data_stream_quotes(
+    trading_api_credentials,
+    live_stream_call,
+):
+    """CryptoDataStream: connect and receive at least one BTC/USD quote."""
+    key, secret = trading_api_credentials
+    stream = CryptoDataStream(api_key=key, secret_key=secret)
+
+    result = live_stream_call(
+        "CryptoDataStream.subscribe_quotes",
+        stream,
+        subscribe=lambda s, h: s.subscribe_quotes(h, "BTC/USD"),
+        connect_path=DATA_CONNECT,
+        require_message=True,
+        timeout=30,
+    )
+    assert result.connected
+    assert len(result.messages) >= 1
+    _assert_user_agent(result)
+
+
+@pytest.mark.live
+def test_option_data_stream_quotes(
+    trading_api_credentials,
+    live_stream_call,
+):
+    """OptionDataStream: connect (+ optional quote if ALPACA_LIVE_OPTION_SYMBOL)."""
+    symbol = os.getenv("ALPACA_LIVE_OPTION_SYMBOL", "").strip()
+    key, secret = trading_api_credentials
+    stream = OptionDataStream(api_key=key, secret_key=secret)
+
+    if symbol:
+        result = live_stream_call(
+            "OptionDataStream.subscribe_quotes",
+            stream,
+            subscribe=lambda s, h: s.subscribe_quotes(h, symbol),
+            connect_path=DATA_CONNECT,
+            require_message=True,
+            timeout=45,
+        )
+        assert len(result.messages) >= 1
+    else:
+        # Without a concrete OCC symbol, prove connect/auth via a noop subscribe
+        # that still starts the socket, then stop before requiring ticks.
+        result = live_stream_call(
+            "OptionDataStream.connect",
+            stream,
+            subscribe=lambda s, h: s.subscribe_quotes(h, "SPY240119C00500000"),
+            connect_path=DATA_CONNECT,
+            require_message=False,
+            timeout=15,
+        )
+    assert result.connected
+    _assert_user_agent(result)
+
+
+@pytest.mark.live
+def test_news_data_stream_connect(
+    trading_api_credentials,
+    live_stream_call,
+):
+    """NewsDataStream: connect + subscribe (news ticks are sporadic)."""
+    key, secret = trading_api_credentials
+    stream = NewsDataStream(api_key=key, secret_key=secret)
+
+    result = live_stream_call(
+        "NewsDataStream.subscribe_news",
+        stream,
+        subscribe=lambda s, h: s.subscribe_news(h, "*"),
+        connect_path=DATA_CONNECT,
+        require_message=False,
+        timeout=15,
+    )
+    assert result.connected
+    _assert_user_agent(result)

--- a/tests/live/test_streaming_helpers.py
+++ b/tests/live/test_streaming_helpers.py
@@ -1,0 +1,140 @@
+"""Unit tests for live stream probe helpers (no network)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Callable, Optional
+from unittest.mock import AsyncMock, patch
+
+from alpaca.data.live import websocket as data_ws
+from tests.live.streaming import StreamProbeResult, probe_stream, stream_timeout_seconds
+
+CONNECT_PATH = "alpaca.data.live.websocket.websockets_legacy.connect"
+
+
+def test_stream_timeout_seconds_default(monkeypatch):
+    monkeypatch.delenv("ALPACA_LIVE_STREAM_TIMEOUT", raising=False)
+    assert stream_timeout_seconds(12.0) == 12.0
+
+
+def test_stream_timeout_seconds_env(monkeypatch):
+    monkeypatch.setenv("ALPACA_LIVE_STREAM_TIMEOUT", "7.5")
+    assert stream_timeout_seconds() == 7.5
+
+
+def test_stream_probe_result_shapes():
+    result = StreamProbeResult(
+        url="wss://example/stream",
+        headers={"User-Agent": "APCA-PY/1.0"},
+        connected=True,
+        messages=[{"T": "q", "S": "SPY"}],
+    )
+    assert result.as_request()["method"] == "WS"
+    assert result.as_request()["url"] == "wss://example/stream"
+    assert result.as_request()["headers"]["User-Agent"] == "APCA-PY/1.0"
+    body = result.as_response_body()
+    assert body["connected"] is True
+    assert body["message_count"] == 1
+    assert body["messages"][0]["S"] == "SPY"
+
+
+class _FakeStream:
+    """Minimal stand-in that uses the same connect symbol DataStream patches."""
+
+    def __init__(self) -> None:
+        self._running = False
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._handler: Optional[Callable] = None
+        self.stop_calls = 0
+
+    def subscribe(self, handler: Callable) -> None:
+        self._handler = handler
+
+    async def stop_ws(self) -> None:
+        self._running = False
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+        self._running = False
+
+    def run(self) -> None:
+        async def _run() -> None:
+            self._loop = asyncio.get_running_loop()
+            await data_ws.websockets_legacy.connect(
+                "wss://example.test/v2/iex",
+                extra_headers={"User-Agent": "test-ua"},
+            )
+            self._running = True
+            if self._handler:
+                await self._handler({"T": "q", "S": "SPY"})
+            while self._running:
+                await asyncio.sleep(0.01)
+
+        asyncio.run(_run())
+
+
+def test_probe_stream_captures_headers_and_message():
+    stream = _FakeStream()
+    fake_ws = AsyncMock()
+
+    async def fake_network_connect(uri, *args, **kwargs):
+        return fake_ws
+
+    with patch(
+        "tests.live.streaming.websockets_legacy.connect",
+        new=fake_network_connect,
+    ):
+        result = probe_stream(
+            stream,
+            subscribe=lambda s, h: s.subscribe(h),
+            connect_path=CONNECT_PATH,
+            timeout=5,
+            min_messages=1,
+            require_message=True,
+        )
+
+    assert result.error is None
+    assert result.connected is True
+    assert result.url == "wss://example.test/v2/iex"
+    assert result.headers["User-Agent"] == "test-ua"
+    assert len(result.messages) == 1
+    assert stream.stop_calls >= 1 or not stream._running
+
+
+def test_probe_stream_require_message_timeout():
+    stream = _FakeStream()
+
+    def quiet_run() -> None:
+        async def _run() -> None:
+            stream._loop = asyncio.get_running_loop()
+            await data_ws.websockets_legacy.connect(
+                "wss://example.test/v2/iex",
+                extra_headers={"User-Agent": "test-ua"},
+            )
+            stream._running = True
+            while stream._running:
+                await asyncio.sleep(0.01)
+
+        asyncio.run(_run())
+
+    stream.run = quiet_run  # type: ignore[method-assign]
+    fake_ws = AsyncMock()
+
+    async def fake_network_connect(uri, *args, **kwargs):
+        return fake_ws
+
+    with patch(
+        "tests.live.streaming.websockets_legacy.connect",
+        new=fake_network_connect,
+    ):
+        result = probe_stream(
+            stream,
+            subscribe=lambda s, h: None,
+            connect_path=CONNECT_PATH,
+            timeout=0.3,
+            require_message=True,
+        )
+
+    assert result.connected is True
+    assert result.error is not None
+    assert "expected at least 1 message" in result.error

--- a/tests/live/test_trading_rest.py
+++ b/tests/live/test_trading_rest.py
@@ -1,0 +1,55 @@
+"""Read-only live TradingClient smoke tests (paper by default)."""
+
+import pytest
+
+from alpaca.trading.requests import GetOrdersRequest
+
+
+@pytest.mark.live
+def test_get_account(trading_client_live, live_call):
+    account = live_call("get_account", trading_client_live.get_account)
+    assert account is not None
+
+
+@pytest.mark.live
+def test_get_account_configurations(trading_client_live, live_call):
+    config = live_call(
+        "get_account_configurations", trading_client_live.get_account_configurations
+    )
+    assert config is not None
+
+
+@pytest.mark.live
+def test_get_clock(trading_client_live, live_call):
+    clock = live_call("get_clock", trading_client_live.get_clock)
+    assert clock is not None
+
+
+@pytest.mark.live
+def test_get_calendar(trading_client_live, live_call):
+    calendar = live_call(
+        "get_calendar",
+        trading_client_live.get_calendar,
+        response_transform=lambda c: c[:5] if isinstance(c, list) else c,
+    )
+    assert calendar is not None
+
+
+@pytest.mark.live
+def test_get_asset(trading_client_live, live_call):
+    asset = live_call("get_asset", trading_client_live.get_asset, "AAPL")
+    assert asset is not None
+
+
+@pytest.mark.live
+def test_get_all_positions(trading_client_live, live_call):
+    positions = live_call("get_all_positions", trading_client_live.get_all_positions)
+    assert positions is not None
+
+
+@pytest.mark.live
+def test_get_orders(trading_client_live, live_call):
+    orders = live_call(
+        "get_orders", trading_client_live.get_orders, GetOrdersRequest(limit=5)
+    )
+    assert orders is not None


### PR DESCRIPTION
Add gated pytest smokes under tests/live so SDK changes can be proven against real paper/sandbox APIs without affecting default CI.

Live tests stay skipped unless --run-live or ALPACA_RUN_LIVE=1. Coverage includes read-only Trading, Market Data, and Broker REST calls plus websocket stream connect/subscribe probes. Failures and successes both record redacted request/response evidence under gitignored artifacts/live_probe/, with console dumps for the edit → verify loop.

Mutative calls remain gated behind --allow-mutative. Docs and .env.example live next to the suite in tests/live/README.md.