### PR TITLE
Support multiple symbols in NewsRequest

### DIFF
--- a/alpaca/data/requests.py
+++ b/alpaca/data/requests.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 from typing import Any, List, Optional, Union
 
 import pytz
-from pydantic import ConfigDict
+from pydantic import ConfigDict, field_serializer
 
 from alpaca.common.enums import Sort, SupportedCurrencies
 from alpaca.common.requests import NonEmptyRequest
@@ -534,7 +534,7 @@ class NewsRequest(NonEmptyRequest):
     end (Optional[datetime])): The inclusive end of the interval. Format: RFC-3339 or YYYY-MM-DD.
         If missing, the default value is the current time.
     sort (Optional[str]): Sort articles by updated date.
-    symbols (Optional[str]): The comma-separated list of symbols to query news for.
+    symbols (Optional[Union[str, List[str]]]): A symbol or list of symbols to query news for.
     limit (Optional[int]): Limit of news items to be returned for given page.
     include_content (Optional[bool]): Boolean indicator to include content for news articles (if available)
     exclude_contentless (Optional[bool]): Boolean indicator to exclude news articles that do not contain content
@@ -544,11 +544,17 @@ class NewsRequest(NonEmptyRequest):
     start: Optional[datetime] = None
     end: Optional[datetime] = None
     sort: Optional[str] = None
-    symbols: Optional[str] = None
+    symbols: Optional[Union[str, List[str]]] = None
     limit: Optional[int] = None
     include_content: Optional[bool] = None
     exclude_contentless: Optional[bool] = None
     page_token: Optional[str] = None
+
+    @field_serializer("symbols")
+    def serialize_symbols(self, symbols: Optional[Union[str, List[str]]]):
+        if isinstance(symbols, list):
+            return ",".join(symbols)
+        return symbols
 
 
 # ############################## CorporateActions #################################### #

--- a/tests/data/test_historical_news_data.py
+++ b/tests/data/test_historical_news_data.py
@@ -6,6 +6,18 @@ from alpaca.data.models.news import NewsSet
 from alpaca.data.requests import NewsRequest
 
 
+def test_news_request_serializes_multiple_symbols():
+    request = NewsRequest(symbols=["AAPL", "GOOGL"])
+
+    assert request.to_request_fields()["symbols"] == "AAPL,GOOGL"
+
+
+def test_news_request_preserves_single_symbol():
+    request = NewsRequest(symbols="AAPL")
+
+    assert request.to_request_fields()["symbols"] == "AAPL"
+
+
 def test_get_news(reqmock, news_client: NewsClient):
     # Test single symbol request
 


### PR DESCRIPTION
## Summary
- accept either one symbol or a list of symbols in `NewsRequest`
- serialize symbol lists as the comma-separated value expected by the News API
- preserve the existing single-symbol request behavior
- add regression coverage for both forms

## Root cause

`NewsRequest.symbols` was typed as `Optional[str]`, so Pydantic rejected lists before the request could be sent. Simply widening the type would send a raw list because this field is named `symbols`, not the generic `symbol_or_symbols` field handled by `NonEmptyRequest`. The field serializer keeps the fix local to News requests and preserves the wire contract.

## Validation
- `pytest tests/data/test_historical_news_data.py -q` (3 passed)
- full `pytest -q` (322 passed, 19 skipped)
- `black --check alpaca/data/requests.py tests/data/test_historical_news_data.py`
- `git diff --check`

Closes #526
