### PR TITLE
Fix stream startup busy-wait before subscriptions

### DIFF
--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -399,18 +399,24 @@ class DataStream:
             # The stream loop may have closed concurrently with the caller.
             pass
 
+    def _drain_stop_queue(self) -> bool:
+        """Consume pending stop markers and report whether any were present."""
+        stop_requested = False
+        while True:
+            try:
+                self._stop_stream_queue.get_nowait()
+            except queue.Empty:
+                return stop_requested
+            stop_requested = True
+
     async def _wait_for_subscriptions(self) -> bool:
         """Wait until a subscription is registered or the stream is stopped."""
         self._subscription_event = asyncio.Event()
         try:
             while True:
-                if not self._should_run:
+                if self._drain_stop_queue():
                     return False
-                try:
-                    self._stop_stream_queue.get_nowait()
-                except queue.Empty:
-                    pass
-                else:
+                if not self._should_run:
                     return False
                 if any(
                     handlers
@@ -460,14 +466,13 @@ class DataStream:
         """Starts event loop for receiving data from websocket connection and handles
         distributing messages
         """
-        is_restart = self._loop is not None
         self._loop = asyncio.get_running_loop()
-        if is_restart:
-            self._should_run = True
-            while not self._stop_stream_queue.empty():
-                self._stop_stream_queue.get_nowait()
         self._stop_stream_event = asyncio.Event()
         self._running = False
+        if self._drain_stop_queue():
+            self._should_run = False
+            return
+        self._should_run = True
         # do not start the websocket connection until we subscribe to something
         if not await self._wait_for_subscriptions():
             self._should_run = False
@@ -478,6 +483,7 @@ class DataStream:
             try:
                 if not self._should_run:
                     # when signaling to stop, this is how we break run_forever
+                    self._drain_stop_queue()
                     log.info("{} stream stopped".format(self._name))
                     return
                 if not self._running:

--- a/alpaca/data/live/websocket.py
+++ b/alpaca/data/live/websocket.py
@@ -104,6 +104,7 @@ class DataStream:
         self._ws = None
         self._running = False
         self._loop = None
+        self._subscription_event: Optional[asyncio.Event] = None
         if data_timeout is not None and data_timeout <= 0:
             raise ValueError("data_timeout must be a positive number of seconds")
         self._raw_data = raw_data
@@ -226,7 +227,7 @@ class DataStream:
             self._stop_stream_event.set()
         if self._stop_stream_queue.empty():
             self._stop_stream_queue.put_nowait({"should_stop": True})
-        await asyncio.sleep(0)
+        self._signal_state_change()
 
     async def _consume(self) -> bool:
         """Distributes data from websocket connection to appropriate callbacks.
@@ -380,10 +381,47 @@ class DataStream:
         self._ensure_coroutine(handler)
         for symbol in symbols:
             handlers[symbol] = handler
+        self._signal_state_change()
         if self._running:
             asyncio.run_coroutine_threadsafe(
                 self._send_subscribe_msg(), self._loop
             ).result()
+
+    def _signal_state_change(self) -> None:
+        """Wake the stream's event loop after a subscription or stop request."""
+        loop = self._loop
+        subscription_event = self._subscription_event
+        if loop is None or subscription_event is None:
+            return
+        try:
+            loop.call_soon_threadsafe(subscription_event.set)
+        except RuntimeError:
+            # The stream loop may have closed concurrently with the caller.
+            pass
+
+    async def _wait_for_subscriptions(self) -> bool:
+        """Wait until a subscription is registered or the stream is stopped."""
+        self._subscription_event = asyncio.Event()
+        try:
+            while True:
+                if not self._should_run:
+                    return False
+                try:
+                    self._stop_stream_queue.get_nowait()
+                except queue.Empty:
+                    pass
+                else:
+                    return False
+                if any(
+                    handlers
+                    for channel, handlers in self._handlers.items()
+                    if channel not in ("cancelErrors", "corrections")
+                ):
+                    return True
+                await self._subscription_event.wait()
+                self._subscription_event.clear()
+        finally:
+            self._subscription_event = None
 
     async def _send_subscribe_msg(self) -> None:
         msg = defaultdict(list)
@@ -422,25 +460,19 @@ class DataStream:
         """Starts event loop for receiving data from websocket connection and handles
         distributing messages
         """
+        is_restart = self._loop is not None
         self._loop = asyncio.get_running_loop()
-        # do not start the websocket connection until we subscribe to something
-        while not any(
-            v
-            for k, v in self._handlers.items()
-            if k not in ("cancelErrors", "corrections")
-        ):
-            if not self._stop_stream_queue.empty():
-                # the ws was signaled to stop before starting the loop so
-                # we break
-                self._stop_stream_queue.get(timeout=1)
-                return
-            await asyncio.sleep(0)
-        log.info(f"started {self._name} stream")
-        self._should_run = True
-        while not self._stop_stream_queue.empty():
-            self._stop_stream_queue.get_nowait()
+        if is_restart:
+            self._should_run = True
+            while not self._stop_stream_queue.empty():
+                self._stop_stream_queue.get_nowait()
         self._stop_stream_event = asyncio.Event()
         self._running = False
+        # do not start the websocket connection until we subscribe to something
+        if not await self._wait_for_subscriptions():
+            self._should_run = False
+            return
+        log.info(f"started {self._name} stream")
         retries = 0
         while True:
             try:

--- a/alpaca/trading/stream.py
+++ b/alpaca/trading/stream.py
@@ -45,6 +45,7 @@ class TradingStream:
         self._ws = None
         self._running = False
         self._loop = None
+        self._subscription_event: Optional[asyncio.Event] = None
         self._raw_data = raw_data
         self._stop_stream_queue = queue.Queue()
         self._stop_stream_event: Optional[asyncio.Event] = None
@@ -156,10 +157,43 @@ class TradingStream:
         """
         self._ensure_coroutine(handler)
         self._trade_updates_handler = handler
+        self._signal_state_change()
         if self._running:
             asyncio.run_coroutine_threadsafe(
                 self._subscribe_trade_updates(), self._loop
             ).result()
+
+    def _signal_state_change(self) -> None:
+        """Wake the stream's event loop after a subscription or stop request."""
+        loop = self._loop
+        subscription_event = self._subscription_event
+        if loop is None or subscription_event is None:
+            return
+        try:
+            loop.call_soon_threadsafe(subscription_event.set)
+        except RuntimeError:
+            # The stream loop may have closed concurrently with the caller.
+            pass
+
+    async def _wait_for_subscription(self) -> bool:
+        """Wait until the trade update handler is registered or the stream is stopped."""
+        self._subscription_event = asyncio.Event()
+        try:
+            while True:
+                if not self._should_run:
+                    return False
+                try:
+                    self._stop_stream_queue.get_nowait()
+                except queue.Empty:
+                    pass
+                else:
+                    return False
+                if self._trade_updates_handler:
+                    return True
+                await self._subscription_event.wait()
+                self._subscription_event.clear()
+        finally:
+            self._subscription_event = None
 
     async def _start_ws(self):
         await self._connect()
@@ -187,19 +221,19 @@ class TradingStream:
                     pass
 
     async def _run_forever(self):
+        is_restart = self._loop is not None
         self._loop = asyncio.get_running_loop()
-        # do not start the websocket connection until we subscribe to something
-        while not self._trade_updates_handler:
-            if not self._stop_stream_queue.empty():
-                self._stop_stream_queue.get(timeout=1)
-                return
-            await asyncio.sleep(0.1)
-        log.info("started trading stream")
-        self._should_run = True
-        while not self._stop_stream_queue.empty():
-            self._stop_stream_queue.get_nowait()
+        if is_restart:
+            self._should_run = True
+            while not self._stop_stream_queue.empty():
+                self._stop_stream_queue.get_nowait()
         self._stop_stream_event = asyncio.Event()
         self._running = False
+        # do not start the websocket connection until we subscribe to something
+        if not await self._wait_for_subscription():
+            self._should_run = False
+            return
+        log.info("started trading stream")
         retries = 0
         while True:
             try:
@@ -258,6 +292,7 @@ class TradingStream:
             self._stop_stream_event.set()
         if self._stop_stream_queue.empty():
             self._stop_stream_queue.put_nowait({"should_stop": True})
+        self._signal_state_change()
 
     def stop(self) -> None:
         """Stops the websocket connection."""

--- a/alpaca/trading/stream.py
+++ b/alpaca/trading/stream.py
@@ -175,18 +175,24 @@ class TradingStream:
             # The stream loop may have closed concurrently with the caller.
             pass
 
+    def _drain_stop_queue(self) -> bool:
+        """Consume pending stop markers and report whether any were present."""
+        stop_requested = False
+        while True:
+            try:
+                self._stop_stream_queue.get_nowait()
+            except queue.Empty:
+                return stop_requested
+            stop_requested = True
+
     async def _wait_for_subscription(self) -> bool:
         """Wait until the trade update handler is registered or the stream is stopped."""
         self._subscription_event = asyncio.Event()
         try:
             while True:
-                if not self._should_run:
+                if self._drain_stop_queue():
                     return False
-                try:
-                    self._stop_stream_queue.get_nowait()
-                except queue.Empty:
-                    pass
-                else:
+                if not self._should_run:
                     return False
                 if self._trade_updates_handler:
                     return True
@@ -221,14 +227,13 @@ class TradingStream:
                     pass
 
     async def _run_forever(self):
-        is_restart = self._loop is not None
         self._loop = asyncio.get_running_loop()
-        if is_restart:
-            self._should_run = True
-            while not self._stop_stream_queue.empty():
-                self._stop_stream_queue.get_nowait()
         self._stop_stream_event = asyncio.Event()
         self._running = False
+        if self._drain_stop_queue():
+            self._should_run = False
+            return
+        self._should_run = True
         # do not start the websocket connection until we subscribe to something
         if not await self._wait_for_subscription():
             self._should_run = False
@@ -238,6 +243,7 @@ class TradingStream:
         while True:
             try:
                 if not self._should_run:
+                    self._drain_stop_queue()
                     log.info("Trading stream stopped")
                     return
                 if not self._running:

--- a/tests/data/test_websockets.py
+++ b/tests/data/test_websockets.py
@@ -1,5 +1,7 @@
+import asyncio
+import threading
 from datetime import datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import msgpack
 import pytest
@@ -33,6 +35,97 @@ def raw_ws_client() -> DataStream:
 def timestamp() -> Timestamp:
     """Msgpack mock timestamp."""
     return Timestamp(seconds=10, nanoseconds=10)
+
+
+@pytest.mark.asyncio
+async def test_run_forever_waits_for_subscription_without_polling(
+    ws_client: DataStream,
+):
+    sleep_calls = []
+    original_sleep = asyncio.sleep
+
+    async def tracked_sleep(delay):
+        sleep_calls.append(delay)
+        await original_sleep(delay)
+
+    with patch("alpaca.data.live.websocket.asyncio.sleep", new=tracked_sleep):
+        run_task = asyncio.create_task(ws_client._run_forever())
+        try:
+            await original_sleep(0)
+            await original_sleep(0)
+            assert sleep_calls == []
+        finally:
+            await ws_client.stop_ws()
+            await asyncio.wait_for(run_task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_subscriptions_honors_stop_state(ws_client: DataStream):
+    ws_client._should_run = False
+
+    assert await ws_client._wait_for_subscriptions() is False
+
+
+@pytest.mark.asyncio
+async def test_run_forever_honors_stop_requested_before_start(
+    ws_client: DataStream,
+):
+    await ws_client.stop_ws()
+
+    await asyncio.wait_for(ws_client._run_forever(), timeout=1)
+
+    assert ws_client._running is False
+
+
+@pytest.mark.asyncio
+async def test_run_forever_wakes_for_subscription_from_another_thread(
+    ws_client: DataStream,
+):
+    websocket_started = asyncio.Event()
+    thread_errors = []
+
+    async def handler(_):
+        pass
+
+    async def start_ws():
+        websocket_started.set()
+        ws_client._should_run = False
+
+    def subscribe():
+        try:
+            ws_client._subscribe(handler, ("AAPL",), ws_client._handlers["trades"])
+        except Exception as error:
+            thread_errors.append(error)
+
+    with (
+        patch.object(ws_client, "_start_ws", side_effect=start_ws),
+        patch.object(ws_client, "_send_subscribe_msg", new=AsyncMock()),
+        patch.object(ws_client, "_consume", new=AsyncMock()),
+    ):
+        run_task = asyncio.create_task(ws_client._run_forever())
+        await asyncio.sleep(0)
+        subscription_thread = threading.Thread(target=subscribe)
+        subscription_thread.start()
+        subscription_thread.join(timeout=1)
+
+        assert not subscription_thread.is_alive()
+        assert thread_errors == []
+        await asyncio.wait_for(websocket_started.wait(), timeout=1)
+        await asyncio.wait_for(run_task, timeout=1)
+
+
+def test_signal_state_change_uses_event_snapshot(ws_client: DataStream):
+    loop = MagicMock()
+    subscription_event = MagicMock()
+    ws_client._loop = loop
+
+    with patch.object(
+        DataStream, "_subscription_event", new_callable=PropertyMock, create=True
+    ) as event_attribute:
+        event_attribute.side_effect = [subscription_event, None]
+        ws_client._signal_state_change()
+
+    loop.call_soon_threadsafe.assert_called_once_with(subscription_event.set)
 
 
 def test_cast(ws_client: DataStream, raw_ws_client: DataStream, timestamp: Timestamp):

--- a/tests/data/test_websockets.py
+++ b/tests/data/test_websockets.py
@@ -78,6 +78,30 @@ async def test_run_forever_honors_stop_requested_before_start(
 
 
 @pytest.mark.asyncio
+async def test_run_forever_honors_stop_requested_before_restart(
+    ws_client: DataStream,
+):
+    async def handler(_):
+        pass
+
+    async def start_ws():
+        ws_client._should_run = False
+
+    ws_client._loop = asyncio.get_running_loop()
+    ws_client._handlers["trades"]["AAPL"] = handler
+    await ws_client.stop_ws()
+
+    with (
+        patch.object(ws_client, "_start_ws", side_effect=start_ws) as start,
+        patch.object(ws_client, "_send_subscribe_msg", new=AsyncMock()),
+        patch.object(ws_client, "_consume", new=AsyncMock()),
+    ):
+        await asyncio.wait_for(ws_client._run_forever(), timeout=1)
+
+    start.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_run_forever_wakes_for_subscription_from_another_thread(
     ws_client: DataStream,
 ):

--- a/tests/trading/test_trading_stream.py
+++ b/tests/trading/test_trading_stream.py
@@ -56,6 +56,29 @@ async def test_run_forever_honors_stop_requested_before_start(
 
 
 @pytest.mark.asyncio
+async def test_run_forever_honors_stop_requested_before_restart(
+    trading_stream: TradingStream,
+):
+    async def handler(_):
+        pass
+
+    async def start_ws():
+        trading_stream._should_run = False
+
+    trading_stream._loop = asyncio.get_running_loop()
+    trading_stream._trade_updates_handler = handler
+    await trading_stream.stop_ws()
+
+    with (
+        patch.object(trading_stream, "_start_ws", side_effect=start_ws) as start,
+        patch.object(trading_stream, "_consume", new=AsyncMock()),
+    ):
+        await asyncio.wait_for(trading_stream._run_forever(), timeout=1)
+
+    start.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_run_forever_wakes_for_subscription_from_another_thread(
     trading_stream: TradingStream,
 ):

--- a/tests/trading/test_trading_stream.py
+++ b/tests/trading/test_trading_stream.py
@@ -1,4 +1,6 @@
-from unittest.mock import AsyncMock, patch
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -9,6 +11,98 @@ from alpaca.trading.stream import TradingStream
 @pytest.fixture
 def trading_stream() -> TradingStream:
     return TradingStream("key-id", "secret-key", paper=True)
+
+
+@pytest.mark.asyncio
+async def test_run_forever_waits_for_subscription_without_polling(
+    trading_stream: TradingStream,
+):
+    sleep_calls = []
+    original_sleep = asyncio.sleep
+
+    async def tracked_sleep(delay):
+        sleep_calls.append(delay)
+        await original_sleep(delay)
+
+    with patch("alpaca.trading.stream.asyncio.sleep", new=tracked_sleep):
+        run_task = asyncio.create_task(trading_stream._run_forever())
+        try:
+            await original_sleep(0)
+            await original_sleep(0)
+            assert sleep_calls == []
+        finally:
+            await trading_stream.stop_ws()
+            await asyncio.wait_for(run_task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_subscription_honors_stop_state(
+    trading_stream: TradingStream,
+):
+    trading_stream._should_run = False
+
+    assert await trading_stream._wait_for_subscription() is False
+
+
+@pytest.mark.asyncio
+async def test_run_forever_honors_stop_requested_before_start(
+    trading_stream: TradingStream,
+):
+    await trading_stream.stop_ws()
+
+    await asyncio.wait_for(trading_stream._run_forever(), timeout=1)
+
+    assert trading_stream._running is False
+
+
+@pytest.mark.asyncio
+async def test_run_forever_wakes_for_subscription_from_another_thread(
+    trading_stream: TradingStream,
+):
+    websocket_started = asyncio.Event()
+    thread_errors = []
+
+    async def handler(_):
+        pass
+
+    async def start_ws():
+        websocket_started.set()
+        trading_stream._should_run = False
+
+    def subscribe():
+        try:
+            trading_stream.subscribe_trade_updates(handler)
+        except Exception as error:
+            thread_errors.append(error)
+
+    with (
+        patch.object(trading_stream, "_start_ws", side_effect=start_ws),
+        patch.object(trading_stream, "_consume", new=AsyncMock()),
+    ):
+        run_task = asyncio.create_task(trading_stream._run_forever())
+        await asyncio.sleep(0)
+        subscription_thread = threading.Thread(target=subscribe)
+        subscription_thread.start()
+        subscription_thread.join(timeout=1)
+
+        assert not subscription_thread.is_alive()
+        assert thread_errors == []
+        await asyncio.wait_for(websocket_started.wait(), timeout=1)
+        await asyncio.wait_for(run_task, timeout=1)
+
+
+def test_signal_state_change_uses_event_snapshot(trading_stream: TradingStream):
+    loop = MagicMock()
+    subscription_event = MagicMock()
+    trading_stream._loop = loop
+
+    with patch.object(
+        TradingStream, "_subscription_event", new_callable=PropertyMock, create=True
+    ) as event_attribute:
+        event_attribute.side_effect = [subscription_event, None]
+        trading_stream._signal_state_change()
+
+    loop.call_soon_threadsafe.assert_called_once_with(subscription_event.set)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This is a clean replacement for #763.

- replace subscription-startup polling with an event-driven wait in both `DataStream` and `TradingStream`
- wake the stream loop immediately when a subscription is registered or shutdown is requested
- use `loop.call_soon_threadsafe(event.set)` with local loop and event snapshots so concurrent subscription registration is safe
- preserve stop requests queued before initial or restarted runs, while consuming handled stop markers so intentional later restarts do not inherit stale state
- add regression coverage for idle startup, cross-thread subscription registration, pre-start shutdown, restart behavior, and event cleanup races

## Root cause

`DataStream._run_forever()` repeatedly called `await asyncio.sleep(0)` while no subscriptions existed. Although this yielded control, the task remained immediately runnable and could consume an entire CPU core. `TradingStream` used the same polling lifecycle with a 100 ms delay, avoiding the busy spin but adding startup latency.

## Impact

Applications may start a stream before registering handlers without idle polling CPU usage. Subscription registration starts the websocket promptly, while shutdown wakes the same wait path and exits cleanly. Existing reconnect/backoff behavior remains intact.

## Testing

- `poetry run black --check alpaca/ tests/`
- `poetry run pytest -q tests/data/test_websockets.py tests/trading/test_trading_stream.py tests/test_streaming_reconnect_issues.py` — 61 passed
- `poetry run pytest -q` — 332 passed, 19 skipped

Fixes #762
