### PR TITLE
fix: trust /github/workspace for Docker PyPI publish

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -34,6 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Docker actions mount RUNNER_TEMP/_github_home -> /github/home; host git config
+      # does not apply inside the container (actions/runner#2033, actions/checkout#766).
+      - name: Trust workspace for Docker publish action
+        run: |
+          mkdir -p "$RUNNER_TEMP/_github_home"
+          git config --file "$RUNNER_TEMP/_github_home/.gitconfig" --add safe.directory /github/workspace
       - name: Build and publish to pypi
         uses: JRubics/poetry-publish@v2.1
         with:


### PR DESCRIPTION
poetry-publish runs as a Docker action, so host-side git config does not apply and poetry-dynamic-versioning fails with dubious ownership.

Write safe.directory into $RUNNER_TEMP/_github_home/.gitconfig, which the runner mounts as /github/home in the container.

https://github.com/actions/runner/issues/2033