### PR TITLE
fix: quote Python 3.10 in PyPI publish workflow matrix

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.10 ] #we'll want to add other versions down the road
+        python-version: [ "3.10" ] #we'll want to add other versions down the road
         poetry-version: [ 2.4.1 ]
         os: [ ubuntu-latest ] #in the future we should add windows here
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Unquoted 3.10 is parsed as float 3.1 in YAML, which can break setup-python on tag publishes.